### PR TITLE
Fix static court.html route

### DIFF
--- a/BackEnd/api/franchise_routes.py
+++ b/BackEnd/api/franchise_routes.py
@@ -10,6 +10,11 @@ router = APIRouter()
 
 STATIC_DIR = Path(__file__).resolve().parents[2] / "FrontEnd" / "static"
 
+@router.get("/court.html")
+def serve_court_html():
+    """Return the court page so query params work in production."""
+    return FileResponse(STATIC_DIR / "court.html")
+
 # @router.get("/franchise/start")
 # def franchise_start():
 #     state = franchise_state_collection.find_one({"_id": "state"}) or {}


### PR DESCRIPTION
## Summary
- expose `/court.html` via FastAPI to allow query parameters

## Testing
- `pip install -r requirements.txt`
- `pip install mongomock`
- `pip install httpx==0.24.* --force-reinstall`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c2c830dbc8328a54dd0bc54935e03