### PR TITLE
Cancel active tweens when locking ball

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animateGameTurns.js
+++ b/FrontEnd/static/js/phaser/animation/animateGameTurns.js
@@ -46,7 +46,7 @@ export async function animateGameTurns({ //hasBallAtStep
 
         if (action === "handle_ball" && anim?.hasBallAtStep?.length) {
           console.log("🔒 Locking ball to ball handler:", playerId);
-          lockBallToPlayer(ballSprite, sprite);
+          lockBallToPlayer(scene, ballSprite, sprite);
         }
 
         if (action === "pass") {
@@ -75,7 +75,7 @@ export async function animateGameTurns({ //hasBallAtStep
 
         if (action === "receive") {
           console.log("📥 Ball received by:", playerId);
-          lockBallToPlayer(ballSprite, sprite);
+          lockBallToPlayer(scene, ballSprite, sprite);
         }
 
         // if (action === "shoot" || sprite.playerId === shooterId) {

--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -1,12 +1,19 @@
 import { generateBallTween } from "./generateBallTween.js";
 
-export function lockBallToPlayer(ballSprite, playerSprite) {
+export function lockBallToPlayer(scene, ballSprite, playerSprite) {
   if (!ballSprite || !playerSprite) {
     console.warn("⚠️ lockBallToPlayer skipped: missing sprite");
     return;
   }
 
-  console.log("🔒 lockBallToPlayer invoked for:", playerSprite.name || playerSprite);
+  console.log(
+    "🔒 lockBallToPlayer invoked for:",
+    playerSprite.name || playerSprite
+  );
+
+  if (scene?.tweens) {
+    scene.tweens.killTweensOf(ballSprite);
+  }
 
   const { x, y } = playerSprite;
   ballSprite.setPosition(x, y);
@@ -52,7 +59,7 @@ export function hideBall(ballSprite) {
  * @param {Object} playerSprites - Map of playerId → Phaser sprite
  * @param {number} currentTimestamp - The current animation timestamp (ms)
  */
-export function updateBallOwnership(ballSprite, animations, playerSprites, currentTimestamp) {
+export function updateBallOwnership(scene, ballSprite, animations, playerSprites, currentTimestamp) {
   for (const anim of animations) {
     const { playerId, hasBallAtStep, movement } = anim;
     if (!hasBallAtStep || !movement || !movement.length) continue;
@@ -69,7 +76,7 @@ export function updateBallOwnership(ballSprite, animations, playerSprites, curre
     if (hasBallAtStep[stepIndex]) {
       const playerSprite = playerSprites[playerId];
       if (playerSprite) {
-        lockBallToPlayer(ballSprite, playerSprite);
+        lockBallToPlayer(scene, ballSprite, playerSprite);
       }
       break; // Only one player can have the ball
     }

--- a/FrontEnd/static/js/phaser/testScene.js
+++ b/FrontEnd/static/js/phaser/testScene.js
@@ -72,7 +72,7 @@ export function createTestScene(Phaser) {
     const passStep = allPlayers[0].movement[1];
     const receiveStep = allPlayers[1].movement[0];
 
-    lockBallToPlayer(this.ballSprite, this.playerSprites[playerId]);
+    lockBallToPlayer(this, this.ballSprite, this.playerSprites[playerId]);
 
     if (!this.playerSprites) {
       console.error("❌ playerSprites is undefined!");


### PR DESCRIPTION
## Summary
- prevent lingering pass animations from affecting the ball
- allow passing the scene to `lockBallToPlayer`
- use the new signature everywhere

## Testing
- `pytest -q` *(fails: ServerSelectionTimeoutError: localhost:27017)*

------
https://chatgpt.com/codex/tasks/task_e_6871c520e61083289c9e6f16fb6d1d4c