### PR TITLE
Fix franchise initialization

### DIFF
--- a/BackEnd/models/franchise_manager.py
+++ b/BackEnd/models/franchise_manager.py
@@ -15,6 +15,8 @@ class FranchiseManager:
         return list(self.db.teams.find())
 
     def initialize_season(self):
+        # Clear any previous season game data to ensure a fresh start
+        self.db.games.delete_many({})
         self.schedule = self.schedule_manager.generate_schedule()
         self.week = 1
         self.reset_stats()

--- a/tests/test_franchise_manager.py
+++ b/tests/test_franchise_manager.py
@@ -1,0 +1,28 @@
+import pytest
+
+from BackEnd.models.franchise_manager import FranchiseManager
+from BackEnd.db import db
+
+
+def insert_mock_teams():
+    teams = [{"_id": f"T{i}", "name": f"Team{i}"} for i in range(8)]
+    db.teams.insert_many(teams)
+
+
+def test_initialize_season_clears_old_games():
+    # Prepopulate games to mimic previous season results
+    db.games.insert_many([
+        {"team1_id": "T0", "team2_id": "T1", "week": 1, "team1_score": 80, "team2_score": 70},
+        {"team1_id": "T2", "team2_id": "T3", "week": 1, "team1_score": 90, "team2_score": 60},
+    ])
+    assert db.games.count_documents({}) == 2
+
+    insert_mock_teams()
+    manager = FranchiseManager(db)
+    manager.initialize_season()
+
+    # All previous game docs should be removed
+    assert db.games.count_documents({}) == 0
+    # Schedule should contain 14 weeks of 4 games each
+    assert len(manager.schedule) == 14
+    assert all(len(week) == 4 for week in manager.schedule)


### PR DESCRIPTION
## Summary
- clear stale game docs when starting a new franchise season
- test that season initialization removes old games

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c22139b4883289efe792081f0105b