### PR TITLE
Fix Duke coach image path in command centers

### DIFF
--- a/FrontEnd/static/franchise-command-center.js
+++ b/FrontEnd/static/franchise-command-center.js
@@ -30,13 +30,13 @@ function populateTop(data) {
 
   const abbr = teamMap[data.team];
   const sammyEl = document.getElementById('coach-sammy');
-  const maryEl = document.getElementById('coach-duke');
+  const dukeEl = document.getElementById('coach-duke');
   if (abbr) {
     if (sammyEl) sammyEl.src = `/static/images/coaches/${abbr}/Sammy-${abbr}.png`;
-    if (maryEl) maryEl.src = `/static/images/coaches/${abbr}/Duke-${abbr}.png`;
+    if (dukeEl) dukeEl.src = `/static/images/coaches/${abbr}/Duke-${abbr}.png`;
   } else {
     if (sammyEl) sammyEl.removeAttribute('src');
-    if (maryEl) maryEl.removeAttribute('src');
+    if (dukeEl) dukeEl.removeAttribute('src');
   }
 
   document.querySelector('.chemistry-bar').textContent = `${data.team_chemistry || 0} / 25`;

--- a/FrontEnd/static/tournament.js
+++ b/FrontEnd/static/tournament.js
@@ -252,10 +252,10 @@ function initTopAssets() {
     logoEl.src = `images/homepage-logos/${formattedTeamName}.png`;
   }
   const abbr = teamAbbreviations[userTeamId] || "";
-  const sammy = document.getElementById("coach-sammy");
-  const duke = document.getElementById("coach-duke");
-  if (sammy) sammy.src = `images/coaches/${abbr}/Sammy-${abbr}.png`;
-  if (duke) duke.src = `images/coaches/${abbr}/Duke-${abbr}.png`;
+  const sammyEl = document.getElementById("coach-sammy");
+  const dukeEl = document.getElementById("coach-duke");
+  if (sammyEl) sammyEl.src = `/static/images/coaches/${abbr}/Sammy-${abbr}.png`;
+  if (dukeEl) dukeEl.src = `/static/images/coaches/${abbr}/Duke-${abbr}.png`;
 }
 
 async function loadTournament() {


### PR DESCRIPTION
## Summary
- update coach image lookup in Franchise and Tournament command centers
- use `/static/images` path and rename variables for Duke coach

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68864b03f6b88328be9a01707b25ddc7