### PR TITLE
Add training allocation interface

### DIFF
--- a/FrontEnd/static/training.css
+++ b/FrontEnd/static/training.css
@@ -1,0 +1,72 @@
+body {
+  font-family: 'Inter', sans-serif;
+  margin: 0;
+  padding: 20px;
+  background: #f9f9f9;
+  color: #222;
+}
+
+h1 {
+  font-family: 'Bebas Neue', cursive;
+  font-size: 48px;
+  text-align: center;
+  margin: 0 0 10px;
+}
+
+#points-remaining {
+  font-size: 24px;
+  font-weight: bold;
+  text-align: center;
+  margin-bottom: 30px;
+}
+
+#training-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 20px;
+}
+
+.category {
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 15px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+
+.category-name {
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+
+label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.slider {
+  flex: 1;
+  margin: 0 10px;
+}
+
+.value {
+  width: 20px;
+  text-align: right;
+}
+
+.slider:hover {
+  opacity: 0.8;
+}
+
+/* Dark mode */
+body.dark-mode {
+  background: #222;
+  color: #eee;
+}
+
+body.dark-mode .category {
+  background: #333;
+  border-color: #555;
+}

--- a/FrontEnd/static/training.html
+++ b/FrontEnd/static/training.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>GOB Training</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="./training.css">
+</head>
+<body>
+  <h1>Training Allocation</h1>
+  <div id="points-remaining">Points Remaining: <span id="remaining">24</span></div>
+
+  <div id="training-grid">
+    <div class="category">
+      <div class="category-name">Offensive Drills</div>
+      <label>Inside
+        <input type="range" min="0" max="5" step="1" value="0" class="slider" id="offensive-inside">
+        <span class="value">0</span>
+      </label>
+      <label>Outside
+        <input type="range" min="0" max="5" step="1" value="0" class="slider" id="offensive-outside">
+        <span class="value">0</span>
+      </label>
+    </div>
+    <div class="category">
+      <div class="category-name">Defensive Drills</div>
+      <label>Inside
+        <input type="range" min="0" max="5" step="1" value="0" class="slider" id="defensive-inside">
+        <span class="value">0</span>
+      </label>
+      <label>Outside
+        <input type="range" min="0" max="5" step="1" value="0" class="slider" id="defensive-outside">
+        <span class="value">0</span>
+      </label>
+    </div>
+    <div class="category">
+      <div class="category-name">Technical Drills</div>
+      <label>Passing
+        <input type="range" min="0" max="5" step="1" value="0" class="slider" id="technical-passing">
+        <span class="value">0</span>
+      </label>
+      <label>Ball Handling
+        <input type="range" min="0" max="5" step="1" value="0" class="slider" id="technical-ball">
+        <span class="value">0</span>
+      </label>
+      <label>Rebounding
+        <input type="range" min="0" max="5" step="1" value="0" class="slider" id="technical-rebound">
+        <span class="value">0</span>
+      </label>
+    </div>
+    <div class="category">
+      <div class="category-name">Weight Room</div>
+      <label>Strength
+        <input type="range" min="0" max="5" step="1" value="0" class="slider" id="weight-strength">
+        <span class="value">0</span>
+      </label>
+      <label>Agility
+        <input type="range" min="0" max="5" step="1" value="0" class="slider" id="weight-agility">
+        <span class="value">0</span>
+      </label>
+    </div>
+    <div class="category">
+      <div class="category-name">Conditioning</div>
+      <label>Conditioning
+        <input type="range" min="0" max="5" step="1" value="0" class="slider" id="conditioning">
+        <span class="value">0</span>
+      </label>
+    </div>
+    <div class="category">
+      <div class="category-name">Team Building</div>
+      <label>Team Building
+        <input type="range" min="0" max="5" step="1" value="0" class="slider" id="team-building">
+        <span class="value">0</span>
+      </label>
+    </div>
+    <div class="category">
+      <div class="category-name">Free Throws</div>
+      <label>Free Throws
+        <input type="range" min="0" max="5" step="1" value="0" class="slider" id="free-throws">
+        <span class="value">0</span>
+      </label>
+    </div>
+    <div class="category">
+      <div class="category-name">Film Study</div>
+      <label>Film Study
+        <input type="range" min="0" max="5" step="1" value="0" class="slider" id="film-study">
+        <span class="value">0</span>
+      </label>
+    </div>
+    <div class="category">
+      <div class="category-name">Scrimmages</div>
+      <label>Scrimmages
+        <input type="range" min="0" max="5" step="1" value="0" class="slider" id="scrimmages">
+        <span class="value">0</span>
+      </label>
+    </div>
+    <div class="category">
+      <div class="category-name">Breaks</div>
+      <label>Breaks
+        <input type="range" min="0" max="5" step="1" value="0" class="slider" id="breaks">
+        <span class="value">0</span>
+      </label>
+    </div>
+  </div>
+
+  <div style="text-align:center; margin-top:20px;">
+    <button id="toggle-mode">Toggle Dark Mode</button>
+  </div>
+
+  <script>
+  const totalPoints = 24;
+  const remainingEl = document.getElementById('remaining');
+  const sliders = document.querySelectorAll('.slider');
+
+  function updateRemaining() {
+    let used = 0;
+    sliders.forEach(s => used += parseInt(s.value));
+    const remaining = totalPoints - used;
+    remainingEl.textContent = remaining;
+    return remaining;
+  }
+
+  sliders.forEach(slider => {
+    slider.dataset.prev = slider.value;
+    slider.addEventListener('input', function(e) {
+      let total = 0;
+      sliders.forEach(s => total += parseInt(s.value));
+      if (total > totalPoints) {
+        this.value = this.dataset.prev;
+        total = Array.from(sliders).reduce((acc,s)=> acc + parseInt(s.value),0);
+      }
+      this.dataset.prev = this.value;
+      this.parentElement.querySelector('.value').textContent = this.value;
+      updateRemaining();
+    });
+  });
+
+  updateRemaining();
+
+  document.getElementById('toggle-mode').addEventListener('click', () => {
+    document.body.classList.toggle('dark-mode');
+  });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new `training.html` page for allocating 24 practice points across drills
- style page with `training.css`
- include dark mode toggle and slider logic preventing over-allocation

## Testing
- `pip install -r requirements.txt`
- `pip install mongomock`
- `pip install httpx==0.24.1`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a8ce244c88328a38ff2bb039bee03