### PR TITLE
Fix vertical centering in tournament bracket

### DIFF
--- a/FrontEnd/static/tournament.css
+++ b/FrontEnd/static/tournament.css
@@ -146,6 +146,8 @@ h1, h2, h3, h4, h5, h6 {
 .bracket {
   display: grid;
   grid-template-columns: repeat(5, 1fr);
+  align-content: stretch;
+  grid-template-rows: 1fr;
   gap: 20px;
   min-width: 1100px;
   height: 640px; /* New: match total visual height of columns with 2 matchups + spacing */
@@ -169,6 +171,7 @@ h1, h2, h3, h4, h5, h6 {
   display: flex;
   flex-direction: column;
   align-items: center;
+  height: 100%;
   /* outline: 1px dashed red; ✅ DEBUG ONLY */
 }
 


### PR DESCRIPTION
## Summary
- stretch the bracket grid to take up available height
- make all round columns fill the grid row so mid columns can center their matchup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'BackEnd')*

------
https://chatgpt.com/codex/tasks/task_e_6878ffd9b3f48328abf12f33320ba774