### PR TITLE
Fix court loading timing

### DIFF
--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -67,8 +67,6 @@ export function createGameScene(Phaser) {
       // Load with fallback
       this.load.image(courtKey, courtPath);
 
-      this.load.start()
-      
       // Ensure animation only runs after everything is loaded and created
       this.load.once("complete", async () => {
         if (this.textures.exists(courtKey)) {
@@ -148,6 +146,7 @@ export function createGameScene(Phaser) {
         }
         }
     });
+      this.load.start()
     }
   };
 }


### PR DESCRIPTION
## Summary
- move the initial `load.start` call until after the `load.once("complete")` registration
- keep fallback logic during load

## Testing
- `pip install -r requirements.txt`
- `pip install mongomock`
- `pip install httpx<0.28`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687449c064b08328b3b1d5c42f8aa3e6