### PR TITLE
Add game mode selection page layout

### DIFF
--- a/FrontEnd/static/mode-select.css
+++ b/FrontEnd/static/mode-select.css
@@ -1,0 +1,51 @@
+body {
+  font-family: 'Inter', sans-serif;
+  background: #f5f5f5;
+  margin: 0;
+  padding: 20px;
+}
+
+#page-title {
+  font-family: 'Bebas Neue', cursive;
+  font-size: 36px;
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.mode-container {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.mode-card {
+  background: #eee;
+  border: 1px solid #ccc;
+  padding: 20px;
+  flex: 1 1 200px;
+  max-width: 250px;
+  text-align: center;
+  transition: transform 0.1s, box-shadow 0.1s;
+}
+
+.mode-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+}
+
+.play-button {
+  background: #ff9800;
+  color: #fff;
+  border: none;
+  padding: 10px 20px;
+  font-weight: bold;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.play-button.disabled {
+  background: #777;
+  cursor: default;
+  pointer-events: none;
+}

--- a/FrontEnd/static/mode-select.html
+++ b/FrontEnd/static/mode-select.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Choose Game Mode</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="./mode-select.css">
+</head>
+<body>
+  <h1 id="page-title">CHOOSE YOUR GAME MODE</h1>
+  <div class="mode-container">
+    <div class="mode-card">
+      <h2>Scrimmage</h2>
+      <button class="play-button">PLAY NOW</button>
+    </div>
+    <div class="mode-card">
+      <h2>Tournament</h2>
+      <button class="play-button">PLAY NOW</button>
+    </div>
+    <div class="mode-card">
+      <h2>Franchise</h2>
+      <button class="play-button disabled" disabled>IN DEVELOPMENT</button>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a `mode-select.html` page for choosing Scrimmage, Tournament or Franchise mode
- style the layout with `mode-select.css`

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877e01b5cb08328acecb7c73e79d39b