### PR TITLE
Center play button and resize team slots

### DIFF
--- a/FrontEnd/static/homepage.js
+++ b/FrontEnd/static/homepage.js
@@ -7,6 +7,17 @@ const playBtn = document.getElementById('play-btn');
 const clickSound = new Audio('./sounds/mixkit-click.wav');
 const addSound = new Audio('./sounds/handgun.mp3');
 
+const teamCodeMap = {
+  "Bentley-Truman": "bt",
+  "Four Corners": "fc",
+  "Lancaster": "lan",
+  "Little York": "ly",
+  "Morristown": "mor",
+  "Ocean City": "oc",
+  "South Lancaster": "sl",
+  "Xavien": "xav"
+};
+
 const teams = [
   'Bentley-Truman',
   'Four Corners',
@@ -58,7 +69,16 @@ function addToFirstAvailable(team) {
 function setLogo(box, team) {
   box.innerHTML = '';
   const img = document.createElement('img');
-  img.src = `./images/homepage-logos/${team}.png`;
+  const code = teamCodeMap[team];
+  if (code) {
+    img.src = `./images/square-logos/${code}_square.png`;
+    img.onerror = () => {
+      img.onerror = null;
+      img.src = `./images/homepage-logos/${team}.png`;
+    };
+  } else {
+    img.src = `./images/homepage-logos/${team}.png`;
+  }
   img.alt = team;
   box.appendChild(img);
   box.dataset.team = team;

--- a/FrontEnd/static/index.html
+++ b/FrontEnd/static/index.html
@@ -22,7 +22,7 @@
     #team-slots {
       display: flex;
       justify-content: center;
-      align-items: flex-start;
+      align-items: center;
       gap: 40px;
       margin-bottom: 20px;
     }
@@ -32,16 +32,21 @@
       align-items: center;
     }
     .box {
-      width: 150px;
-      height: 150px;
+      width: 230px;
+      height: 110px;
       border: 2px dashed #999;
       margin-bottom: 5px;
       display: flex;
       align-items: center;
       justify-content: center;
       background: #fff;
+      overflow: hidden;
     }
-    .box img { max-width: 100%; max-height: 100%; }
+    .box img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
     #play-btn {
       position: relative;
       border: none;


### PR DESCRIPTION
## Summary
- resize the Home and Away selection boxes to match logo buttons
- make logos fill the boxes without white space
- vertically center the Play Now button between the slots

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'BackEnd')*

------
https://chatgpt.com/codex/tasks/task_e_6873daea76448328aa0864ecb50438a6