### PR TITLE
Center later rounds in bracket

### DIFF
--- a/FrontEnd/static/tournament.css
+++ b/FrontEnd/static/tournament.css
@@ -4,6 +4,11 @@ body {
   padding: 0;
 }
 
+:root {
+  --matchup-height: 160px;
+  --matchup-gap: 40px;
+}
+
 h1, h2, h3 {
   font-family: 'Bebas Neue', cursive;
 }
@@ -122,13 +127,28 @@ h1, h2, h3 {
   align-items: center;
 }
 
+.round.semifinals .matchup-wrapper:first-child,
+.round.final .matchup-wrapper:first-child {
+  margin-top: calc(var(--matchup-height) / 2 + var(--matchup-gap) / 2);
+}
+
+.matchup-wrapper {
+  height: var(--matchup-height);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.round .matchup-wrapper:not(:last-child) {
+  margin-bottom: var(--matchup-gap);
+}
+
 .matchup {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   padding: 10px;
-  margin-bottom: 40px;
   position: relative;
   border: 2px solid transparent;
 }

--- a/FrontEnd/static/tournament.html
+++ b/FrontEnd/static/tournament.html
@@ -49,37 +49,51 @@
     <div id="bracket-tab" class="tab-content active">
       <div id="bracket" class="bracket">
         <div class="round quarterfinals">
-          <div class="matchup" data-round="1" data-matchup="1">
-            <img src="images/bracket-logos/Bently-Horizontal.svg" data-team-id="TEAM-1">
-            <img src="images/bracket-logos/Corners-Horizontal.svg" data-team-id="TEAM-2">
+          <div class="matchup-wrapper">
+            <div class="matchup" data-round="1" data-matchup="1">
+              <img src="images/bracket-logos/Bently-Horizontal.svg" data-team-id="TEAM-1">
+              <img src="images/bracket-logos/Corners-Horizontal.svg" data-team-id="TEAM-2">
+            </div>
           </div>
-          <div class="matchup" data-round="1" data-matchup="2">
-            <img src="images/bracket-logos/Lancaster-Horizontal.svg" data-team-id="TEAM-3">
-            <img src="images/bracket-logos/Morristown-Horizontal.svg" data-team-id="TEAM-4">
+          <div class="matchup-wrapper">
+            <div class="matchup" data-round="1" data-matchup="2">
+              <img src="images/bracket-logos/Lancaster-Horizontal.svg" data-team-id="TEAM-3">
+              <img src="images/bracket-logos/Morristown-Horizontal.svg" data-team-id="TEAM-4">
+            </div>
           </div>
-          <div class="matchup" data-round="1" data-matchup="3">
-            <img src="images/bracket-logos/Ocean-Horizontal (1).svg" data-team-id="TEAM-5">
-            <img src="images/bracket-logos/South-Horizontal.svg" data-team-id="TEAM-6">
+          <div class="matchup-wrapper">
+            <div class="matchup" data-round="1" data-matchup="3">
+              <img src="images/bracket-logos/Ocean-Horizontal (1).svg" data-team-id="TEAM-5">
+              <img src="images/bracket-logos/South-Horizontal.svg" data-team-id="TEAM-6">
+            </div>
           </div>
-          <div class="matchup" data-round="1" data-matchup="4">
-            <img src="images/bracket-logos/Xavien-Horizontal (1).svg" data-team-id="TEAM-7">
-            <img src="images/bracket-logos/York-Horizontal.svg" data-team-id="TEAM-8">
+          <div class="matchup-wrapper">
+            <div class="matchup" data-round="1" data-matchup="4">
+              <img src="images/bracket-logos/Xavien-Horizontal (1).svg" data-team-id="TEAM-7">
+              <img src="images/bracket-logos/York-Horizontal.svg" data-team-id="TEAM-8">
+            </div>
           </div>
         </div>
         <div class="round semifinals">
-          <div class="matchup" data-round="2" data-matchup="1">
-            <img src="images/bracket-logos/Bently-Horizontal.svg" data-team-id="SEMIS-1A">
-            <img src="images/bracket-logos/Lancaster-Horizontal.svg" data-team-id="SEMIS-1B">
+          <div class="matchup-wrapper">
+            <div class="matchup" data-round="2" data-matchup="1">
+              <img src="images/bracket-logos/Bently-Horizontal.svg" data-team-id="SEMIS-1A">
+              <img src="images/bracket-logos/Lancaster-Horizontal.svg" data-team-id="SEMIS-1B">
+            </div>
           </div>
-          <div class="matchup" data-round="2" data-matchup="2">
-            <img src="images/bracket-logos/South-Horizontal.svg" data-team-id="SEMIS-2A">
-            <img src="images/bracket-logos/York-Horizontal.svg" data-team-id="SEMIS-2B">
+          <div class="matchup-wrapper">
+            <div class="matchup" data-round="2" data-matchup="2">
+              <img src="images/bracket-logos/South-Horizontal.svg" data-team-id="SEMIS-2A">
+              <img src="images/bracket-logos/York-Horizontal.svg" data-team-id="SEMIS-2B">
+            </div>
           </div>
         </div>
         <div class="round final">
-          <div class="matchup" data-round="3" data-matchup="1">
-            <img src="images/bracket-logos/Bently-Horizontal.svg" data-team-id="FINALS-1">
-            <img src="images/bracket-logos/South-Horizontal.svg" data-team-id="FINALS-2">
+          <div class="matchup-wrapper">
+            <div class="matchup" data-round="3" data-matchup="1">
+              <img src="images/bracket-logos/Bently-Horizontal.svg" data-team-id="FINALS-1">
+              <img src="images/bracket-logos/South-Horizontal.svg" data-team-id="FINALS-2">
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- wrap bracket matchups with `.matchup-wrapper`
- space wrappers evenly and use CSS vars for consistent heights
- add offset for semifinal and final rounds so each round is centered against the one before it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876abb4d59c8328bb7e9e285b74f9cd