### PR TITLE
Update tournament UI for responsive layout

### DIFF
--- a/FrontEnd/static/tournament.css
+++ b/FrontEnd/static/tournament.css
@@ -9,8 +9,13 @@ body {
   --matchup-gap: 20px;
 }
 
-h1, h2, h3 {
+h1, h2, h3, h4, h5, h6 {
   font-family: 'Bebas Neue', cursive;
+}
+
+#tournament-container {
+  max-width: 1200px;
+  margin: 0 auto;
 }
 
 #tournament-top {
@@ -102,6 +107,10 @@ h1, h2, h3 {
   cursor: pointer;
 }
 
+.tab-buttons button:hover {
+  background-color: #f0f0f0;
+}
+
 .tab-buttons button.active {
   border-bottom: 2px solid #333;
 }
@@ -119,6 +128,7 @@ h1, h2, h3 {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 20px;
+  min-width: 900px;
 }
 
 .round {
@@ -220,6 +230,7 @@ h1, h2, h3 {
 .scroll-x {
   overflow-x: auto;
   white-space: nowrap;
+  width: 100%;
 }
 
 table.roster-table,
@@ -263,4 +274,20 @@ table.stats-table tbody tr:nth-child(odd) {
 
 table.leaders-table tbody tr:nth-child(odd) {
   background-color: #f9f9f9;
+}
+
+@media (max-width: 768px) {
+  :root {
+    --matchup-height: 80px;
+    --matchup-gap: 10px;
+  }
+
+  #tournament-top {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .coach-info img {
+    width: 60px;
+  }
 }

--- a/FrontEnd/static/tournament.html
+++ b/FrontEnd/static/tournament.html
@@ -9,6 +9,8 @@
 </head>
 <body>
 
+  <div id="tournament-container">
+
   <div id="tournament-top">
     <div id="top-left">
       <img src="images/homepage-logos/Bentley-Truman.png" alt="Bentley-Truman Logo" class="team-logo">
@@ -47,6 +49,7 @@
       <button data-tab="leaders-tab">Leaders</button>
     </div>
     <div id="bracket-tab" class="tab-content active">
+      <div class="scroll-x">
       <div id="bracket" class="bracket">
         <div class="round quarterfinals">
           <div class="matchup-wrapper">
@@ -390,6 +393,8 @@
       </div>
     </div>
   </div>
+
+  </div> <!-- end tournament-container -->
 
   <script>
     const tabButtons = document.querySelectorAll('.tab-buttons button');


### PR DESCRIPTION
## Summary
- wrap tournament markup in main container
- add scroll wrapper for bracket
- improve styles: container max width, hover styles, mobile media query
- adjust bracket sizing and table overflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876bda4fb08832887687b93cc1e0bf4