### PR TITLE
Refine bracket layout

### DIFF
--- a/FrontEnd/static/tournament.css
+++ b/FrontEnd/static/tournament.css
@@ -5,8 +5,8 @@ body {
 }
 
 :root {
-  --matchup-height: 160px;
-  --matchup-gap: 40px;
+  --matchup-height: 100px;
+  --matchup-gap: 20px;
 }
 
 h1, h2, h3 {
@@ -127,9 +127,19 @@ h1, h2, h3 {
   align-items: center;
 }
 
-.round.semifinals .matchup-wrapper:first-child,
-.round.final .matchup-wrapper {
-  margin-top: calc(var(--matchup-height) + var(--matchup-gap));
+.round.semifinals .matchup-wrapper:first-child {
+  margin-top: calc((var(--matchup-height) + var(--matchup-gap)) / 2);
+}
+
+.round.final {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  height: 100%;
+}
+
+.round.final .spacer {
+  flex: 1;
 }
 
 .matchup-wrapper {
@@ -154,7 +164,7 @@ h1, h2, h3 {
 }
 
 .matchup img {
-  width: 80px;
+  width: 160px;
   height: auto;
   margin: 4px 0;
 }

--- a/FrontEnd/static/tournament.html
+++ b/FrontEnd/static/tournament.html
@@ -89,12 +89,14 @@
           </div>
         </div>
         <div class="round final">
+          <div class="spacer"></div>
           <div class="matchup-wrapper">
             <div class="matchup" data-round="3" data-matchup="1">
               <img src="images/bracket-logos/Bently-Horizontal.svg" data-team-id="FINALS-1">
               <img src="images/bracket-logos/South-Horizontal.svg" data-team-id="FINALS-2">
             </div>
           </div>
+          <div class="spacer"></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- resize team logos in the bracket
- tighten spacing in the bracket layout
- vertically center semifinals and final matchups
- center the championship with spacer elements

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876b124ce9083288d0e204163064ab8