### PR TITLE
Fix ball tween setup visibility

### DIFF
--- a/BackEnd/models/animator.py
+++ b/BackEnd/models/animator.py
@@ -51,6 +51,16 @@ class Animator:
                 if action_info["action"] in ball_actions:
                     owner = off_lineup[pos_key]
                     break
+            if owner is None:
+                for event in step.get("events", []):
+                    if event.get("type") == "pass":
+                        owner = off_lineup.get(event.get("to"))
+                        if owner:
+                            break
+                    elif event.get("type") == "shot":
+                        owner = off_lineup.get(event.get("by"))
+                        if owner:
+                            break
             ball_owner_by_step.append(owner)
 
         for idx, owner in enumerate(ball_owner_by_step):

--- a/tests/test_animation_ball_ownership.py
+++ b/tests/test_animation_ball_ownership.py
@@ -1,0 +1,30 @@
+import pytest
+from tests.test_utils import build_mock_game
+from BackEnd.models.animator import Animator
+
+
+def extract_ball_owners(animations, step_count):
+    owners = [None] * step_count
+    for anim in animations:
+        for idx, has in enumerate(anim.get("hasBallAtStep", [])):
+            if idx < step_count and has:
+                owners[idx] = anim["playerId"]
+    return owners
+
+
+def test_ball_ownership_transitions():
+    game = build_mock_game()
+    tm = game.turn_manager
+    roles = tm.assign_roles()
+    animator = Animator(game)
+    animations = animator.capture_halfcourt_animation(roles)
+    steps_len = len(roles["steps"])
+    owners = extract_ball_owners(animations, steps_len)
+
+    offense_lineup = game.offense_team.lineup
+    pos_by_id = {p.player_id: pos for pos, p in offense_lineup.items()}
+    owner_positions = [pos_by_id.get(o) for o in owners]
+
+    assert owner_positions[0] == "PG"
+    # Expect at least one change away from PG
+    assert "PF" in owner_positions or "C" in owner_positions


### PR DESCRIPTION
## Summary
- kill any active ball tweens before a new turn starts
- pre-lock the ball to the step0 handler
- move the ball with the owner during setup tween
- pass events now update ball ownership in animation data
- add regression test for ball-owner transitions

## Testing
- `python -m pytest -q tests/test_animation_ball_ownership.py` *(fails: KeyError: 'MONGO_URI')*

------
https://chatgpt.com/codex/tasks/task_e_6871c51f62708328b705fc8a1345ce2d