### PR TITLE
Update tournament page assets dynamically

### DIFF
--- a/FrontEnd/static/tournament.css
+++ b/FrontEnd/static/tournament.css
@@ -39,6 +39,11 @@ h1, h2, h3, h4, h5, h6 {
   width: 100px;
   height: auto;
   margin-bottom: 10px;
+  border: 2px solid black;
+}
+
+.team-logo.user-team {
+  border: 3px solid yellow;
 }
 
 .left-info {

--- a/FrontEnd/static/tournament.html
+++ b/FrontEnd/static/tournament.html
@@ -13,7 +13,7 @@
 
   <div id="tournament-top">
     <div id="top-left">
-      <img src="images/homepage-logos/Bentley-Truman.png" alt="Bentley-Truman Logo" class="team-logo">
+      <img id="user-team-logo" src="" alt="Team Logo" class="team-logo">
       <div class="left-info">
         <span class="username">Username</span>
       </div>
@@ -33,11 +33,11 @@
     </div>
 
       <div id="top-right-coach1" class="coach-info">
-        <img src="images/coaches/BT/Sammy-BT.png" alt="Coach Sammy" class="coach-img">
+        <img id="coach-sammy" src="" alt="Coach Sammy" class="coach-img">
         <div class="coach-bonus">+SH / +SC</div>
       </div>
       <div id="top-right-coach2" class="coach-info">
-        <img src="images/coaches/BT/Mary-BT.png" alt="Coach Mary" class="coach-img">
+        <img id="coach-mary" src="" alt="Coach Mary" class="coach-img">
         <div class="coach-bonus">+Home Crowd</div>
       </div>
   </div>


### PR DESCRIPTION
## Summary
- show the user's team logo dynamically
- load matching coach images
- highlight the user's bracket logo with a yellow border
- fetch data using stored team id
- keep tests passing with updated dependencies

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877f4e24ff88328b2adfa62aa259c8b