### PR TITLE
Add dynamic placeholders for tournament data

### DIFF
--- a/FrontEnd/static/tournament.html
+++ b/FrontEnd/static/tournament.html
@@ -51,56 +51,6 @@
     <div id="bracket-tab" class="tab-content active">
       <div class="scroll-x">
       <div id="bracket" class="bracket">
-        <div class="round quarterfinals">
-          <div class="matchup-wrapper">
-            <div class="matchup" data-round="1" data-matchup="1">
-              <img src="images/bracket-logos/Bently-Horizontal.svg" data-team-id="TEAM-1">
-              <img src="images/bracket-logos/Corners-Horizontal.svg" data-team-id="TEAM-2">
-            </div>
-          </div>
-          <div class="matchup-wrapper">
-            <div class="matchup" data-round="1" data-matchup="2">
-              <img src="images/bracket-logos/Lancaster-Horizontal.svg" data-team-id="TEAM-3">
-              <img src="images/bracket-logos/Morristown-Horizontal.svg" data-team-id="TEAM-4">
-            </div>
-          </div>
-          <div class="matchup-wrapper">
-            <div class="matchup" data-round="1" data-matchup="3">
-              <img src="images/bracket-logos/Ocean-Horizontal (1).svg" data-team-id="TEAM-5">
-              <img src="images/bracket-logos/South-Horizontal.svg" data-team-id="TEAM-6">
-            </div>
-          </div>
-          <div class="matchup-wrapper">
-            <div class="matchup" data-round="1" data-matchup="4">
-              <img src="images/bracket-logos/Xavien-Horizontal (1).svg" data-team-id="TEAM-7">
-              <img src="images/bracket-logos/York-Horizontal.svg" data-team-id="TEAM-8">
-            </div>
-          </div>
-        </div>
-        <div class="round semifinals">
-          <div class="matchup-wrapper">
-            <div class="matchup" data-round="2" data-matchup="1">
-              <img src="images/bracket-logos/Bently-Horizontal.svg" data-team-id="SEMIS-1A">
-              <img src="images/bracket-logos/Lancaster-Horizontal.svg" data-team-id="SEMIS-1B">
-            </div>
-          </div>
-          <div class="matchup-wrapper">
-            <div class="matchup" data-round="2" data-matchup="2">
-              <img src="images/bracket-logos/South-Horizontal.svg" data-team-id="SEMIS-2A">
-              <img src="images/bracket-logos/York-Horizontal.svg" data-team-id="SEMIS-2B">
-            </div>
-          </div>
-        </div>
-        <div class="round final">
-          <div class="spacer"></div>
-          <div class="matchup-wrapper">
-            <div class="matchup" data-round="3" data-matchup="1">
-              <img src="images/bracket-logos/Bently-Horizontal.svg" data-team-id="FINALS-1">
-              <img src="images/bracket-logos/South-Horizontal.svg" data-team-id="FINALS-2">
-            </div>
-          </div>
-          <div class="spacer"></div>
-        </div>
       </div>
     </div>
     <div id="team-tab" class="tab-content">
@@ -123,44 +73,7 @@
               <th>FT</th>
             </tr>
           </thead>
