### PR TITLE
Implement team roster and stats tables

### DIFF
--- a/FrontEnd/static/tournament.css
+++ b/FrontEnd/static/tournament.css
@@ -200,3 +200,32 @@ h1, h2, h3 {
 .champion {
   outline: 3px solid #00e676;
 }
+
+/* --- Team Tab Tables --- */
+.scroll-x {
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+table.roster-table,
+table.stats-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: 'Inter', sans-serif;
+  min-width: 800px;
+}
+
+table.roster-table th,
+table.roster-table td,
+table.stats-table th,
+table.stats-table td {
+  border: 1px solid #ccc;
+  padding: 4px 6px;
+  text-align: center;
+  font-size: 14px;
+}
+
+table.roster-table tbody tr:nth-child(odd),
+table.stats-table tbody tr:nth-child(odd) {
+  background-color: #f9f9f9;
+}

--- a/FrontEnd/static/tournament.html
+++ b/FrontEnd/static/tournament.html
@@ -98,7 +98,124 @@
         </div>
       </div>
     </div>
-    <div id="team-tab" class="tab-content"></div>
+    <div id="team-tab" class="tab-content">
+      <div class="scroll-x">
+        <table class="roster-table">
+          <thead>
+            <tr>
+              <th>Player</th>
+              <th>SC</th>
+              <th>SH</th>
+              <th>ID</th>
+              <th>OD</th>
+              <th>PS</th>
+              <th>BH</th>
+              <th>RB</th>
+              <th>ST</th>
+              <th>AG</th>
+              <th>ND</th>
+              <th>IQ</th>
+              <th>FT</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr data-player-id="P1" data-team-id="TEAM-1">
+              <td>Player 1</td><td>80</td><td>75</td><td>70</td><td>72</td><td>68</td><td>74</td><td>65</td><td>60</td><td>78</td><td>70</td><td>85</td><td>76</td>
+            </tr>
+            <tr data-player-id="P2" data-team-id="TEAM-1">
+              <td>Player 2</td><td>82</td><td>77</td><td>68</td><td>71</td><td>70</td><td>73</td><td>67</td><td>62</td><td>79</td><td>71</td><td>84</td><td>74</td>
+            </tr>
+            <tr data-player-id="P3" data-team-id="TEAM-1">
+              <td>Player 3</td><td>79</td><td>74</td><td>69</td><td>70</td><td>69</td><td>72</td><td>66</td><td>61</td><td>77</td><td>69</td><td>83</td><td>75</td>
+            </tr>
+            <tr data-player-id="P4" data-team-id="TEAM-1">
+              <td>Player 4</td><td>81</td><td>76</td><td>71</td><td>69</td><td>71</td><td>75</td><td>64</td><td>63</td><td>76</td><td>72</td><td>82</td><td>77</td>
+            </tr>
+            <tr data-player-id="P5" data-team-id="TEAM-1">
+              <td>Player 5</td><td>78</td><td>73</td><td>72</td><td>68</td><td>72</td><td>71</td><td>68</td><td>59</td><td>75</td><td>73</td><td>81</td><td>78</td>
+            </tr>
+            <tr data-player-id="P6" data-team-id="TEAM-1">
+              <td>Player 6</td><td>77</td><td>72</td><td>70</td><td>67</td><td>70</td><td>70</td><td>69</td><td>60</td><td>74</td><td>70</td><td>80</td><td>79</td>
+            </tr>
+            <tr data-player-id="P7" data-team-id="TEAM-1">
+              <td>Player 7</td><td>83</td><td>78</td><td>73</td><td>72</td><td>74</td><td>76</td><td>70</td><td>64</td><td>80</td><td>75</td><td>86</td><td>75</td>
+            </tr>
+            <tr data-player-id="P8" data-team-id="TEAM-1">
+              <td>Player 8</td><td>76</td><td>71</td><td>67</td><td>66</td><td>68</td><td>69</td><td>64</td><td>58</td><td>73</td><td>68</td><td>79</td><td>72</td>
+            </tr>
+            <tr data-player-id="P9" data-team-id="TEAM-1">
+              <td>Player 9</td><td>80</td><td>75</td><td>71</td><td>70</td><td>72</td><td>74</td><td>67</td><td>65</td><td>78</td><td>72</td><td>84</td><td>77</td>
+            </tr>
+            <tr data-player-id="P10" data-team-id="TEAM-1">
+              <td>Player 10</td><td>81</td><td>76</td><td>72</td><td>71</td><td>73</td><td>75</td><td>68</td><td>66</td><td>79</td><td>73</td><td>85</td><td>78</td>
+            </tr>
+            <tr data-player-id="P11" data-team-id="TEAM-1">
+              <td>Player 11</td><td>79</td><td>74</td><td>70</td><td>69</td><td>71</td><td>72</td><td>65</td><td>62</td><td>77</td><td>71</td><td>83</td><td>76</td>
+            </tr>
+            <tr data-player-id="P12" data-team-id="TEAM-1">
+              <td>Player 12</td><td>78</td><td>73</td><td>69</td><td>68</td><td>70</td><td>71</td><td>66</td><td>61</td><td>75</td><td>70</td><td>82</td><td>74</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="scroll-x" style="margin-top: 20px;">
+        <table class="stats-table">
+          <thead>
+            <tr>
+              <th>Player</th>
+              <th>PTS</th>
+              <th>FGM/FGA</th>
+              <th>3PTM/3PTA</th>
+              <th>FTM/FTA</th>
+              <th>REB</th>
+              <th>AST</th>
+              <th>STL</th>
+              <th>BLK</th>
+              <th>TO</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr data-player-id="P1" data-team-id="TEAM-1">
+              <td>Player 1</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td>
+            </tr>
+            <tr data-player-id="P2" data-team-id="TEAM-1">
+              <td>Player 2</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td>
+            </tr>
+            <tr data-player-id="P3" data-team-id="TEAM-1">
+              <td>Player 3</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td>
+            </tr>
+            <tr data-player-id="P4" data-team-id="TEAM-1">
+              <td>Player 4</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td>
+            </tr>
+            <tr data-player-id="P5" data-team-id="TEAM-1">
+              <td>Player 5</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td>
+            </tr>
+            <tr data-player-id="P6" data-team-id="TEAM-1">
+              <td>Player 6</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td>
+            </tr>
+            <tr data-player-id="P7" data-team-id="TEAM-1">
+              <td>Player 7</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td>
+            </tr>
+            <tr data-player-id="P8" data-team-id="TEAM-1">
+              <td>Player 8</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td>
+            </tr>
+            <tr data-player-id="P9" data-team-id="TEAM-1">
+              <td>Player 9</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td>
+            </tr>
+            <tr data-player-id="P10" data-team-id="TEAM-1">
+              <td>Player 10</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td>
+            </tr>
+            <tr data-player-id="P11" data-team-id="TEAM-1">
+              <td>Player 11</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td>
+            </tr>
+            <tr data-player-id="P12" data-team-id="TEAM-1">
+              <td>Player 12</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
     <div id="leaders-tab" class="tab-content"></div>
   </div>
 


### PR DESCRIPTION
## Summary
- build out the Team tab in the tournament view
- add scrollable roster and stats tables with placeholder data
- style tables for horizontal scrolling

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876b00414fc8328b8a256abfb9676ac