### PR TITLE
Fix franchise onboarding and dynamic team info

### DIFF
--- a/BackEnd/api/franchise_routes.py
+++ b/BackEnd/api/franchise_routes.py
@@ -12,8 +12,8 @@ STATIC_DIR = Path(__file__).resolve().parents[2] / "FrontEnd" / "static"
 
 @router.get("/franchise/start")
 def franchise_start():
-    state = franchise_state_collection.find_one({"_id": "state"})
-    if state is None:
+    state = franchise_state_collection.find_one({"_id": "state"}) or {}
+    if not state.get("team"):
         return RedirectResponse(url="/franchise/select-team")
     return RedirectResponse(url="/franchise/command-center")
 
@@ -59,8 +59,8 @@ def command_center_data():
     team_doc = db.teams.find_one({"name": team_name}) or {}
     return {
         "team": team_name,
-        "username": "Coach",
-        "seed": 1,
+        "username": state.get("username", "Coach"),
+        "seed": state.get("seed", 1),
         "team_chemistry": team_doc.get("team_chemistry", 0),
         "offense": team_doc.get("offense", "-"),
         "defense": team_doc.get("defense", "-"),

--- a/BackEnd/flask_app.py
+++ b/BackEnd/flask_app.py
@@ -11,8 +11,8 @@ app = Flask(__name__, static_folder=str(STATIC_DIR))
 
 @app.route('/franchise/start')
 def franchise_start():
-    state = franchise_state_collection.find_one({"_id": "state"})
-    if state is None:
+    state = franchise_state_collection.find_one({"_id": "state"}) or {}
+    if not state.get("team"):
         return redirect('/franchise/select-team')
     return redirect('/franchise/command-center')
 

--- a/FrontEnd/static/franchise-command-center.html
+++ b/FrontEnd/static/franchise-command-center.html
@@ -45,6 +45,7 @@
     <div id="tournament-tabs">
       <div class="tab-buttons">
         <button data-tab="standings-tab" class="active">Standings</button>
+        <button data-tab="team-tab">Team</button>
         <button data-tab="leaders-tab">Leaders</button>
         <button data-tab="teamstats-tab">Team Stats</button>
         <button data-tab="recruits-tab">Recruits</button>
@@ -56,6 +57,16 @@
               <tr><th>Rank</th><th>Team</th><th>Record</th></tr>
             </thead>
             <tbody id="standings-body"></tbody>
+          </table>
+        </div>
+      </div>
+      <div id="team-tab" class="tab-content">
+        <div class="scroll-x">
+          <table class="roster-table">
+            <thead>
+              <tr><th>Name</th><th>SC</th><th>SH</th><th>ID</th><th>OD</th><th>PS</th><th>BH</th><th>RB</th><th>AG</th><th>ST</th><th>ND</th><th>IQ</th><th>FT</th></tr>
+            </thead>
+            <tbody id="team-body"></tbody>
           </table>
         </div>
       </div>

--- a/FrontEnd/static/franchise-command-center.js
+++ b/FrontEnd/static/franchise-command-center.js
@@ -14,8 +14,9 @@ function populateTop(data) {
   document.querySelector('.username').textContent = data.username || 'User';
   document.querySelector('.seed').textContent = `Seed: ${data.seed || '--'}`;
   document.getElementById('team-logo').src = `/static/images/homepage-logos/${data.team}.png`;
-  document.getElementById('coach-sammy').src = '/static/images/coach.png';
-  document.getElementById('coach-mary').src = '/static/images/fan.png';
+  const folder = (data.team || '').toLowerCase().replace(/\s+/g, '-');
+  document.getElementById('coach-sammy').src = `/static/images/coaches/${folder}/sammy.png`;
+  document.getElementById('coach-mary').src = `/static/images/coaches/${folder}/mary.png`;
   document.querySelector('.chemistry-bar').textContent = `${data.team_chemistry || 0} / 25`;
   document.getElementById('stat-offense').textContent = `Offense: ${data.offense || '--'}`;
   document.getElementById('stat-defense').textContent = `Defense: ${data.defense || '--'}`;
@@ -89,8 +90,32 @@ function renderRecruits(data) {
   });
 }
 
+function renderTeam(data) {
+  if (!data) return;
+  const tbody = document.getElementById('team-body');
+  if (!tbody) return;
+  tbody.innerHTML = '';
+  const headers = ["SC","SH","ID","OD","PS","BH","RB","AG","ST","ND","IQ","FT","NG"];
+  (data.players || []).forEach(p => {
+    const tr = document.createElement('tr');
+    let html = `<td>${p.name}</td>`;
+    headers.forEach(h => {
+      let val = p.attributes ? p.attributes[h] : null;
+      if (h === 'NG') val = (val ?? 0).toFixed(2);
+      else val = Math.round(val ?? 0);
+      html += `<td>${val}</td>`;
+    });
+    tr.innerHTML = html;
+    tbody.appendChild(tr);
+  });
+}
+
 async function init() {
-  populateTop(await fetchJSON('/franchise/command-center/data'));
+  const topData = await fetchJSON('/franchise/command-center/data');
+  populateTop(topData);
+  if (topData && topData.team) {
+    renderTeam(await fetchJSON(`/roster/${encodeURIComponent(topData.team)}`));
+  }
   renderStandings(await fetchJSON('/franchise/standings'));
   renderLeaders(await fetchJSON('/franchise/leaders'));
   renderTeamStats(await fetchJSON('/franchise/team-stats'));


### PR DESCRIPTION
## Summary
- validate franchise state when entering Franchise mode
- include username and seed in franchise command center data
- update coach image paths and load roster tab
- add missing Team tab to command center UI

## Testing
- `pip install -r requirements.txt`
- `pip install mongomock`
- `pip install 'httpx<0.24' --force-reinstall`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bd09da26483289244aa21e762b53d