### PR TITLE
Fix tournament request models

### DIFF
--- a/BackEnd/api/tournament_routes.py
+++ b/BackEnd/api/tournament_routes.py
@@ -5,9 +5,13 @@ from BackEnd.tournament.tournament_manager import TournamentManager
 from BackEnd.main import run_simulation
 from BackEnd.utils.shared import summarize_game_state
 from bson import ObjectId
-from pydantic import BaseModel
 
 router = APIRouter()
+
+
+class StartTournamentRequest(BaseModel):
+    """Payload for creating a new tournament."""
+    user_team_id: str
 
 class TournamentResultRequest(BaseModel):
     tournament_id: str
@@ -71,7 +75,7 @@ def simulate_round(request: SimulateRequest):
         updated["_id"] = str(updated["_id"])
     return updated
 
-@app.post("/tournament/save-result")
+@router.post("/tournament/save-result")
 def save_result(request: TournamentResultRequest):
     from bson import ObjectId
 


### PR DESCRIPTION
## Summary
- define StartTournamentRequest in `tournament_routes.py`
- correct route decorator for `/tournament/save-result`

## Testing
- `pytest tests/test_tournament_manager.py::test_create_tournament_generates_seeded_bracket -q`
- `pytest -q` *(fails: ServerSelectionTimeoutError)*

------
https://chatgpt.com/codex/tasks/task_e_6873b3b58768832885eafac77b0647af