### PR TITLE
Implement Leaders tab UI

### DIFF
--- a/FrontEnd/static/tournament.css
+++ b/FrontEnd/static/tournament.css
@@ -230,6 +230,14 @@ table.stats-table {
   min-width: 800px;
 }
 
+/* Leaderboard tables share the same base styling */
+table.leaders-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: 'Inter', sans-serif;
+  min-width: 600px;
+}
+
 table.roster-table th,
 table.roster-table td,
 table.stats-table th,
@@ -240,7 +248,19 @@ table.stats-table td {
   font-size: 14px;
 }
 
+table.leaders-table th,
+table.leaders-table td {
+  border: 1px solid #ccc;
+  padding: 4px 6px;
+  text-align: center;
+  font-size: 14px;
+}
+
 table.roster-table tbody tr:nth-child(odd),
 table.stats-table tbody tr:nth-child(odd) {
+  background-color: #f9f9f9;
+}
+
+table.leaders-table tbody tr:nth-child(odd) {
   background-color: #f9f9f9;
 }

--- a/FrontEnd/static/tournament.html
+++ b/FrontEnd/static/tournament.html
@@ -218,7 +218,175 @@
         </table>
       </div>
     </div>
-    <div id="leaders-tab" class="tab-content"></div>
+    <div id="leaders-tab" class="tab-content">
+      <div class="leaderboard-section">
+        <h3>Points</h3>
+        <div class="scroll-x">
+          <table class="leaders-table">
+            <thead>
+              <tr>
+                <th>Rank</th>
+                <th>Player</th>
+                <th>Team</th>
+                <th>Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr data-player-id="P1" data-team-id="TEAM-A"><td>1</td><td>Player 1</td><td>Team A</td><td>22.3</td></tr>
+              <tr data-player-id="P2" data-team-id="TEAM-B"><td>2</td><td>Player 2</td><td>Team B</td><td>21.9</td></tr>
+              <tr data-player-id="P3" data-team-id="TEAM-C"><td>3</td><td>Player 3</td><td>Team C</td><td>20.7</td></tr>
+              <tr data-player-id="P4" data-team-id="TEAM-D"><td>4</td><td>Player 4</td><td>Team D</td><td>19.5</td></tr>
+              <tr data-player-id="P5" data-team-id="TEAM-E"><td>5</td><td>Player 5</td><td>Team E</td><td>18.2</td></tr>
+              <tr data-player-id="P6" data-team-id="TEAM-F"><td>6</td><td>Player 6</td><td>Team F</td><td>17.8</td></tr>
+              <tr data-player-id="P7" data-team-id="TEAM-G"><td>7</td><td>Player 7</td><td>Team G</td><td>17.0</td></tr>
+              <tr data-player-id="P8" data-team-id="TEAM-H"><td>8</td><td>Player 8</td><td>Team H</td><td>16.5</td></tr>
+              <tr data-player-id="P9" data-team-id="TEAM-I"><td>9</td><td>Player 9</td><td>Team I</td><td>15.9</td></tr>
+              <tr data-player-id="P10" data-team-id="TEAM-J"><td>10</td><td>Player 10</td><td>Team J</td><td>15.2</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="leaderboard-section">
+        <h3>3-Pointers Made</h3>
+        <div class="scroll-x">
+          <table class="leaders-table">
+            <thead>
+              <tr>
+                <th>Rank</th>
+                <th>Player</th>
+                <th>Team</th>
+                <th>Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr data-player-id="T1" data-team-id="TEAM-A"><td>1</td><td>Player 1</td><td>Team A</td><td>4.2</td></tr>
+              <tr data-player-id="T2" data-team-id="TEAM-B"><td>2</td><td>Player 2</td><td>Team B</td><td>3.9</td></tr>
+              <tr data-player-id="T3" data-team-id="TEAM-C"><td>3</td><td>Player 3</td><td>Team C</td><td>3.7</td></tr>
+              <tr data-player-id="T4" data-team-id="TEAM-D"><td>4</td><td>Player 4</td><td>Team D</td><td>3.5</td></tr>
+              <tr data-player-id="T5" data-team-id="TEAM-E"><td>5</td><td>Player 5</td><td>Team E</td><td>3.4</td></tr>
+              <tr data-player-id="T6" data-team-id="TEAM-F"><td>6</td><td>Player 6</td><td>Team F</td><td>3.1</td></tr>
+              <tr data-player-id="T7" data-team-id="TEAM-G"><td>7</td><td>Player 7</td><td>Team G</td><td>2.9</td></tr>
+              <tr data-player-id="T8" data-team-id="TEAM-H"><td>8</td><td>Player 8</td><td>Team H</td><td>2.8</td></tr>
+              <tr data-player-id="T9" data-team-id="TEAM-I"><td>9</td><td>Player 9</td><td>Team I</td><td>2.7</td></tr>
+              <tr data-player-id="T10" data-team-id="TEAM-J"><td>10</td><td>Player 10</td><td>Team J</td><td>2.5</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="leaderboard-section">
+        <h3>Rebounds</h3>
+        <div class="scroll-x">
+          <table class="leaders-table">
+            <thead>
+              <tr>
+                <th>Rank</th>
+                <th>Player</th>
+                <th>Team</th>
+                <th>Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr data-player-id="R1" data-team-id="TEAM-A"><td>1</td><td>Player 1</td><td>Team A</td><td>11.2</td></tr>
+              <tr data-player-id="R2" data-team-id="TEAM-B"><td>2</td><td>Player 2</td><td>Team B</td><td>10.9</td></tr>
+              <tr data-player-id="R3" data-team-id="TEAM-C"><td>3</td><td>Player 3</td><td>Team C</td><td>10.5</td></tr>
+              <tr data-player-id="R4" data-team-id="TEAM-D"><td>4</td><td>Player 4</td><td>Team D</td><td>10.1</td></tr>
+              <tr data-player-id="R5" data-team-id="TEAM-E"><td>5</td><td>Player 5</td><td>Team E</td><td>9.8</td></tr>
+              <tr data-player-id="R6" data-team-id="TEAM-F"><td>6</td><td>Player 6</td><td>Team F</td><td>9.5</td></tr>
+              <tr data-player-id="R7" data-team-id="TEAM-G"><td>7</td><td>Player 7</td><td>Team G</td><td>9.3</td></tr>
+              <tr data-player-id="R8" data-team-id="TEAM-H"><td>8</td><td>Player 8</td><td>Team H</td><td>9.1</td></tr>
+              <tr data-player-id="R9" data-team-id="TEAM-I"><td>9</td><td>Player 9</td><td>Team I</td><td>8.9</td></tr>
+              <tr data-player-id="R10" data-team-id="TEAM-J"><td>10</td><td>Player 10</td><td>Team J</td><td>8.7</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="leaderboard-section">
+        <h3>Assists</h3>
+        <div class="scroll-x">
+          <table class="leaders-table">
+            <thead>
+              <tr>
+                <th>Rank</th>
+                <th>Player</th>
+                <th>Team</th>
+                <th>Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr data-player-id="A1" data-team-id="TEAM-A"><td>1</td><td>Player 1</td><td>Team A</td><td>8.6</td></tr>
+              <tr data-player-id="A2" data-team-id="TEAM-B"><td>2</td><td>Player 2</td><td>Team B</td><td>8.2</td></tr>
+              <tr data-player-id="A3" data-team-id="TEAM-C"><td>3</td><td>Player 3</td><td>Team C</td><td>7.9</td></tr>
+              <tr data-player-id="A4" data-team-id="TEAM-D"><td>4</td><td>Player 4</td><td>Team D</td><td>7.6</td></tr>
+              <tr data-player-id="A5" data-team-id="TEAM-E"><td>5</td><td>Player 5</td><td>Team E</td><td>7.3</td></tr>
+              <tr data-player-id="A6" data-team-id="TEAM-F"><td>6</td><td>Player 6</td><td>Team F</td><td>7.0</td></tr>
+              <tr data-player-id="A7" data-team-id="TEAM-G"><td>7</td><td>Player 7</td><td>Team G</td><td>6.8</td></tr>
+              <tr data-player-id="A8" data-team-id="TEAM-H"><td>8</td><td>Player 8</td><td>Team H</td><td>6.6</td></tr>
+              <tr data-player-id="A9" data-team-id="TEAM-I"><td>9</td><td>Player 9</td><td>Team I</td><td>6.4</td></tr>
+              <tr data-player-id="A10" data-team-id="TEAM-J"><td>10</td><td>Player 10</td><td>Team J</td><td>6.2</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="leaderboard-section">
+        <h3>Steals</h3>
+        <div class="scroll-x">
+          <table class="leaders-table">
+            <thead>
+              <tr>
+                <th>Rank</th>
+                <th>Player</th>
+                <th>Team</th>
+                <th>Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr data-player-id="S1" data-team-id="TEAM-A"><td>1</td><td>Player 1</td><td>Team A</td><td>2.4</td></tr>
+              <tr data-player-id="S2" data-team-id="TEAM-B"><td>2</td><td>Player 2</td><td>Team B</td><td>2.3</td></tr>
+              <tr data-player-id="S3" data-team-id="TEAM-C"><td>3</td><td>Player 3</td><td>Team C</td><td>2.2</td></tr>
+              <tr data-player-id="S4" data-team-id="TEAM-D"><td>4</td><td>Player 4</td><td>Team D</td><td>2.1</td></tr>
+              <tr data-player-id="S5" data-team-id="TEAM-E"><td>5</td><td>Player 5</td><td>Team E</td><td>2.0</td></tr>
+              <tr data-player-id="S6" data-team-id="TEAM-F"><td>6</td><td>Player 6</td><td>Team F</td><td>1.9</td></tr>
+              <tr data-player-id="S7" data-team-id="TEAM-G"><td>7</td><td>Player 7</td><td>Team G</td><td>1.8</td></tr>
+              <tr data-player-id="S8" data-team-id="TEAM-H"><td>8</td><td>Player 8</td><td>Team H</td><td>1.7</td></tr>
+              <tr data-player-id="S9" data-team-id="TEAM-I"><td>9</td><td>Player 9</td><td>Team I</td><td>1.6</td></tr>
+              <tr data-player-id="S10" data-team-id="TEAM-J"><td>10</td><td>Player 10</td><td>Team J</td><td>1.5</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="leaderboard-section">
+        <h3>Blocks</h3>
+        <div class="scroll-x">
+          <table class="leaders-table">
+            <thead>
+              <tr>
+                <th>Rank</th>
+                <th>Player</th>
+                <th>Team</th>
+                <th>Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr data-player-id="B1" data-team-id="TEAM-A"><td>1</td><td>Player 1</td><td>Team A</td><td>2.3</td></tr>
+              <tr data-player-id="B2" data-team-id="TEAM-B"><td>2</td><td>Player 2</td><td>Team B</td><td>2.2</td></tr>
+              <tr data-player-id="B3" data-team-id="TEAM-C"><td>3</td><td>Player 3</td><td>Team C</td><td>2.1</td></tr>
+              <tr data-player-id="B4" data-team-id="TEAM-D"><td>4</td><td>Player 4</td><td>Team D</td><td>2.0</td></tr>
+              <tr data-player-id="B5" data-team-id="TEAM-E"><td>5</td><td>Player 5</td><td>Team E</td><td>1.9</td></tr>
+              <tr data-player-id="B6" data-team-id="TEAM-F"><td>6</td><td>Player 6</td><td>Team F</td><td>1.8</td></tr>
+              <tr data-player-id="B7" data-team-id="TEAM-G"><td>7</td><td>Player 7</td><td>Team G</td><td>1.7</td></tr>
+              <tr data-player-id="B8" data-team-id="TEAM-H"><td>8</td><td>Player 8</td><td>Team H</td><td>1.6</td></tr>
+              <tr data-player-id="B9" data-team-id="TEAM-I"><td>9</td><td>Player 9</td><td>Team I</td><td>1.5</td></tr>
+              <tr data-player-id="B10" data-team-id="TEAM-J"><td>10</td><td>Player 10</td><td>Team J</td><td>1.4</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
   </div>
 
   <script>


### PR DESCRIPTION
## Summary
- add stacked leaderboards UI in `tournament.html`
- style new `.leaders-table` to match roster/box score tables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876b6dd27248328abffb1489a0b4cde