### PR TITLE
Implement standings and schedule display

### DIFF
--- a/BackEnd/models/franchise_manager.py
+++ b/BackEnd/models/franchise_manager.py
@@ -23,7 +23,10 @@ class FranchiseManager:
     def reset_stats(self):
         for team in self.teams:
             self.db.players.update_many({"team_id": team["_id"]}, {"$set": {"season_stats": {}}})
-            self.db.teams.update_one({"_id": team["_id"]}, {"$set": {"season_stats": {}, "record": {"W": 0, "L": 0}}})
+            self.db.teams.update_one(
+                {"_id": team["_id"]},
+                {"$set": {"season_stats": {}, "record": {"W": 0, "L": 0}, "PF": 0, "PA": 0}}
+            )
 
     def run_week(self):
         if self.week > 14:
@@ -42,6 +45,14 @@ class FranchiseManager:
 
         self.db.teams.update_one({"_id": winner}, {"$inc": {"record.W": 1}})
         self.db.teams.update_one({"_id": loser}, {"$inc": {"record.L": 1}})
+        self.db.teams.update_one(
+            {"_id": team1_id},
+            {"$inc": {"PF": team1_score, "PA": team2_score}}
+        )
+        self.db.teams.update_one(
+            {"_id": team2_id},
+            {"$inc": {"PF": team2_score, "PA": team1_score}}
+        )
         self.db.games.insert_one({
             "team1_id": team1_id,
             "team2_id": team2_id,

--- a/FrontEnd/static/franchise-command-center.html
+++ b/FrontEnd/static/franchise-command-center.html
@@ -53,14 +53,17 @@
         <button data-tab="recruits-tab">Recruits</button>
       </div>
       <div id="standings-tab" class="tab-content active">
+        <h3>Team Standings</h3>
         <div class="scroll-x">
-          <table class="leaders-table">
+          <table class="leaders-table" id="standings-table">
             <thead>
-              <tr><th>Rank</th><th>Team</th><th>Record</th></tr>
+              <tr><th>Team</th><th>W</th><th>L</th><th>%</th><th>PF</th><th>PA</th><th>Next</th></tr>
             </thead>
             <tbody id="standings-body"></tbody>
           </table>
         </div>
+        <h3>Season Schedule</h3>
+        <div id="schedule-container" class="schedule-container"></div>
       </div>
       <div id="team-tab" class="tab-content">
         <div class="scroll-x">

--- a/FrontEnd/static/tournament.css
+++ b/FrontEnd/static/tournament.css
@@ -367,6 +367,24 @@ table.leaders-table tbody tr:nth-child(odd) {
   background-color: #f9f9f9;
 }
 
+.schedule-container {
+  max-height: 400px;
+  overflow-y: auto;
+  margin-top: 10px;
+}
+
+.schedule-week {
+  margin-bottom: 8px;
+}
+
+.schedule-week h4 {
+  margin: 4px 0;
+}
+
+.schedule-game {
+  padding-left: 10px;
+}
+
 @media (max-width: 768px) {
   :root {
     --matchup-height: 80px;


### PR DESCRIPTION
## Summary
- extend franchise standings endpoint with detailed fields and upcoming matchup
- add franchise schedule endpoint
- track PF/PA in FranchiseManager
- display standings and schedule in franchise command center
- update styles for schedule display

## Testing
- `pip install -r requirements.txt`
- `pip install mongomock`
- `pip install httpx==0.24.1`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c1b993f4883289d8cea0d0088d829