-          <tbody>
-            <tr data-player-id="P1" data-team-id="TEAM-1">
-              <td>Player 1</td><td>80</td><td>75</td><td>70</td><td>72</td><td>68</td><td>74</td><td>65</td><td>60</td><td>78</td><td>70</td><td>85</td><td>76</td>
-            </tr>
-            <tr data-player-id="P2" data-team-id="TEAM-1">
-              <td>Player 2</td><td>82</td><td>77</td><td>68</td><td>71</td><td>70</td><td>73</td><td>67</td><td>62</td><td>79</td><td>71</td><td>84</td><td>74</td>
-            </tr>
-            <tr data-player-id="P3" data-team-id="TEAM-1">
-              <td>Player 3</td><td>79</td><td>74</td><td>69</td><td>70</td><td>69</td><td>72</td><td>66</td><td>61</td><td>77</td><td>69</td><td>83</td><td>75</td>
-            </tr>
-            <tr data-player-id="P4" data-team-id="TEAM-1">
-              <td>Player 4</td><td>81</td><td>76</td><td>71</td><td>69</td><td>71</td><td>75</td><td>64</td><td>63</td><td>76</td><td>72</td><td>82</td><td>77</td>
-            </tr>
-            <tr data-player-id="P5" data-team-id="TEAM-1">
-              <td>Player 5</td><td>78</td><td>73</td><td>72</td><td>68</td><td>72</td><td>71</td><td>68</td><td>59</td><td>75</td><td>73</td><td>81</td><td>78</td>
-            </tr>
-            <tr data-player-id="P6" data-team-id="TEAM-1">
-              <td>Player 6</td><td>77</td><td>72</td><td>70</td><td>67</td><td>70</td><td>70</td><td>69</td><td>60</td><td>74</td><td>70</td><td>80</td><td>79</td>
-            </tr>
-            <tr data-player-id="P7" data-team-id="TEAM-1">
-              <td>Player 7</td><td>83</td><td>78</td><td>73</td><td>72</td><td>74</td><td>76</td><td>70</td><td>64</td><td>80</td><td>75</td><td>86</td><td>75</td>
-            </tr>
-            <tr data-player-id="P8" data-team-id="TEAM-1">
-              <td>Player 8</td><td>76</td><td>71</td><td>67</td><td>66</td><td>68</td><td>69</td><td>64</td><td>58</td><td>73</td><td>68</td><td>79</td><td>72</td>
-            </tr>
-            <tr data-player-id="P9" data-team-id="TEAM-1">
-              <td>Player 9</td><td>80</td><td>75</td><td>71</td><td>70</td><td>72</td><td>74</td><td>67</td><td>65</td><td>78</td><td>72</td><td>84</td><td>77</td>
-            </tr>
-            <tr data-player-id="P10" data-team-id="TEAM-1">
-              <td>Player 10</td><td>81</td><td>76</td><td>72</td><td>71</td><td>73</td><td>75</td><td>68</td><td>66</td><td>79</td><td>73</td><td>85</td><td>78</td>
-            </tr>
-            <tr data-player-id="P11" data-team-id="TEAM-1">
-              <td>Player 11</td><td>79</td><td>74</td><td>70</td><td>69</td><td>71</td><td>72</td><td>65</td><td>62</td><td>77</td><td>71</td><td>83</td><td>76</td>
-            </tr>
-            <tr data-player-id="P12" data-team-id="TEAM-1">
-              <td>Player 12</td><td>78</td><td>73</td><td>69</td><td>68</td><td>70</td><td>71</td><td>66</td><td>61</td><td>75</td><td>70</td><td>82</td><td>74</td>
-            </tr>
-          </tbody>
+          <tbody id="roster-body"></tbody>
         </table>
       </div>
 
@@ -182,220 +95,18 @@
               <th>TO</th>
             </tr>
           </thead>
-          <tbody>
-            <tr data-player-id="P1" data-team-id="TEAM-1">
-              <td>Player 1</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td>
-            </tr>
-            <tr data-player-id="P2" data-team-id="TEAM-1">
-              <td>Player 2</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0.0</td><td>0</td>
-            </tr>
-            <tr data-player-id="P3" data-team-id="TEAM-1">
-              <td>Player 3</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0.0</td><td>0</td>
-            </tr>
-            <tr data-player-id="P4" data-team-id="TEAM-1">
-              <td>Player 4</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0.0</td><td>0</td>
-            </tr>
-            <tr data-player-id="P5" data-team-id="TEAM-1">
-              <td>Player 5</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0.0</td><td>0</td>
-            </tr>
-            <tr data-player-id="P6" data-team-id="TEAM-1">
-              <td>Player 6</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0.0</td><td>0</td>
-            </tr>
-            <tr data-player-id="P7" data-team-id="TEAM-1">
-              <td>Player 7</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0.0</td><td>0</td>
-            </tr>
-            <tr data-player-id="P8" data-team-id="TEAM-1">
-              <td>Player 8</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0.0</td><td>0</td>
-            </tr>
-            <tr data-player-id="P9" data-team-id="TEAM-1">
-              <td>Player 9</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0.0</td><td>0</td>
-            </tr>
-            <tr data-player-id="P10" data-team-id="TEAM-1">
-              <td>Player 10</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0.0</td><td>0</td>
-            </tr>
-            <tr data-player-id="P11" data-team-id="TEAM-1">
-              <td>Player 11</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0.0</td><td>0</td>
-            </tr>
-            <tr data-player-id="P12" data-team-id="TEAM-1">
-              <td>Player 12</td><td>0</td><td>0/0</td><td>0/0</td><td>0/0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0.0</td><td>0</td>
-            </tr>
-          </tbody>
+          <tbody id="stats-body"></tbody>
         </table>
       </div>
     </div>
     <div id="leaders-tab" class="tab-content">
