### PR TITLE
Add team player sync script

### DIFF
--- a/scripts/update_player_ids_from_players.py
+++ b/scripts/update_player_ids_from_players.py
@@ -1,0 +1,11 @@
+from BackEnd.db import teams_collection, players_collection
+
+for team in teams_collection.find({}):
+    name = team.get("name")
+    player_cursor = players_collection.find({"team": name})
+    player_ids = [p["_id"] for p in player_cursor]
+    teams_collection.update_one(
+        {"_id": team["_id"]},
+        {"$set": {"player_ids": player_ids}}
+    )
+    print(f"✅ Updated {name} with {len(player_ids)} player_ids")


### PR DESCRIPTION
## Summary
- add new `scripts/update_player_ids_from_players.py` helper
- script loops through every team and populates each `player_ids` array from the `players` collection

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874f0ca84d0832888828c4ace973020