### PR TITLE
Fix tournament start endpoint fetch

### DIFF
--- a/FrontEnd/static/tournament-select.js
+++ b/FrontEnd/static/tournament-select.js
@@ -22,7 +22,13 @@ function createButtons() {
 
 async function selectTeam(team) {
   try {
-    const res = await fetch("/start-tournament", {
+    // Use absolute URL so the request always goes to the FastAPI backend
+    const backendURL =
+      window.location.hostname === "localhost"
+        ? "http://localhost:8000"
+        : window.location.origin;
+
+    const res = await fetch(`${backendURL}/start-tournament`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ user_team_id: team })


### PR DESCRIPTION
## Summary
- use absolute URL for POST /start-tournament so request always hits FastAPI backend

## Testing
- `pip install -r requirements.txt`
- `pip install mongomock`
- `pip install httpx<0.26 -U`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877de0fde408328943d6fc2ef9492b2