### PR TITLE
Wire Play Now button to court animation

### DIFF
--- a/FrontEnd/static/franchise-command-center.js
+++ b/FrontEnd/static/franchise-command-center.js
@@ -178,9 +178,23 @@ async function init() {
   renderRecruits(await fetchJSON('/franchise/recruits'));
 }
 
-document.getElementById('play-now').addEventListener('click', async () => {
-  await fetch('/franchise/play-next-game', { method: 'POST' });
-  window.location.href = '/animation';
+const playNowBtn = document.getElementById('play-now');
+playNowBtn.addEventListener('click', async () => {
+  const originalText = playNowBtn.textContent;
+  playNowBtn.disabled = true;
+  playNowBtn.textContent = 'Loading...';
+  try {
+    const res = await fetch('/franchise/play-next-game', { method: 'POST' });
+    if (!res.ok) throw new Error('Simulation failed');
+    const { home, away } = await res.json();
+    if (!home || !away) throw new Error('Matchup not found');
+    window.location.href = `/court.html?home=${encodeURIComponent(home)}&away=${encodeURIComponent(away)}`;
+  } catch (err) {
+    console.error(err);
+    alert('Unable to play next game');
+    playNowBtn.disabled = false;
+    playNowBtn.textContent = originalText;
+  }
 });
 
 window.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## Summary
- find user's matchup when playing next game
- return matchup from `/franchise/play-next-game`
- redirect Play Now to `/court.html` with teams
- disable button while simulating

## Testing
- `pip install -r requirements.txt`
- `pip install mongomock`
- `pip install 'httpx<0.25' --force-reinstall`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c284fe91c83288c21715d58b093c3