### PR TITLE
Implement franchise command center

### DIFF
--- a/BackEnd/api/franchise_routes.py
+++ b/BackEnd/api/franchise_routes.py
@@ -35,3 +35,88 @@ def select_team(selection: TeamSelection):
 @router.get("/franchise/command-center")
 def command_center():
     return FileResponse(STATIC_DIR / "franchise-command-center.html")
+
+
+@router.get("/animation")
+def get_animation_page():
+    return FileResponse(STATIC_DIR / "court.html")
+
+
+@router.post("/franchise/play-next-game")
+def play_next_game():
+    state = franchise_state_collection.find_one({"_id": "state"}) or {}
+    manager = FranchiseManager(db)
+    manager.schedule = state.get("schedule", [])
+    manager.week = state.get("week", 1)
+    manager.run_week()
+    return {"status": "ok"}
+
+
+@router.get("/franchise/command-center/data")
+def command_center_data():
+    state = franchise_state_collection.find_one({"_id": "state"}) or {}
+    team_name = state.get("team", "")
+    team_doc = db.teams.find_one({"name": team_name}) or {}
+    return {
+        "team": team_name,
+        "username": "Coach",
+        "seed": 1,
+        "team_chemistry": team_doc.get("team_chemistry", 0),
+        "offense": team_doc.get("offense", "-"),
+        "defense": team_doc.get("defense", "-"),
+        "athleticism": team_doc.get("athleticism", "-"),
+        "intangibles": team_doc.get("intangibles", "-"),
+        "prestige": team_doc.get("prestige", "-"),
+        "rank": team_doc.get("rank", "-")
+    }
+
+
+@router.get("/franchise/standings")
+def standings():
+    teams = list(db.teams.find({}, {"name": 1, "record": 1}))
+    for t in teams:
+        t["record"] = t.get("record", {"W": 0, "L": 0})
+    teams.sort(key=lambda x: x["record"].get("W", 0), reverse=True)
+    return {"standings": teams}
+
+
+@router.get("/franchise/leaders")
+def leaders():
+    players = list(db.players.find())
+    categories = ["PTS", "AST", "TPM", "REB", "BLK", "STL"]
+    result = {}
+    for cat in categories:
+        sorted_players = sorted(
+            players,
+            key=lambda p: p.get("season_stats", {}).get(cat, 0),
+            reverse=True
+        )[:10]
+        result[cat] = [
+            {
+                "name": f"{p.get('first_name', '')} {p.get('last_name', '')}".strip(),
+                "team": p.get("team"),
+                "value": p.get("season_stats", {}).get(cat, 0)
+            }
+            for p in sorted_players
+        ]
+    return result
+
+
+@router.get("/franchise/team-stats")
+def team_stats():
+    teams = list(db.teams.find({}, {"name": 1}))
+    output = []
+    for t in teams:
+        players = list(db.players.find({"team": t["name"]}))
+        totals = {}
+        for p in players:
+            for stat, val in p.get("season_stats", {}).items():
+                totals[stat] = totals.get(stat, 0) + val
+        output.append({"team": t["name"], "stats": totals})
+    return {"teams": output}
+
+
+@router.get("/franchise/recruits")
+def recruits():
+    recs = list(db.recruits.find({}, {"_id": 0}).limit(40))
+    return {"recruits": recs}

--- a/FrontEnd/static/franchise-command-center.html
+++ b/FrontEnd/static/franchise-command-center.html
@@ -9,7 +9,95 @@
 </head>
 <body>
   <div id="franchise-container">
