### PR TITLE
Wire up mode selection buttons

### DIFF
--- a/FrontEnd/static/mode-select.html
+++ b/FrontEnd/static/mode-select.html
@@ -12,16 +12,17 @@
   <div class="mode-container">
     <div class="mode-card">
       <h2>Scrimmage</h2>
-      <button class="play-button">PLAY NOW</button>
+      <button id="scrimmage-btn" class="play-button">PLAY NOW</button>
     </div>
     <div class="mode-card">
       <h2>Tournament</h2>
-      <button class="play-button">PLAY NOW</button>
+      <button id="tournament-btn" class="play-button">PLAY NOW</button>
     </div>
     <div class="mode-card">
       <h2>Franchise</h2>
       <button class="play-button disabled" disabled>IN DEVELOPMENT</button>
     </div>
   </div>
+  <script src="./mode-select.js"></script>
 </body>
 </html>

--- a/FrontEnd/static/mode-select.js
+++ b/FrontEnd/static/mode-select.js
@@ -1,0 +1,14 @@
+const scrimmageBtn = document.getElementById('scrimmage-btn');
+const tournamentBtn = document.getElementById('tournament-btn');
+
+if (scrimmageBtn) {
+  scrimmageBtn.addEventListener('click', () => {
+    window.location.href = './index.html';
+  });
+}
+
+if (tournamentBtn) {
+  tournamentBtn.addEventListener('click', () => {
+    window.location.href = './tournament-select.html';
+  });
+}


### PR DESCRIPTION
## Summary
- add IDs and JS to enable Scrimmage and Tournament buttons
- keep Franchise button disabled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877e454a7448328abca0ed9090b8015