-      <div class="leaderboard-section">
-        <h3>Points</h3>
-        <div class="scroll-x">
-          <table class="leaders-table">
-            <thead>
-              <tr>
-                <th>Rank</th>
-                <th>Player</th>
-                <th>Team</th>
-                <th>Value</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr data-player-id="P1" data-team-id="TEAM-A"><td>1</td><td>Player 1</td><td>Team A</td><td>22.3</td></tr>
-              <tr data-player-id="P2" data-team-id="TEAM-B"><td>2</td><td>Player 2</td><td>Team B</td><td>21.9</td></tr>
-              <tr data-player-id="P3" data-team-id="TEAM-C"><td>3</td><td>Player 3</td><td>Team C</td><td>20.7</td></tr>
-              <tr data-player-id="P4" data-team-id="TEAM-D"><td>4</td><td>Player 4</td><td>Team D</td><td>19.5</td></tr>
-              <tr data-player-id="P5" data-team-id="TEAM-E"><td>5</td><td>Player 5</td><td>Team E</td><td>18.2</td></tr>
-              <tr data-player-id="P6" data-team-id="TEAM-F"><td>6</td><td>Player 6</td><td>Team F</td><td>17.8</td></tr>
-              <tr data-player-id="P7" data-team-id="TEAM-G"><td>7</td><td>Player 7</td><td>Team G</td><td>17.0</td></tr>
-              <tr data-player-id="P8" data-team-id="TEAM-H"><td>8</td><td>Player 8</td><td>Team H</td><td>16.5</td></tr>
-              <tr data-player-id="P9" data-team-id="TEAM-I"><td>9</td><td>Player 9</td><td>Team I</td><td>15.9</td></tr>
-              <tr data-player-id="P10" data-team-id="TEAM-J"><td>10</td><td>Player 10</td><td>Team J</td><td>15.2</td></tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-
-      <div class="leaderboard-section">
-        <h3>3-Pointers Made</h3>
-        <div class="scroll-x">
-          <table class="leaders-table">
-            <thead>
-              <tr>
-                <th>Rank</th>
-                <th>Player</th>
-                <th>Team</th>
-                <th>Value</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr data-player-id="T1" data-team-id="TEAM-A"><td>1</td><td>Player 1</td><td>Team A</td><td>4.2</td></tr>
-              <tr data-player-id="T2" data-team-id="TEAM-B"><td>2</td><td>Player 2</td><td>Team B</td><td>3.9</td></tr>
-              <tr data-player-id="T3" data-team-id="TEAM-C"><td>3</td><td>Player 3</td><td>Team C</td><td>3.7</td></tr>
-              <tr data-player-id="T4" data-team-id="TEAM-D"><td>4</td><td>Player 4</td><td>Team D</td><td>3.5</td></tr>
-              <tr data-player-id="T5" data-team-id="TEAM-E"><td>5</td><td>Player 5</td><td>Team E</td><td>3.4</td></tr>
-              <tr data-player-id="T6" data-team-id="TEAM-F"><td>6</td><td>Player 6</td><td>Team F</td><td>3.1</td></tr>
-              <tr data-player-id="T7" data-team-id="TEAM-G"><td>7</td><td>Player 7</td><td>Team G</td><td>2.9</td></tr>
-              <tr data-player-id="T8" data-team-id="TEAM-H"><td>8</td><td>Player 8</td><td>Team H</td><td>2.8</td></tr>
-              <tr data-player-id="T9" data-team-id="TEAM-I"><td>9</td><td>Player 9</td><td>Team I</td><td>2.7</td></tr>
-              <tr data-player-id="T10" data-team-id="TEAM-J"><td>10</td><td>Player 10</td><td>Team J</td><td>2.5</td></tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-
-      <div class="leaderboard-section">
-        <h3>Rebounds</h3>
-        <div class="scroll-x">
-          <table class="leaders-table">
-            <thead>
-              <tr>
-                <th>Rank</th>
-                <th>Player</th>
-                <th>Team</th>
-                <th>Value</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr data-player-id="R1" data-team-id="TEAM-A"><td>1</td><td>Player 1</td><td>Team A</td><td>11.2</td></tr>
-              <tr data-player-id="R2" data-team-id="TEAM-B"><td>2</td><td>Player 2</td><td>Team B</td><td>10.9</td></tr>
-              <tr data-player-id="R3" data-team-id="TEAM-C"><td>3</td><td>Player 3</td><td>Team C</td><td>10.5</td></tr>
-              <tr data-player-id="R4" data-team-id="TEAM-D"><td>4</td><td>Player 4</td><td>Team D</td><td>10.1</td></tr>
-              <tr data-player-id="R5" data-team-id="TEAM-E"><td>5</td><td>Player 5</td><td>Team E</td><td>9.8</td></tr>
-              <tr data-player-id="R6" data-team-id="TEAM-F"><td>6</td><td>Player 6</td><td>Team F</td><td>9.5</td></tr>
-              <tr data-player-id="R7" data-team-id="TEAM-G"><td>7</td><td>Player 7</td><td>Team G</td><td>9.3</td></tr>
-              <tr data-player-id="R8" data-team-id="TEAM-H"><td>8</td><td>Player 8</td><td>Team H</td><td>9.1</td></tr>
-              <tr data-player-id="R9" data-team-id="TEAM-I"><td>9</td><td>Player 9</td><td>Team I</td><td>8.9</td></tr>
-              <tr data-player-id="R10" data-team-id="TEAM-J"><td>10</td><td>Player 10</td><td>Team J</td><td>8.7</td></tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-
-      <div class="leaderboard-section">
-        <h3>Assists</h3>
-        <div class="scroll-x">
-          <table class="leaders-table">
-            <thead>
-              <tr>
-                <th>Rank</th>
-                <th>Player</th>
-                <th>Team</th>
-                <th>Value</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr data-player-id="A1" data-team-id="TEAM-A"><td>1</td><td>Player 1</td><td>Team A</td><td>8.6</td></tr>
-              <tr data-player-id="A2" data-team-id="TEAM-B"><td>2</td><td>Player 2</td><td>Team B</td><td>8.2</td></tr>
-              <tr data-player-id="A3" data-team-id="TEAM-C"><td>3</td><td>Player 3</td><td>Team C</td><td>7.9</td></tr>
-              <tr data-player-id="A4" data-team-id="TEAM-D"><td>4</td><td>Player 4</td><td>Team D</td><td>7.6</td></tr>
-              <tr data-player-id="A5" data-team-id="TEAM-E"><td>5</td><td>Player 5</td><td>Team E</td><td>7.3</td></tr>
-              <tr data-player-id="A6" data-team-id="TEAM-F"><td>6</td><td>Player 6</td><td>Team F</td><td>7.0</td></tr>
-              <tr data-player-id="A7" data-team-id="TEAM-G"><td>7</td><td>Player 7</td><td>Team G</td><td>6.8</td></tr>
-              <tr data-player-id="A8" data-team-id="TEAM-H"><td>8</td><td>Player 8</td><td>Team H</td><td>6.6</td></tr>
-              <tr data-player-id="A9" data-team-id="TEAM-I"><td>9</td><td>Player 9</td><td>Team I</td><td>6.4</td></tr>
-              <tr data-player-id="A10" data-team-id="TEAM-J"><td>10</td><td>Player 10</td><td>Team J</td><td>6.2</td></tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-
-      <div class="leaderboard-section">
-        <h3>Steals</h3>
-        <div class="scroll-x">
-          <table class="leaders-table">
-            <thead>
-              <tr>
-                <th>Rank</th>
-                <th>Player</th>
-                <th>Team</th>
-                <th>Value</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr data-player-id="S1" data-team-id="TEAM-A"><td>1</td><td>Player 1</td><td>Team A</td><td>2.4</td></tr>
-              <tr data-player-id="S2" data-team-id="TEAM-B"><td>2</td><td>Player 2</td><td>Team B</td><td>2.3</td></tr>
-              <tr data-player-id="S3" data-team-id="TEAM-C"><td>3</td><td>Player 3</td><td>Team C</td><td>2.2</td></tr>
-              <tr data-player-id="S4" data-team-id="TEAM-D"><td>4</td><td>Player 4</td><td>Team D</td><td>2.1</td></tr>
-              <tr data-player-id="S5" data-team-id="TEAM-E"><td>5</td><td>Player 5</td><td>Team E</td><td>2.0</td></tr>
-              <tr data-player-id="S6" data-team-id="TEAM-F"><td>6</td><td>Player 6</td><td>Team F</td><td>1.9</td></tr>
-              <tr data-player-id="S7" data-team-id="TEAM-G"><td>7</td><td>Player 7</td><td>Team G</td><td>1.8</td></tr>
-              <tr data-player-id="S8" data-team-id="TEAM-H"><td>8</td><td>Player 8</td><td>Team H</td><td>1.7</td></tr>
-              <tr data-player-id="S9" data-team-id="TEAM-I"><td>9</td><td>Player 9</td><td>Team I</td><td>1.6</td></tr>
-              <tr data-player-id="S10" data-team-id="TEAM-J"><td>10</td><td>Player 10</td><td>Team J</td><td>1.5</td></tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-
-      <div class="leaderboard-section">
-        <h3>Blocks</h3>
-        <div class="scroll-x">
-          <table class="leaders-table">
-            <thead>
-              <tr>
-                <th>Rank</th>
-                <th>Player</th>
-                <th>Team</th>
-                <th>Value</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr data-player-id="B1" data-team-id="TEAM-A"><td>1</td><td>Player 1</td><td>Team A</td><td>2.3</td></tr>
-              <tr data-player-id="B2" data-team-id="TEAM-B"><td>2</td><td>Player 2</td><td>Team B</td><td>2.2</td></tr>
-              <tr data-player-id="B3" data-team-id="TEAM-C"><td>3</td><td>Player 3</td><td>Team C</td><td>2.1</td></tr>
-              <tr data-player-id="B4" data-team-id="TEAM-D"><td>4</td><td>Player 4</td><td>Team D</td><td>2.0</td></tr>
-              <tr data-player-id="B5" data-team-id="TEAM-E"><td>5</td><td>Player 5</td><td>Team E</td><td>1.9</td></tr>
-              <tr data-player-id="B6" data-team-id="TEAM-F"><td>6</td><td>Player 6</td><td>Team F</td><td>1.8</td></tr>
-              <tr data-player-id="B7" data-team-id="TEAM-G"><td>7</td><td>Player 7</td><td>Team G</td><td>1.7</td></tr>
-              <tr data-player-id="B8" data-team-id="TEAM-H"><td>8</td><td>Player 8</td><td>Team H</td><td>1.6</td></tr>
-              <tr data-player-id="B9" data-team-id="TEAM-I"><td>9</td><td>Player 9</td><td>Team I</td><td>1.5</td></tr>
-              <tr data-player-id="B10" data-team-id="TEAM-J"><td>10</td><td>Player 10</td><td>Team J</td><td>1.4</td></tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
+      <div id="leaderboards"></div>
     </div>
   </div>
 
   </div> <!-- end tournament-container -->
 
