### PR TITLE
Fix bracket spacing and logo styles

### DIFF
--- a/FrontEnd/static/tournament.css
+++ b/FrontEnd/static/tournament.css
@@ -46,6 +46,13 @@ h1, h2, h3, h4, h5, h6 {
   border: 3px solid yellow;
 }
 
+/* Remove border from the logo displayed in the top-left user info box */
+#user-team-logo {
+  border: none;
+  box-shadow: none;
+  background: none;
+}
+
 .left-info {
   display: flex;
   width: 100%;
@@ -143,6 +150,12 @@ h1, h2, h3, h4, h5, h6 {
   min-width: 900px;
 }
 
+/* extra spacing so the top-most logo isn't clipped and all matchups fit */
+#bracket {
+  padding-top: 16px;
+  min-height: 520px;
+}
+
 .round {
   display: flex;
   flex-direction: column;
@@ -194,6 +207,12 @@ h1, h2, h3, h4, h5, h6 {
   height: auto;
   object-fit: contain;
   margin: 4px 0;
+}
+
+/* Consistent sizing for team logos in the bracket */
+.bracket-logo {
+  height: 48px;
+  width: auto;
 }
 
 /* Connector line to next round */

--- a/FrontEnd/static/tournament.js
+++ b/FrontEnd/static/tournament.js
@@ -93,12 +93,12 @@ function renderBracket() {
 
     const imgA = document.createElement("img");
     imgA.src = getLogo(m.home_team);
-    imgA.classList.add("team-logo");
+    imgA.classList.add("team-logo", "bracket-logo");
     if (isUserTeam(m.home_team)) imgA.classList.add("user-team");
 
     const imgB = document.createElement("img");
     imgB.src = getLogo(m.away_team);
-    imgB.classList.add("team-logo");
+    imgB.classList.add("team-logo", "bracket-logo");
     if (isUserTeam(m.away_team)) imgB.classList.add("user-team");
 
     matchup.appendChild(imgA);


### PR DESCRIPTION
## Summary
- remove border from top-left team logo
- ensure bracket logos use consistent sizing
- pad bracket top and extend its height
- mark bracket logos in JS

## Testing
- `pytest -q` *(fails: Client.__init__ unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6877f9be4c248328b260a95d846e0b07