### PR TITLE
Fix ball ownership tracking

### DIFF
--- a/BackEnd/models/animator.py
+++ b/BackEnd/models/animator.py
@@ -42,6 +42,21 @@ class Animator:
         bh_pos = get_player_position(off_lineup, ball_handler)
         ball_handler_end_coords = None
 
+        # Determine which offensive player has the ball at each step
+        ball_actions = {"handle_ball", "receive", "shoot"}
+        ball_owner_by_step = []
+        for step in steps:
+            owner = None
+            for pos_key, action_info in step["pos_actions"].items():
+                if action_info["action"] in ball_actions:
+                    owner = off_lineup[pos_key]
+                    break
+            ball_owner_by_step.append(owner)
+
+        for idx, owner in enumerate(ball_owner_by_step):
+            if owner is None:
+                print(f"[WARN] No ball owner detected for step {idx}")
+
         for pos, player in off_lineup.items():
             timeline = action_timeline.get(player, [])
             print("Inside capture_halfcourt_animation")
@@ -49,7 +64,7 @@ class Animator:
             if not timeline:
                 continue
 
-            hasBallAtStep = [action in {"handle_ball", "receive", "shoot"} for (_, action, _) in timeline]
+            hasBallAtStep = [ball_owner_by_step[i] is player for i in range(len(timeline))]
 
             timeline.sort(key=lambda tup: tup[0])
             first_spot = timeline[0][2]
@@ -89,7 +104,7 @@ class Animator:
             def_coords = None
             action_type = ACTIONS["GUARD_OFFBALL"]
 
-            hasBallAtStep = [action in {"handle_ball", "receive", "shoot"} for (_, action, _) in timeline]
+            hasBallAtStep = [False for _ in ball_owner_by_step]
 
             if pos == bh_pos:
                 def_coords = assign_bh_defender_coords(ball_handler_end_coords, aggression_call, is_away_offense)

--- a/tests/test_animator.py
+++ b/tests/test_animator.py
@@ -1,0 +1,51 @@
+from tests.test_utils import build_mock_game
+from BackEnd.models.animator import Animator
+from BackEnd.models.team_manager import TeamManager
+from BackEnd import db
+import pytest
+
+BALL_ACTIONS = {"handle_ball", "receive", "shoot"}
+
+def test_capture_halfcourt_animation_ball_assignment(monkeypatch):
+    monkeypatch.setattr(TeamManager, "_load_roster", lambda self: [])
+    monkeypatch.setattr(TeamManager, "_load_lineup", lambda self: {})
+    dummy_collection = type("Dummy", (), {"find": lambda self, q=None: [], "find_one": lambda self, q=None: None})()
+    monkeypatch.setattr(db, "players_collection", dummy_collection)
+    monkeypatch.setattr(db, "teams_collection", dummy_collection)
+    import BackEnd.models.team_manager as tm
+    monkeypatch.setattr(tm, "players_collection", dummy_collection)
+    monkeypatch.setattr(tm, "teams_collection", dummy_collection)
+    import BackEnd.models.turn_manager as trm
+    monkeypatch.setattr(trm, "players_collection", dummy_collection)
+    monkeypatch.setattr(trm, "teams_collection", dummy_collection)
+    game = build_mock_game()
+    # Ensure mock players have coordinates for animation logic
+    for player in game.home_team.lineup.values():
+        player.coords = {"x": 25, "y": 50}
+        player.player_id = player.get_name()
+    for player in game.away_team.lineup.values():
+        player.coords = {"x": 25, "y": 50}
+        player.player_id = player.get_name()
+    roles = game.turn_manager.assign_roles()
+    animator = Animator(game)
+    animations = animator.capture_halfcourt_animation(roles)
+
+    step_count = len(roles["steps"])
+    offense_ids = [p.player_id for p in game.offense_team.lineup.values()]
+    defense_ids = [p.player_id for p in game.defense_team.lineup.values()]
+
+    anim_map = {a["playerId"]: a for a in animations}
+
+    # Validate offensive ball ownership
+    for idx in range(step_count):
+        owners = [pid for pid in offense_ids if anim_map[pid]["hasBallAtStep"][idx]]
+        assert len(owners) == 1
+        owner_anim = anim_map[owners[0]]
+        action = owner_anim["movement"][idx]["action"]
+        assert action in BALL_ACTIONS
+
+    # Defensive players should not have the ball
+    for pid in defense_ids:
+        hb = anim_map[pid].get("hasBallAtStep", [])
+        if hb:
+            assert not any(hb)


### PR DESCRIPTION
## Summary
- ensure only offensive players track ball possession during animations
- mark defenders' `hasBallAtStep` arrays as all `False`
- add regression test verifying exactly one offensive player has the ball each step

## Testing
- `python -m py_compile BackEnd/models/animator.py`
- `python -m py_compile tests/test_animator.py`
- `PYTHONPATH=. pytest tests/test_animator.py::test_capture_halfcourt_animation_ball_assignment -q`

------
https://chatgpt.com/codex/tasks/task_e_6871b48cb3a48328b2def718ddb223f3