### PR TITLE
Fix away-team defensive coords

### DIFF
--- a/BackEnd/utils/shared_defense.py
+++ b/BackEnd/utils/shared_defense.py
@@ -1,4 +1,5 @@
 import random
+from BackEnd.utils.shared import get_away_player_coords
 
 def assign_bh_defender_coords(ball_coords, aggression_level: str, is_away_offense: bool) -> dict:
     """
@@ -44,6 +45,13 @@ def assign_non_bh_defender_coords(o_coords, ball_coords, aggression_level, is_aw
 
     ox, oy = o_coords["x"], o_coords["y"]
     bx, by = ball_coords["x"], ball_coords["y"]
+
+    # When the away team has the ball the offensive coordinates are flipped
+    # horizontally. Convert the ball handler's coordinates back to the home
+    # orientation so the logic below can remain consistent.
+    if is_away_offense:
+        flipped = get_away_player_coords(ball_coords)
+        bx, by = flipped["x"], flipped["y"]
 
     # Edge case: defending someone on the block or in the lane (score threat)
     if 74 <= ox <= 88 and 15 <= oy <= 33:

--- a/tests/test_shared_defense.py
+++ b/tests/test_shared_defense.py
@@ -1,0 +1,21 @@
+import random
+from BackEnd.utils.shared_defense import assign_non_bh_defender_coords
+from BackEnd.utils.shared import get_away_player_coords
+
+
+def test_assign_non_bh_defender_coords_away_mirrors_home_spacing():
+    random.seed(0)
+    o_coords = {"x": 60, "y": 30}
+    ball_home = {"x": 70, "y": 25}
+    ball_away = get_away_player_coords(ball_home)
+
+    home_def = assign_non_bh_defender_coords(o_coords, ball_home, "normal", False)
+    away_def = assign_non_bh_defender_coords(o_coords, ball_away, "normal", True)
+
+    home_diff = home_def["x"] - o_coords["x"]
+    away_def_flipped = get_away_player_coords(away_def)
+    away_o_flipped = get_away_player_coords(o_coords)
+    away_diff = away_def_flipped["x"] - away_o_flipped["x"]
+
+    assert abs(abs(home_diff) - abs(away_diff)) <= 1
+    assert home_diff == -away_diff


### PR DESCRIPTION
## Summary
- correct defender placement when away team is on offense
- test that away-team logic mirrors home-team logic

## Testing
- `PYTHONPATH=$PWD pytest tests/test_shared_defense.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6867ef0e315883288952df0124b99530