### PR TITLE
Implement franchise mode routing and templates

### DIFF
--- a/BackEnd/api/api.py
+++ b/BackEnd/api/api.py
@@ -23,6 +23,7 @@ from fastapi.staticfiles import StaticFiles
 from BackEnd.models.animator import Animator   
 from .tournament_routes import router as tournament_router
 from .training_routes import router as training_router
+from .franchise_routes import router as franchise_router
 import traceback
 from unidecode import unidecode
 from typing import Optional
@@ -30,6 +31,7 @@ from typing import Optional
 app = FastAPI()
 app.include_router(tournament_router)
 app.include_router(training_router)
+app.include_router(franchise_router)
 
 
 # app.mount("/", StaticFiles(directory="FrontEnd", html=True), name="static")

--- a/BackEnd/api/franchise_routes.py
+++ b/BackEnd/api/franchise_routes.py
@@ -1,0 +1,37 @@
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import FileResponse, RedirectResponse
+from pydantic import BaseModel
+from pathlib import Path
+
+from BackEnd.db import db, franchise_state_collection
+from BackEnd.models.franchise_manager import FranchiseManager
+
+router = APIRouter()
+
+STATIC_DIR = Path(__file__).resolve().parents[2] / "FrontEnd" / "static"
+
+@router.get("/franchise/start")
+def franchise_start():
+    state = franchise_state_collection.find_one({"_id": "state"})
+    if state is None:
+        return RedirectResponse(url="/franchise/select-team")
+    return RedirectResponse(url="/franchise/command-center")
+
+@router.get("/franchise/select-team")
+def get_select_team_page():
+    return FileResponse(STATIC_DIR / "franchise-select-team.html")
+
+class TeamSelection(BaseModel):
+    team_name: str
+
+@router.post("/franchise/select-team")
+def select_team(selection: TeamSelection):
+    franchise_state_collection.delete_many({})
+    franchise_state_collection.insert_one({"_id": "state", "team": selection.team_name})
+    manager = FranchiseManager(db)
+    manager.initialize_season()
+    return {"status": "ok"}
+
+@router.get("/franchise/command-center")
+def command_center():
+    return FileResponse(STATIC_DIR / "franchise-command-center.html")

--- a/BackEnd/db.py
+++ b/BackEnd/db.py
@@ -25,6 +25,7 @@ if client:
     games_collection = db["games"]
     tournaments_collection = db["tournaments"]
     training_log_collection = db["training_sessions"]
+    franchise_state_collection = db["franchise_state"]
 else:
     import mongomock
     client = mongomock.MongoClient()
@@ -34,5 +35,6 @@ else:
     games_collection = db["games"]
     tournaments_collection = db["tournaments"]
     training_log_collection = db["training_sessions"]
+    franchise_state_collection = db["franchise_state"]
 
 

--- a/FrontEnd/static/franchise-command-center.html
+++ b/FrontEnd/static/franchise-command-center.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Franchise Command Center</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="./tournament.css">
+</head>
+<body>
+  <div id="franchise-container">
+    <h1>Franchise Command Center</h1>
+  </div>
+</body>
+</html>

--- a/FrontEnd/static/franchise-select-team.html
+++ b/FrontEnd/static/franchise-select-team.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Select Franchise Team</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="./tournament-select.css">
+</head>
+<body>
+  <h1>CHOOSE YOUR SQUAD</h1>
+  <div id="team-container"></div>
+  <script src="./franchise-select-team.js"></script>
+</body>
+</html>

--- a/FrontEnd/static/franchise-select-team.js
+++ b/FrontEnd/static/franchise-select-team.js
@@ -1,0 +1,44 @@
+const teams = [
+  "Bentley-Truman",
+  "Lancaster",
+  "Four Corners",
+  "Ocean City",
+  "Morristown",
+  "Little York",
+  "Xavien",
+  "South Lancaster"
+];
+
+function createButtons() {
+  const container = document.getElementById("team-container");
+  teams.forEach(team => {
+    const btn = document.createElement("button");
+    btn.className = "team-button";
+    btn.innerHTML = `<img src="./images/homepage-logos/${team}.png" alt="${team} logo"><span>${team}</span>`;
+    btn.addEventListener("click", () => selectTeam(team));
+    container.appendChild(btn);
+  });
+}
+
+async function selectTeam(team) {
+  try {
+    // Use absolute URL so the request always goes to the FastAPI backend
+    const backendURL =
+      window.location.hostname === "localhost"
+        ? "http://localhost:8000"
+        : window.location.origin;
+
+    const res = await fetch(`${backendURL}/franchise/select-team`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ team_name: team })
+    });
+    if (!res.ok) throw new Error("Failed to start franchise");
+    window.location.href = "/franchise/command-center";
+  } catch (err) {
+    console.error(err);
+    alert("Unable to start franchise");
+  }
+}
+
+document.addEventListener("DOMContentLoaded", createButtons);

--- a/FrontEnd/static/mode-select.html
+++ b/FrontEnd/static/mode-select.html
@@ -20,7 +20,7 @@
     </div>
     <div class="mode-card">
       <h2>Franchise</h2>
-      <button class="play-button disabled" disabled>IN DEVELOPMENT</button>
+      <button id="franchise-btn" class="play-button">PLAY NOW</button>
     </div>
   </div>
   <script src="./mode-select.js"></script>

--- a/FrontEnd/static/mode-select.js
+++ b/FrontEnd/static/mode-select.js
@@ -1,5 +1,6 @@
 const scrimmageBtn = document.getElementById('scrimmage-btn');
 const tournamentBtn = document.getElementById('tournament-btn');
+const franchiseBtn = document.getElementById('franchise-btn');
 
 if (scrimmageBtn) {
   scrimmageBtn.addEventListener('click', () => {
@@ -10,5 +11,11 @@ if (scrimmageBtn) {
 if (tournamentBtn) {
   tournamentBtn.addEventListener('click', () => {
     window.location.href = './tournament-select.html';
+  });
+}
+
+if (franchiseBtn) {
+  franchiseBtn.addEventListener('click', () => {
+    window.location.href = '/franchise/start';
   });
 }


### PR DESCRIPTION
## Summary
- add FastAPI router for franchise mode
- add franchise state collection in database setup
- enable Franchise tile on the mode select screen
- add pages for selecting a franchise team and command center
- wire up frontend JS for franchise workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687abe5f09408328a6e3ff8b827a72d2