### PR TITLE
Add fouls and minutes columns

### DIFF
--- a/FrontEnd/static/tournament.html
+++ b/FrontEnd/static/tournament.html
@@ -172,45 +172,47 @@
               <th>AST</th>
               <th>STL</th>
               <th>BLK</th>
+              <th>F</th>
+              <th>MIN</th>
               <th>TO</th>
             </tr>
           </thead>
           <tbody>
             <tr data-player-id="P1" data-team-id="TEAM-1">
-              <td>Player 1</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td>
+              <td>Player 1</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0.0</td><td>0</td>
             </tr>
             <tr data-player-id="P2" data-team-id="TEAM-1">
-              <td>Player 2</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td>
+              <td>Player 2</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0.0</td><td>0</td>
             </tr>
             <tr data-player-id="P3" data-team-id="TEAM-1">
-              <td>Player 3</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td>
+              <td>Player 3</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0.0</td><td>0</td>
             </tr>
             <tr data-player-id="P4" data-team-id="TEAM-1">
-              <td>Player 4</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td>
+              <td>Player 4</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0.0</td><td>0</td>
             </tr>
             <tr data-player-id="P5" data-team-id="TEAM-1">
-              <td>Player 5</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td>
+              <td>Player 5</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0.0</td><td>0</td>
             </tr>
             <tr data-player-id="P6" data-team-id="TEAM-1">
-              <td>Player 6</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td>
+              <td>Player 6</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0.0</td><td>0</td>
             </tr>
             <tr data-player-id="P7" data-team-id="TEAM-1">
-              <td>Player 7</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td>
+              <td>Player 7</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0.0</td><td>0</td>
             </tr>
             <tr data-player-id="P8" data-team-id="TEAM-1">
-              <td>Player 8</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td>
+              <td>Player 8</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0.0</td><td>0</td>
             </tr>
             <tr data-player-id="P9" data-team-id="TEAM-1">
-              <td>Player 9</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td>
+              <td>Player 9</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0.0</td><td>0</td>
             </tr>
             <tr data-player-id="P10" data-team-id="TEAM-1">
-              <td>Player 10</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td>
+              <td>Player 10</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0.0</td><td>0</td>
             </tr>
             <tr data-player-id="P11" data-team-id="TEAM-1">
-              <td>Player 11</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td>
+              <td>Player 11</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0.0</td><td>0</td>
             </tr>
             <tr data-player-id="P12" data-team-id="TEAM-1">
-              <td>Player 12</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td>
+              <td>Player 12</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0.0</td><td>0</td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
## Summary
- extend the tournament stats table with personal foul and minutes columns

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876b2a183188328aeee74b0ae2ffd4a