### PR TITLE
Fix Duke coach image on tournament page

### DIFF
--- a/FrontEnd/static/tournament.js
+++ b/FrontEnd/static/tournament.js
@@ -1,5 +1,5 @@
 let tournament = JSON.parse(localStorage.getItem("activeTournament")) || null;
-const userTeamId = (localStorage.getItem("userTeamId") || "").toUpperCase();
+let userTeamId = (localStorage.getItem("userTeamId") || "").toUpperCase();
 
 const teamAbbreviations = {
   "BENTLEY-TRUMAN": "BT",
@@ -245,13 +245,14 @@ function renderLeaderboards() {
   });
 }
 
-function initTopAssets() {
-  const formattedTeamName = formatTeamName(userTeamId);
+function initTopAssets(teamName) {
+  const teamKey = (teamName || userTeamId || "").toUpperCase();
+  const formattedTeamName = formatTeamName(teamKey);
   const logoEl = document.getElementById("user-team-logo");
   if (logoEl) {
     logoEl.src = `images/homepage-logos/${formattedTeamName}.png`;
   }
-  const abbr = teamAbbreviations[userTeamId] || "";
+  const abbr = teamAbbreviations[teamKey] || "";
   const sammyEl = document.getElementById("coach-sammy");
   const dukeEl = document.getElementById("coach-duke");
   if (sammyEl) sammyEl.src = `/static/images/coaches/${abbr}/Sammy-${abbr}.png`;
@@ -287,8 +288,12 @@ async function loadRoster() {
 }
 
 document.addEventListener("DOMContentLoaded", async () => {
-  initTopAssets();
   await loadTournament();
+  if (!userTeamId && tournament && tournament.user_team_id) {
+    userTeamId = tournament.user_team_id.toUpperCase();
+    localStorage.setItem("userTeamId", tournament.user_team_id);
+  }
+  initTopAssets(userTeamId);
   await loadRoster();
   renderBracket();
   renderRoster();


### PR DESCRIPTION
## Summary
- ensure tournament page loads user team info before setting image paths
- fall back to tournament data if localStorage is empty

## Testing
- `pip install -q fastapi uvicorn pydantic requests pymongo==4.6.1 'pymongo[srv]==4.6.1' Unidecode python-dotenv mongomock httpx`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68864e91fb2c8328a49880158a9bdc48