### PR TITLE
Adjust tournament bracket layout

### DIFF
--- a/FrontEnd/static/tournament.css
+++ b/FrontEnd/static/tournament.css
@@ -131,6 +131,10 @@ h1, h2, h3 {
   margin-top: calc((var(--matchup-height) + var(--matchup-gap)) / 2);
 }
 
+.round.semifinals .matchup-wrapper:nth-child(2) {
+  margin-top: calc(var(--matchup-height) + var(--matchup-gap));
+}
+
 .round.final {
   display: flex;
   flex-direction: column;
@@ -164,8 +168,9 @@ h1, h2, h3 {
 }
 
 .matchup img {
-  width: 160px;
+  width: 128px;
   height: auto;
+  object-fit: contain;
   margin: 4px 0;
 }
 


### PR DESCRIPTION
## Summary
- shrink logo sizes in tournament bracket
- normalize logo rendering
- refine vertical spacing for semifinal round

## Testing
- `pytest -q` *(fails: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6876b42e7fdc832885b04810ca1e9557