### PR TITLE
Add TBD placeholders in tournament bracket

### DIFF
--- a/FrontEnd/static/tournament.css
+++ b/FrontEnd/static/tournament.css
@@ -233,6 +233,18 @@ h1, h2, h3, h4, h5, h6 {
   outline: 3px solid #00e676;
 }
 
+/* Placeholder for TBD rounds */
+.placeholder {
+  width: 128px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #f0f0f0;
+  font-weight: bold;
+  border: 1px dashed #999;
+}
+
 /* --- Team Tab Tables --- */
 .scroll-x {
   display: block;

--- a/FrontEnd/static/tournament.js
+++ b/FrontEnd/static/tournament.js
@@ -31,14 +31,32 @@ function getLogo(teamName) {
   return `images/bracket-logos/${logoMap[teamName] || `${teamName}-Horizontal.svg`}`;
 }
 
+function addTbdRound(bracketEl, count, cls) {
+  const div = document.createElement("div");
+  div.className = `round ${cls}`;
+  for (let i = 0; i < count; i++) {
+    const wrap = document.createElement("div");
+    wrap.className = "matchup-wrapper";
+    const matchup = document.createElement("div");
+    matchup.className = "matchup";
+    const placeholder = document.createElement("div");
+    placeholder.className = "placeholder";
+    placeholder.textContent = "TBD";
+    matchup.appendChild(placeholder);
+    wrap.appendChild(matchup);
+    div.appendChild(wrap);
+  }
+  bracketEl.appendChild(div);
+}
+
 function renderBracket() {
   if (!tournament) return;
   const bracket = document.getElementById("bracket");
   bracket.innerHTML = "";
 
   const round1 = tournament.bracket?.round1 || [];
-  const roundDiv = document.createElement("div");
-  roundDiv.className = "round quarterfinals";
+  const r1Div = document.createElement("div");
+  r1Div.className = "round quarterfinals";
 
   round1.forEach(m => {
     const wrap = document.createElement("div");
@@ -57,10 +75,14 @@ function renderBracket() {
     matchup.appendChild(imgA);
     matchup.appendChild(imgB);
     wrap.appendChild(matchup);
-    roundDiv.appendChild(wrap);
+    r1Div.appendChild(wrap);
   });
 
-  bracket.appendChild(roundDiv);
+  bracket.appendChild(r1Div);
+
+  const round2Count = Math.ceil(round1.length / 2);
+  addTbdRound(bracket, round2Count, "semifinals");
+  addTbdRound(bracket, 1, "final");
 }
 
 function renderRoster() {


### PR DESCRIPTION
## Summary
- show placeholder "TBD" matchups for the semifinal and final rounds
- style placeholder boxes in the bracket

## Testing
- `pip install -r requirements.txt`
- `pip install mongomock`
- `pip install httpx`
- `pytest -q` *(fails: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6877bd443e28832882f6db913bfae80e