### PR TITLE
Disable Phaser audio for testing

### DIFF
--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -43,6 +43,8 @@ async function initTournamentGame() {
     height: 768,
     backgroundColor: "#1e1e1e",
     parent: "phaser-container",
+    // Disable audio to avoid AudioContext warnings in automated testing
+    audio: { noAudio: true },
     scene: {
       key: 'GameScene',
       ...GameScene,


### PR DESCRIPTION
## Summary
- turn off Phaser audio in `bootGame.js` to avoid browser warnings

## Testing
- `pytest -q` *(fails: `Client.__init__()` got unexpected keyword argument `app`)*

------
https://chatgpt.com/codex/tasks/task_e_687449c226648328bfebf3b44ccc3602