### PR TITLE
Simplify tournament document

### DIFF
--- a/BackEnd/api/api.py
+++ b/BackEnd/api/api.py
@@ -111,59 +111,18 @@ def simulate_game(request: SimulationRequest):
 def get_team_roster(team_name: str, tournament_id: str | None = None):
     """Return a team's roster.
 
-    If ``tournament_id`` is provided, the roster is looked up within that
-    tournament document. Otherwise the roster is loaded from the global
-    ``teams_collection``/JSON files using ``load_roster``.
+    ``tournament_id`` is ignored but accepted for backward compatibility.
+    The roster is always loaded using :func:`load_roster`.
     """
     print(f"🔍 Endpoint hit: GET /roster/{team_name}")
     if tournament_id:
-        print(f"🔍 Tournament ID: {tournament_id}")
+        print(f"🔍 Tournament ID provided but ignored: {tournament_id}")
 
-    team_doc = None
-    player_objects = []
+    team_doc, player_objects = load_roster(team_name)
 
-    if tournament_id:
-        # Tournament context lookup
-        try:
-            oid = ObjectId(tournament_id)
-        except Exception:
-            raise HTTPException(status_code=400, detail="Invalid tournament_id")
-
-        tournament = tournaments_collection.find_one({"_id": oid})
-        if not tournament:
-            raise HTTPException(status_code=404, detail="Tournament not found")
-
-        players_data = tournament.get("players", {})
-        team_data = None
-
-        if isinstance(players_data, dict):
-            # players stored as mapping of team_name -> roster or team object
-            team_data = players_data.get(team_name)
-        elif isinstance(players_data, list):
-            # players stored as list of team docs
-            for entry in players_data:
-                name = entry.get("team") or entry.get("team_name") or entry.get("name")
-                if name == team_name:
-                    team_data = entry
-                    break
-
-        if team_data:
-            if isinstance(team_data, dict) and "players" in team_data:
-                player_objects = team_data.get("players", [])
-                team_doc = team_data
-            elif isinstance(team_data, list):
-                player_objects = team_data
-                team_doc = {"name": team_name}
-
-        if not player_objects:
-            raise HTTPException(status_code=404, detail="Team not found in tournament")
-    else:
-        # Standard single game lookup
-        team_doc, player_objects = load_roster(team_name)
-
-        if not player_objects:
-            print(f"❌ No players found for {team_name}")
-            raise HTTPException(status_code=404, detail=f"No players found for team '{team_name}'")
+    if not player_objects:
+        print(f"❌ No players found for {team_name}")
+        raise HTTPException(status_code=404, detail=f"No players found for team '{team_name}'")
 
     team = team_doc or {"name": team_name}
 

--- a/BackEnd/tournament/tournament_manager.py
+++ b/BackEnd/tournament/tournament_manager.py
@@ -3,7 +3,6 @@ import random
 from bson import ObjectId
 
 from BackEnd.db import tournaments_collection as default_tournaments_collection
-from BackEnd.utils.roster_loader import load_roster
 
 class TournamentManager:
     """Manage tournament creation and progression."""
@@ -32,19 +31,6 @@ class TournamentManager:
         seeds = {team_id: i + 1 for i, team_id in enumerate(teams)}
         round1 = self._generate_first_round(seeds)
 
-        # Build roster mapping for all teams in the bracket
-        tournament_teams = {
-            team
-            for matchup in round1
-            for team in (matchup["home_team"], matchup["away_team"])
-        }
-        players_map = {}
-        for team_name in tournament_teams:
-            team_doc, players = load_roster(team_name)
-            team_entry = team_doc.copy() if team_doc else {"name": team_name}
-            team_entry["players"] = players
-            players_map[team_name] = team_entry
-
         tournament_doc = {
             "user_team_id": self.user_team_id,
             "created_at": datetime.utcnow(),
@@ -61,7 +47,6 @@ class TournamentManager:
                 "top_10_blocks": [],
                 "top_10_steals": []
             },
-            "players": players_map,
             "completed": False
         }
         self.tournament_id = self.tournaments_collection.insert_one(tournament_doc).inserted_id

--- a/tests/test_tournament_manager.py
+++ b/tests/test_tournament_manager.py
@@ -28,9 +28,8 @@ def test_create_tournament_generates_seeded_bracket(mock_collection):
     assert tournament["_id"] == "mock_id"
     mock_collection.insert_one.assert_called_once()
 
-    # ensure players mapping was created for all teams
-    assert isinstance(tournament.get("players"), dict)
-    assert set(tournament["players"].keys()) == set(all_teams)
+    # tournament should not contain embedded rosters
+    assert "players" not in tournament
 
 def test_save_game_result_and_advance_round(mock_collection):
     manager = TournamentManager(


### PR DESCRIPTION
## Summary
- stop embedding team rosters in tournaments
- ignore `tournament_id` param in roster API
- update tests for new tournament layout

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873fd93a46083288c6ad232dcc09fb3