### PR TITLE
Fix script imports

### DIFF
--- a/scripts/franchise_debug.py
+++ b/scripts/franchise_debug.py
@@ -1,3 +1,17 @@
+"""Debugging utilities for the franchise manager.
+
+This script can be executed directly via ``python scripts/franchise_debug.py``.
+To ensure imports work correctly when run this way we add the project root to
+``sys.path``.
+"""
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 from BackEnd.db import db
 from BackEnd.models.franchise_manager import FranchiseManager
 import pprint


### PR DESCRIPTION
## Summary
- add project root to sys.path when running franchise_debug script

## Testing
- `python -m pytest -q` *(fails: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_687c081a27e08328b3d78e9c58e7812f