### PR TITLE
Store tournament rosters

### DIFF
--- a/BackEnd/tournament/tournament_manager.py
+++ b/BackEnd/tournament/tournament_manager.py
@@ -3,6 +3,7 @@ import random
 from bson import ObjectId
 
 from BackEnd.db import tournaments_collection as default_tournaments_collection
+from BackEnd.utils.roster_loader import load_roster
 
 class TournamentManager:
     """Manage tournament creation and progression."""
@@ -30,6 +31,20 @@ class TournamentManager:
         random.shuffle(teams)
         seeds = {team_id: i + 1 for i, team_id in enumerate(teams)}
         round1 = self._generate_first_round(seeds)
+
+        # Build roster mapping for all teams in the bracket
+        tournament_teams = {
+            team
+            for matchup in round1
+            for team in (matchup["home_team"], matchup["away_team"])
+        }
+        players_map = {}
+        for team_name in tournament_teams:
+            team_doc, players = load_roster(team_name)
+            team_entry = team_doc.copy() if team_doc else {"name": team_name}
+            team_entry["players"] = players
+            players_map[team_name] = team_entry
+
         tournament_doc = {
             "user_team_id": self.user_team_id,
             "created_at": datetime.utcnow(),
@@ -46,6 +61,7 @@ class TournamentManager:
                 "top_10_blocks": [],
                 "top_10_steals": []
             },
+            "players": players_map,
             "completed": False
         }
         self.tournament_id = self.tournaments_collection.insert_one(tournament_doc).inserted_id

--- a/tests/test_tournament_manager.py
+++ b/tests/test_tournament_manager.py
@@ -28,6 +28,10 @@ def test_create_tournament_generates_seeded_bracket(mock_collection):
     assert tournament["_id"] == "mock_id"
     mock_collection.insert_one.assert_called_once()
 
+    # ensure players mapping was created for all teams
+    assert isinstance(tournament.get("players"), dict)
+    assert set(tournament["players"].keys()) == set(all_teams)
+
 def test_save_game_result_and_advance_round(mock_collection):
     manager = TournamentManager(
         user_team_id="Xavien",


### PR DESCRIPTION
## Summary
- extend `TournamentManager.create_tournament` to include full team rosters
- test for players mapping when creating tournaments

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873f6bd4dec8328bca836f167068ddf