### PR TITLE
Use square team logos on home page

### DIFF
--- a/FrontEnd/static/homepage.js
+++ b/FrontEnd/static/homepage.js
@@ -7,6 +7,17 @@ const playBtn = document.getElementById('play-btn');
 const clickSound = new Audio('./sounds/mixkit-click.wav');
 const addSound = new Audio('./sounds/handgun.mp3');
 
+const teamCodeMap = {
+  "Bentley-Truman": "bt",
+  "Four Corners": "fc",
+  "Lancaster": "lan",
+  "Little York": "ly",
+  "Morristown": "mor",
+  "Ocean City": "oc",
+  "South Lancaster": "sl",
+  "Xavien": "xav"
+};
+
 const teams = [
   'Bentley-Truman',
   'Four Corners',
@@ -58,7 +69,16 @@ function addToFirstAvailable(team) {
 function setLogo(box, team) {
   box.innerHTML = '';
   const img = document.createElement('img');
-  img.src = `./images/homepage-logos/${team}.png`;
+  const code = teamCodeMap[team];
+  if (code) {
+    img.src = `./images/square-logos/${code}_square.png`;
+    img.onerror = () => {
+      img.onerror = null;
+      img.src = `./images/homepage-logos/${team}.png`;
+    };
+  } else {
+    img.src = `./images/homepage-logos/${team}.png`;
+  }
   img.alt = team;
   box.appendChild(img);
   box.dataset.team = team;

--- a/FrontEnd/static/index.html
+++ b/FrontEnd/static/index.html
@@ -41,7 +41,11 @@
       justify-content: center;
       background: #fff;
     }
-    .box img { max-width: 100%; max-height: 100%; }
+    .box img {
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+    }
     #play-btn {
       position: relative;
       border: none;


### PR DESCRIPTION
## Summary
- show selected teams using square logos on index page
- support fallback to legacy horizontal logos if a square logo fails to load
- add placeholder directory for square logos
- improve styling so logos fit the selection boxes

## Testing
- `pytest -q` *(fails: `KeyError: 'MONGO_URI'`)*

------
https://chatgpt.com/codex/tasks/task_e_6873daea76448328aa0864ecb50438a6