### PR TITLE
Add basic bracket UI layout

### DIFF
--- a/FrontEnd/static/tournament.css
+++ b/FrontEnd/static/tournament.css
@@ -97,10 +97,86 @@ h1, h2, h3 {
   cursor: pointer;
 }
 
+.tab-buttons button.active {
+  border-bottom: 2px solid #333;
+}
+
 .tab-content {
   display: none;
 }
 
 .tab-content.active {
   display: block;
+}
+
+/* --- Bracket Layout --- */
+.bracket {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+}
+
+.round {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.matchup {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  margin-bottom: 40px;
+  position: relative;
+  border: 2px solid transparent;
+}
+
+.matchup img {
+  width: 80px;
+  height: auto;
+  margin: 4px 0;
+}
+
+/* Connector line to next round */
+.round:not(.final) .matchup::after {
+  content: "";
+  position: absolute;
+  right: -20px;
+  top: 50%;
+  width: 20px;
+  height: 2px;
+  background: #999;
+}
+
+/* --- Bracket State Styles --- */
+.winner {
+  outline: 3px solid #00e676;
+}
+
+@keyframes pulse-yellow {
+  0% { outline-color: #ffeb3b; }
+  50% { outline-color: #fff176; }
+  100% { outline-color: #ffeb3b; }
+}
+
+.upcoming {
+  animation: pulse-yellow 1s infinite;
+  outline: 3px solid #ffeb3b;
+}
+
+@keyframes pulse-green {
+  0% { outline-color: #00e676; }
+  50% { outline-color: #69f0ae; }
+  100% { outline-color: #00e676; }
+}
+
+.champion.won {
+  animation: pulse-green 1s infinite;
+  outline: 3px solid #00e676;
+}
+
+.champion {
+  outline: 3px solid #00e676;
 }

--- a/FrontEnd/static/tournament.html
+++ b/FrontEnd/static/tournament.html
@@ -46,10 +46,61 @@
       <button data-tab="team-tab">Team</button>
       <button data-tab="leaders-tab">Leaders</button>
     </div>
-    <div id="bracket-tab" class="tab-content active"></div>
+    <div id="bracket-tab" class="tab-content active">
+      <div id="bracket" class="bracket">
+        <div class="round quarterfinals">
+          <div class="matchup" data-round="1" data-matchup="1">
+            <img src="images/bracket-logos/Bently-Horizontal.svg" data-team-id="TEAM-1">
+            <img src="images/bracket-logos/Corners-Horizontal.svg" data-team-id="TEAM-2">
+          </div>
+          <div class="matchup" data-round="1" data-matchup="2">
+            <img src="images/bracket-logos/Lancaster-Horizontal.svg" data-team-id="TEAM-3">
+            <img src="images/bracket-logos/Morristown-Horizontal.svg" data-team-id="TEAM-4">
+          </div>
+          <div class="matchup" data-round="1" data-matchup="3">
+            <img src="images/bracket-logos/Ocean-Horizontal (1).svg" data-team-id="TEAM-5">
+            <img src="images/bracket-logos/South-Horizontal.svg" data-team-id="TEAM-6">
+          </div>
+          <div class="matchup" data-round="1" data-matchup="4">
+            <img src="images/bracket-logos/Xavien-Horizontal (1).svg" data-team-id="TEAM-7">
+            <img src="images/bracket-logos/York-Horizontal.svg" data-team-id="TEAM-8">
+          </div>
+        </div>
+        <div class="round semifinals">
+          <div class="matchup" data-round="2" data-matchup="1">
+            <img src="images/bracket-logos/Bently-Horizontal.svg" data-team-id="SEMIS-1A">
+            <img src="images/bracket-logos/Lancaster-Horizontal.svg" data-team-id="SEMIS-1B">
+          </div>
+          <div class="matchup" data-round="2" data-matchup="2">
+            <img src="images/bracket-logos/South-Horizontal.svg" data-team-id="SEMIS-2A">
+            <img src="images/bracket-logos/York-Horizontal.svg" data-team-id="SEMIS-2B">
+          </div>
+        </div>
+        <div class="round final">
+          <div class="matchup" data-round="3" data-matchup="1">
+            <img src="images/bracket-logos/Bently-Horizontal.svg" data-team-id="FINALS-1">
+            <img src="images/bracket-logos/South-Horizontal.svg" data-team-id="FINALS-2">
+          </div>
+        </div>
+      </div>
+    </div>
     <div id="team-tab" class="tab-content"></div>
     <div id="leaders-tab" class="tab-content"></div>
   </div>
+
+  <script>
+    const tabButtons = document.querySelectorAll('.tab-buttons button');
+    const tabContents = document.querySelectorAll('.tab-content');
+    tabButtons.forEach(btn => {
+      btn.addEventListener('click', () => {
+        tabButtons.forEach(b => b.classList.remove('active'));
+        tabContents.forEach(c => c.classList.remove('active'));
+        btn.classList.add('active');
+        const target = document.getElementById(btn.dataset.tab);
+        if (target) target.classList.add('active');
+      });
+    });
+  </script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement quarterfinals, semifinals and finals layout
- support tab switching via small script
- style bracket states and tab buttons

## Testing
- `pip install -r requirements.txt`
- `pip install mongomock`
- `pip install 'httpx<0.25' --force-reinstall`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68769f53ecc0832899e4a08b3bb7e2dd