### PR TITLE
Track possession start for each turn

### DIFF
--- a/BackEnd/models/turn_manager.py
+++ b/BackEnd/models/turn_manager.py
@@ -73,6 +73,9 @@ class TurnManager:
         print(f"offense team id: {self.game.offense_team.team_id}")
         print(f"defense team id: {self.game.defense_team.team_id}")
 
+        # Record possession team before any potential flip
+        result["starting_possession_team_id"] = self.game.offense_team.team_id
+
         # STEP 4: Final updates (clock, logs, animation)
         self.update_clock_and_possession(result)
         self.logger.log_turn_result(result)

--- a/tests/test_turn_manager.py
+++ b/tests/test_turn_manager.py
@@ -88,5 +88,14 @@ def test_turn_result_has_possession_flips():
     assert isinstance(result["possession_flips"], bool)
 
 
+def test_turn_result_includes_possession_ids():
+    game = build_mock_game()
+    tm = TurnManager(game)
+    starting_id = game.offense_team.team_id
+    result = tm.run_micro_turn()
+    assert result["starting_possession_team_id"] == starting_id
+    assert result["possession_team_id"] == game.offense_team.team_id
+
+
 
  


### PR DESCRIPTION
## Summary
- record starting possession team before clocks/possession flips
- expose this field through test helpers

## Testing
- `pytest -q` *(fails: ServerSelectionTimeoutError because MongoDB isn't available)*

------
https://chatgpt.com/codex/tasks/task_e_687285a2d1ac8328904d6a299658dcfd