### PR TITLE
Ensure ball follows player during step animation

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animateStep.js
+++ b/FrontEnd/static/js/phaser/animation/animateStep.js
@@ -10,7 +10,7 @@ import { gridToPixels } from "../utils/gridToPixels.js";
  * @param {number} duration - Milliseconds for tween duration
  * @returns {Promise} resolves when tween completes
  */
-export function animateStep({ scene, sprite, step, duration }) {
+export function animateStep({ scene, sprite, step, duration, ballSprite, currentBallOwnerRef }) {
   return new Promise((resolve) => {
     const { x: targetX, y: targetY } = gridToPixels(
       step.coords.x,
@@ -25,6 +25,14 @@ export function animateStep({ scene, sprite, step, duration }) {
       y: targetY,
       duration,
       ease: "Linear",
+      onUpdate: () => {
+        if (
+          currentBallOwnerRef?.value === sprite &&
+          ballSprite?.setPosition
+        ) {
+          ballSprite.setPosition(sprite.x, sprite.y);
+        }
+      },
       onComplete: resolve
     });
   });

--- a/FrontEnd/static/js/phaser/animation/playTurnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/playTurnAnimation.js
@@ -5,7 +5,7 @@ import { gridToPixels } from "../utils/gridToPixels.js";
  * Centralized ball ownership logic
  * Assigns the ball to the correct player for the current stepIndex
  */
-function updateBallOwnership({ ballSprite, animations, playerSprites, stepIndex, offenseTeamId }) {
+function updateBallOwnership({ ballSprite, animations, playerSprites, stepIndex, offenseTeamId, currentBallOwnerRef }) {
   for (const anim of animations) {
     const sprite = playerSprites[anim.playerId];
     const hasBall = anim.hasBallAtStep?.[stepIndex];
@@ -14,6 +14,7 @@ function updateBallOwnership({ ballSprite, animations, playerSprites, stepIndex,
     if (hasBall && sprite && team === offenseTeamId && ballSprite?.setPosition) {
       ballSprite.setPosition(sprite.x, sprite.y);
       ballSprite.setVisible(true);
+      if (currentBallOwnerRef) currentBallOwnerRef.value = sprite;
       break;
     }
   }
@@ -24,7 +25,7 @@ function updateBallOwnership({ ballSprite, animations, playerSprites, stepIndex,
  * Locks the ball to the player with hasBallAtStep[0] during this setup tween.
  */
 
-async function runSetupTween({ scene, ballSprite, animations, playerSprites, offenseTeamId }) {
+async function runSetupTween({ scene, ballSprite, animations, playerSprites, offenseTeamId, currentBallOwnerRef }) {
   const stepIndex = 0;
   const promises = []; //onUpdate
 
@@ -42,6 +43,7 @@ async function runSetupTween({ scene, ballSprite, animations, playerSprites, off
   if (ballOwnerSprite && ballSprite?.setPosition) {
     ballSprite.setPosition(ballOwnerSprite.x, ballOwnerSprite.y);
     ballSprite.setVisible(true);
+    if (currentBallOwnerRef) currentBallOwnerRef.value = ballOwnerSprite;
   }
 
   for (const anim of animations) {
@@ -77,6 +79,7 @@ async function runSetupTween({ scene, ballSprite, animations, playerSprites, off
   // Final snap just in case
   if (ballOwnerSprite && ballSprite?.setPosition) {
     ballSprite.setPosition(ballOwnerSprite.x, ballOwnerSprite.y);
+    if (currentBallOwnerRef) currentBallOwnerRef.value = ballOwnerSprite;
   }
 
   await Promise.all(promises);
@@ -153,6 +156,7 @@ async function runSetupTween({ scene, ballSprite, animations, playerSprites, off
  * Each stepIndex is animated across all players, then the next step begins.
  */
 export async function playTurnAnimation({ scene, simData, playerSprites, turnData, ballSprite, onAction }) {
+  const currentBallOwnerRef = { value: null };
   const maxSteps = Math.max(
     ...turnData.animations.map(anim => anim.movement.length)
   );
@@ -163,7 +167,8 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
     ballSprite,
     animations: turnData.animations,
     playerSprites,
-    offenseTeamId: turnData.possession_team_id
+    offenseTeamId: turnData.possession_team_id,
+    currentBallOwnerRef
   });
 
   for (let stepIndex = 1; stepIndex < maxSteps; stepIndex++) {
@@ -172,7 +177,8 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
       animations: turnData.animations,
       playerSprites,
       stepIndex,
-      offenseTeamId: turnData.possession_team_id
+      offenseTeamId: turnData.possession_team_id,
+      currentBallOwnerRef
     });
 
     const promises = [];
@@ -191,7 +197,9 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
         scene,
         sprite,
         step: curr,
-        duration
+        duration,
+        ballSprite,
+        currentBallOwnerRef
       });
 
       promises.push(promise);


### PR DESCRIPTION
## Summary
- update `animateStep` to keep the ball locked to the current player
- record the active ball owner during setup and step updates
- pass ball tracking info through the play-turn animation pipeline

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: 'BackEnd', KeyError: 'MONGO_URI')*

------
https://chatgpt.com/codex/tasks/task_e_68716e5c7f108328b71367aff4d6252a