+<script src="tournament.js"></script>
   <script>
     const tabButtons = document.querySelectorAll('.tab-buttons button');
     const tabContents = document.querySelectorAll('.tab-content');

--- a/FrontEnd/static/tournament.js
+++ b/FrontEnd/static/tournament.js
@@ -1,0 +1,130 @@
+// Placeholder data for Tournament Mode
+const userTeamId = "BENTLEY-TRUMAN";
+
+const bracketData = [
+  { round: 1, matchups: [
+      { teamA: "Bently", teamB: "Corners", winner: "Bently" },
+      { teamA: "Lancaster", teamB: "Morristown", winner: "Lancaster" },
+      { teamA: "Ocean", teamB: "South", upcoming: true },
+      { teamA: "Xavien", teamB: "York" }
+  ]},
+  { round: 2, matchups: [
+      { teamA: "Bently", teamB: "Lancaster" },
+      { teamA: "South", teamB: "York" }
+  ]},
+  { round: 3, matchups: [
+      { teamA: "Bently", teamB: "South", champion: true }
+  ]}
+];
+
+const roster = Array.from({ length: 12 }, (_, i) => ({
+  name: `Player ${i+1}`,
+  SC: 70 + (i % 5), SH: 72 + (i % 5), ID: 68 + (i % 5), OD: 69 + (i % 5),
+  PS: 70 + (i % 5), BH: 71 + (i % 5), RB: 65 + (i % 5), ST: 60 + (i % 5),
+  AG: 75 + (i % 5), ND: 70 + (i % 5), IQ: 80 + (i % 5), FT: 75 + (i % 5)
+}));
+
+const stats = roster.map(p => ({ name: p.name, PTS: 0, FGM: 0, FGA: 0,
+  TPM: 0, TPA: 0, FTM: 0, FTA: 0, REB: 0, AST: 0, STL: 0, BLK: 0,
+  F: 0, MIN: 0, TO: 0 }));
+
+const leaderBoards = [
+  { title: "Points", key: "PTS" },
+  { title: "3-Pointers Made", key: "TPM" },
+  { title: "Rebounds", key: "REB" },
+  { title: "Assists", key: "AST" },
+  { title: "Steals", key: "STL" },
+  { title: "Blocks", key: "BLK" }
+];
+
+function renderBracket() {
+  const bracket = document.getElementById("bracket");
+  bracket.innerHTML = "";
+  bracketData.forEach(round => {
+    const roundDiv = document.createElement("div");
+    roundDiv.className = round.round === 1 ? "round quarterfinals" :
+      round.round === 2 ? "round semifinals" : "round final";
+
+    round.matchups.forEach(m => {
+      const wrap = document.createElement("div");
+      wrap.className = "matchup-wrapper";
+      const matchup = document.createElement("div");
+      matchup.className = "matchup";
+      if (m.champion) matchup.classList.add("champion");
+      if (m.winner) matchup.classList.add("winner");
+      if (m.upcoming) matchup.classList.add("upcoming");
+
+      const imgA = document.createElement("img");
+      imgA.src = `images/bracket-logos/${m.teamA}-Horizontal.svg`;
+      const imgB = document.createElement("img");
+      imgB.src = `images/bracket-logos/${m.teamB}-Horizontal.svg`;
+      matchup.appendChild(imgA);
+      matchup.appendChild(imgB);
+      wrap.appendChild(matchup);
+      roundDiv.appendChild(wrap);
+    });
+    bracket.appendChild(roundDiv);
+  });
+}
+
+function renderRoster() {
+  const tbody = document.getElementById("roster-body");
+  tbody.innerHTML = "";
+  roster.forEach(p => {
+    const tr = document.createElement("tr");
+    tr.innerHTML = `
+      <td>${p.name}</td>
+      <td>${p.SC}</td><td>${p.SH}</td><td>${p.ID}</td><td>${p.OD}</td>
+      <td>${p.PS}</td><td>${p.BH}</td><td>${p.RB}</td><td>${p.ST}</td>
+      <td>${p.AG}</td><td>${p.ND}</td><td>${p.IQ}</td><td>${p.FT}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+function renderStats() {
+  const tbody = document.getElementById("stats-body");
+  tbody.innerHTML = "";
+  stats.forEach(s => {
+    const tr = document.createElement("tr");
+    tr.innerHTML = `
+      <td>${s.name}</td><td>${s.PTS}</td><td>${s.FGM}/${s.FGA}</td>
+      <td>${s.TPM}/${s.TPA}</td><td>${s.FTM}/${s.FTA}</td><td>${s.REB}</td>
+      <td>${s.AST}</td><td>${s.STL}</td><td>${s.BLK}</td><td>${s.F}</td>
+      <td>${s.MIN}</td><td>${s.TO}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+function renderLeaderboards() {
+  const container = document.getElementById("leaderboards");
+  container.innerHTML = "";
+  leaderBoards.forEach(board => {
+    const section = document.createElement("div");
+    section.className = "leaderboard-section";
+    const h3 = document.createElement("h3");
+    h3.textContent = board.title;
+    section.appendChild(h3);
+    const div = document.createElement("div");
+    div.className = "scroll-x";
+    const table = document.createElement("table");
+    table.className = "leaders-table";
+    table.innerHTML = `<thead><tr><th>Rank</th><th>Player</th><th>Team</th><th>Value</th></tr></thead>`;
+    const body = document.createElement("tbody");
+    for (let i=1;i<=10;i++) {
+      const tr = document.createElement("tr");
+      tr.innerHTML = `<td>${i}</td><td>Player ${i}</td><td>Team ${String.fromCharCode(64+i)}</td><td>${(20-i).toFixed(1)}</td>`;
+      body.appendChild(tr);
+    }
+    table.appendChild(body);
+    div.appendChild(table);
+    section.appendChild(div);
+    container.appendChild(section);
+  });
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  renderBracket();
+  renderRoster();
+  renderStats();
+  renderLeaderboards();
+});


### PR DESCRIPTION
## Summary
- strip static bracket, roster and leaderboard rows from tournament.html
- add tournament.js for client-side rendering of bracket, roster, stats and leaderboards
- load new script in tournament.html

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'BackEnd')*

------
https://chatgpt.com/codex/tasks/task_e_6876ca229a3c8328b5f17ade8953deb2