-    <h1>Franchise Command Center</h1>
+    <div id="tournament-top">
+      <div id="top-left">
+        <img id="team-logo" src="" alt="Team Logo" class="team-logo">
+        <div class="left-info">
+          <span class="username">Username</span>
+          <span class="seed">Seed: --</span>
+        </div>
+      </div>
+      <div id="top-center">
+        <div class="chemistry-label">Team Chemistry</div>
+        <div class="chemistry-bar">0 / 25</div>
+        <div class="team-stats">
+          <div id="stat-offense">Offense: --</div>
+          <div id="stat-athleticism">Athleticism: --</div>
+          <div id="stat-prestige">Prestige: --</div>
+          <div id="stat-defense">Defense: --</div>
+          <div id="stat-intangibles">Intangibles: --</div>
+          <div id="stat-rank">Nat'l Rank: --</div>
+        </div>
+      </div>
+      <div id="top-right-coach1" class="coach-info">
+        <img id="coach-sammy" src="" alt="Coach" class="coach-img">
+        <div class="coach-bonus">+SH / +SC</div>
+      </div>
+      <div id="top-right-coach2" class="coach-info">
+        <img id="coach-mary" src="" alt="Fans" class="coach-img">
+        <div class="coach-bonus">+ Home Crowd</div>
+      </div>
+      <div style="position:absolute; top:20px; right:20px;">
+        <button id="play-now" style="background:#ff6600;color:#fff;border:none;padding:10px 16px;font-family:'Bebas Neue',cursive;font-size:20px;cursor:pointer;">Play Now</button>
+      </div>
+    </div>
+
+    <div id="tournament-tabs">
+      <div class="tab-buttons">
+        <button data-tab="standings-tab" class="active">Standings</button>
+        <button data-tab="leaders-tab">Leaders</button>
+        <button data-tab="teamstats-tab">Team Stats</button>
+        <button data-tab="recruits-tab">Recruits</button>
+      </div>
+      <div id="standings-tab" class="tab-content active">
+        <div class="scroll-x">
+          <table class="leaders-table">
+            <thead>
+              <tr><th>Rank</th><th>Team</th><th>Record</th></tr>
+            </thead>
+            <tbody id="standings-body"></tbody>
+          </table>
+        </div>
+      </div>
+      <div id="leaders-tab" class="tab-content">
+        <div id="leaders-container"></div>
+      </div>
+      <div id="teamstats-tab" class="tab-content">
+        <div class="scroll-x">
+          <table class="stats-table">
+            <thead>
+              <tr><th>Team</th><th>PTS</th><th>REB</th><th>AST</th><th>STL</th><th>BLK</th></tr>
+            </thead>
+            <tbody id="teamstats-body"></tbody>
+          </table>
+        </div>
+      </div>
+      <div id="recruits-tab" class="tab-content">
+        <div class="scroll-x">
+          <table class="roster-table">
+            <thead>
+              <tr><th>Name</th><th>SC</th><th>SH</th><th>ID</th><th>OD</th><th>PS</th><th>BH</th><th>RB</th><th>AG</th><th>ST</th><th>ND</th><th>IQ</th><th>FT</th></tr>
+            </thead>
+            <tbody id="recruits-body"></tbody>
+          </table>
+        </div>
+      </div>
+    </div>
   </div>
+
+  <script src="./franchise-command-center.js"></script>
+  <script>
+    const tabButtons = document.querySelectorAll('.tab-buttons button');
+    const tabContents = document.querySelectorAll('.tab-content');
+    tabButtons.forEach(btn => {
+      btn.addEventListener('click', () => {
+        tabButtons.forEach(b => b.classList.remove('active'));
+        tabContents.forEach(c => c.classList.remove('active'));
+        btn.classList.add('active');
+        const target = document.getElementById(btn.dataset.tab);
+        if (target) target.classList.add('active');
+      });
+    });
+  </script>
 </body>
 </html>

