### PR TITLE
Add Play Now to tournament UI

### DIFF
--- a/FrontEnd/static/franchise-command-center.html
+++ b/FrontEnd/static/franchise-command-center.html
@@ -29,16 +29,18 @@
           <div id="stat-rank">Nat'l Rank: --</div>
         </div>
       </div>
-      <div id="top-right-coach1" class="coach-info">
-        <img id="coach-sammy" src="" alt="Coach Sammy" class="coach-img">
-        <div class="coach-bonus">+SH / +SC</div>
-      </div>
-      <div id="top-right-coach2" class="coach-info">
-        <img id="coach-mary" src="" alt="Coach Mary" class="coach-img">
-        <div class="coach-bonus">+Home Crowd</div>
-      </div>
-      <div style="position:absolute; top:20px; right:20px;">
-        <button id="play-now" style="background:#ff6600;color:#fff;border:none;padding:10px 16px;font-family:'Bebas Neue',cursive;font-size:20px;cursor:pointer;">Play Now</button>
+      <div id="top-right" class="right-controls">
+        <div id="top-right-coach1" class="coach-info">
+          <img id="coach-sammy" src="" alt="Coach Sammy" class="coach-img">
+          <div class="coach-bonus">+SH / +SC</div>
+        </div>
+        <div id="top-right-coach2" class="coach-info">
+          <img id="coach-mary" src="" alt="Coach Mary" class="coach-img">
+          <div class="coach-bonus">+Home Crowd</div>
+        </div>
+        <div class="play-now-container">
+          <button id="play-now" class="play-now-btn">Play Now</button>
+        </div>
       </div>
     </div>
 

--- a/FrontEnd/static/tournament.css
+++ b/FrontEnd/static/tournament.css
@@ -21,7 +21,7 @@ h1, h2, h3, h4, h5, h6 {
 #tournament-top {
   background: #f5f5f5;
   display: grid;
-  grid-template-columns: 2fr 2fr 1fr 1fr;
+  grid-template-columns: 2fr 2fr 2fr;
   gap: 10px;
   padding: 20px;
   margin-bottom: 20px;
@@ -95,6 +95,23 @@ h1, h2, h3, h4, h5, h6 {
 
 .coach-info {
   text-align: center;
+}
+
+#top-right {
+  display: flex;
+  align-items: center;
+  justify-content: space-evenly;
+  gap: 10px;
+}
+
+.play-now-btn {
+  background: #ff6600;
+  color: #fff;
+  border: none;
+  padding: 10px 16px;
+  font-family: 'Bebas Neue', cursive;
+  font-size: 20px;
+  cursor: pointer;
 }
 
 .coach-info img {

--- a/FrontEnd/static/tournament.html
+++ b/FrontEnd/static/tournament.html
@@ -32,13 +32,18 @@
       </div>
     </div>
 
-      <div id="top-right-coach1" class="coach-info">
-        <img id="coach-sammy" src="" alt="Coach Sammy" class="coach-img">
-        <div class="coach-bonus">+SH / +SC</div>
-      </div>
-      <div id="top-right-coach2" class="coach-info">
-        <img id="coach-mary" src="" alt="Coach Mary" class="coach-img">
-        <div class="coach-bonus">+Home Crowd</div>
+      <div id="top-right" class="right-controls">
+        <div id="top-right-coach1" class="coach-info">
+          <img id="coach-sammy" src="" alt="Coach Sammy" class="coach-img">
+          <div class="coach-bonus">+SH / +SC</div>
+        </div>
+        <div id="top-right-coach2" class="coach-info">
+          <img id="coach-mary" src="" alt="Coach Mary" class="coach-img">
+          <div class="coach-bonus">+Home Crowd</div>
+        </div>
+        <div class="play-now-container">
+          <button id="play-now" class="play-now-btn">Play Now</button>
+        </div>
       </div>
   </div>
 

--- a/FrontEnd/static/tournament.js
+++ b/FrontEnd/static/tournament.js
@@ -294,4 +294,11 @@ document.addEventListener("DOMContentLoaded", async () => {
   renderRoster();
   renderStats();
   renderLeaderboards();
+
+  const playBtn = document.getElementById('play-now');
+  if (playBtn) {
+    playBtn.addEventListener('click', () => {
+      console.log('Play Now clicked (tournament)');
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- add shared right-side layout with Play Now button
- add styling for Play Now button and right-side flexbox
- wire up Play Now in tournament page (console log placeholder)

## Testing
- `pip install -r requirements.txt`
- `pip install mongomock`
- `pip install httpx`
- `PYTHONPATH=. pytest -q` *(fails: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_687bed092a0483288c5f00c1e6e93b83