### PR TITLE
Implement tournament top sections

### DIFF
--- a/FrontEnd/static/tournament.css
+++ b/FrontEnd/static/tournament.css
@@ -16,6 +16,58 @@ h1, h2, h3 {
   padding: 20px;
 }
 
+#top-left {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.team-logo {
+  width: 100px;
+  height: auto;
+  margin-bottom: 10px;
+}
+
+.left-info {
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  font-weight: bold;
+}
+
+#top-center {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.chemistry-bar {
+  width: 100%;
+  height: 20px;
+  border-radius: 10px;
+  background: linear-gradient(to right, #003366, #4a90e2, #ffd580, #ff6600);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+
+.team-stats {
+  line-height: 1.4;
+}
+
+.coach-info {
+  text-align: center;
+}
+
+.coach-info img {
+  width: 80px;
+  height: auto;
+  margin-bottom: 5px;
+}
+
 #tournament-tabs {
   padding: 20px;
 }

--- a/FrontEnd/static/tournament.html
+++ b/FrontEnd/static/tournament.html
@@ -10,10 +10,34 @@
 <body>
 
   <div id="tournament-top">
-    <div id="top-left"></div>
-    <div id="top-center"></div>
-    <div id="top-right-coach1"></div>
-    <div id="top-right-coach2"></div>
+    <div id="top-left">
+      <img src="/static/images/homepage-logos/bentley-truman.png" class="team-logo" />
+      <div class="left-info">
+        <span class="username">Username</span>
+        <span class="seed">Seed: 1</span>
+      </div>
+    </div>
+
+    <div id="top-center">
+      <div class="chemistry-bar">14 / 25</div>
+      <div class="team-stats">
+        Offense: A<br/>
+        Defense: B<br/>
+        Athleticism: B+<br/>
+        Intangibles: C<br/>
+        Prestige: A+<br/>
+        Nat'l Rank: 11/128
+      </div>
+    </div>
+
+    <div id="top-right-coach1" class="coach-info">
+      <img src="/static/images/coaches/BT/Sammy.png" />
+      <div>+SH / +SC</div>
+    </div>
+    <div id="top-right-coach2" class="coach-info">
+      <img src="/static/images/coaches/BT/Mary.png" />
+      <div>+Home Crowd</div>
+    </div>
   </div>
 
   <div id="tournament-tabs">


### PR DESCRIPTION
## Summary
- build left 1/3 with team logo and user details
- show chemistry bar and team ratings in middle section
- display coaches side-by-side on the right

## Testing
- `pytest` *(fails: TypeError in TestClient)*

------
https://chatgpt.com/codex/tasks/task_e_68756b0e690483288c53894bbf8bb7a6