--- a/FrontEnd/static/franchise-command-center.js
+++ b/FrontEnd/static/franchise-command-center.js
@@ -1,0 +1,103 @@
+async function fetchJSON(url) {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error('Request failed');
+    return await res.json();
+  } catch (err) {
+    console.error('Failed loading', url, err);
+    return null;
+  }
+}
+
+function populateTop(data) {
+  if (!data) return;
+  document.querySelector('.username').textContent = data.username || 'User';
+  document.querySelector('.seed').textContent = `Seed: ${data.seed || '--'}`;
+  document.getElementById('team-logo').src = `images/homepage-logos/${data.team}.png`;
+  document.querySelector('.chemistry-bar').textContent = `${data.team_chemistry || 0} / 25`;
+  document.getElementById('stat-offense').textContent = `Offense: ${data.offense || '--'}`;
+  document.getElementById('stat-defense').textContent = `Defense: ${data.defense || '--'}`;
+  document.getElementById('stat-athleticism').textContent = `Athleticism: ${data.athleticism || '--'}`;
+  document.getElementById('stat-intangibles').textContent = `Intangibles: ${data.intangibles || '--'}`;
+  document.getElementById('stat-prestige').textContent = `Prestige: ${data.prestige || '--'}`;
+  document.getElementById('stat-rank').textContent = `Nat'l Rank: ${data.rank || '--'}`;
+}
+
+function renderStandings(data) {
+  if (!data) return;
+  const tbody = document.getElementById('standings-body');
+  tbody.innerHTML = '';
+  data.standings.forEach((t, i) => {
+    const tr = document.createElement('tr');
+    const rec = t.record || {W:0,L:0};
+    tr.innerHTML = `<td>${i + 1}</td><td>${t.name}</td><td>${rec.W}-${rec.L}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+function renderLeaders(data) {
+  if (!data) return;
+  const container = document.getElementById('leaders-container');
+  container.innerHTML = '';
+  const categories = Object.keys(data);
+  categories.forEach(cat => {
+    const section = document.createElement('div');
+    const h3 = document.createElement('h3');
+    h3.textContent = cat;
+    section.appendChild(h3);
+    const div = document.createElement('div');
+    div.className = 'scroll-x';
+    const table = document.createElement('table');
+    table.className = 'leaders-table';
+    table.innerHTML = '<thead><tr><th>Rank</th><th>Player</th><th>Team</th><th>Value</th></tr></thead>';
+    const body = document.createElement('tbody');
+    (data[cat] || []).forEach((p, idx) => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td>${idx + 1}</td><td>${p.name}</td><td>${p.team}</td><td>${p.value}</td>`;
+      body.appendChild(tr);
+    });
+    table.appendChild(body);
+    div.appendChild(table);
+    section.appendChild(div);
+    container.appendChild(section);
+  });
+}
+
+function renderTeamStats(data) {
+  if (!data) return;
+  const tbody = document.getElementById('teamstats-body');
+  tbody.innerHTML = '';
+  data.teams.forEach(t => {
+    const tr = document.createElement('tr');
+    const s = t.stats || {};
+    tr.innerHTML = `<td>${t.team}</td><td>${s.PTS || 0}</td><td>${s.REB || 0}</td><td>${s.AST || 0}</td><td>${s.STL || 0}</td><td>${s.BLK || 0}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+function renderRecruits(data) {
+  if (!data) return;
+  const tbody = document.getElementById('recruits-body');
+  tbody.innerHTML = '';
+  data.recruits.forEach(r => {
+    const tr = document.createElement('tr');
+    const a = r.attributes || {};
+    tr.innerHTML = `<td>${r.name}</td><td>${a.SC}</td><td>${a.SH}</td><td>${a.ID}</td><td>${a.OD}</td><td>${a.PS}</td><td>${a.BH}</td><td>${a.RB}</td><td>${a.AG}</td><td>${a.ST}</td><td>${a.ND}</td><td>${a.IQ}</td><td>${a.FT}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+async function init() {
+  populateTop(await fetchJSON('/franchise/command-center/data'));
+  renderStandings(await fetchJSON('/franchise/standings'));
+  renderLeaders(await fetchJSON('/franchise/leaders'));
+  renderTeamStats(await fetchJSON('/franchise/team-stats'));
+  renderRecruits(await fetchJSON('/franchise/recruits'));
+}
+
+document.getElementById('play-now').addEventListener('click', async () => {
+  await fetch('/franchise/play-next-game', { method: 'POST' });
+  window.location.href = '/animation';
+});
+
+window.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## Summary
- flesh out Franchise Command Center UI
- add JS to load standings, leaders, stats and recruits
- expand franchise API with data endpoints and play-next-game route
- map `/animation` to court HTML

## Testing
- `pip install -r requirements.txt`
- `pip install mongomock`
- `pip install httpx<0.24 --force-reinstall`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ac0f66fdc83288ff923c3d73cf8df