### PR TITLE
Add Scout The Teams functionality

### DIFF
--- a/FrontEnd/static/mode-select.css
+++ b/FrontEnd/static/mode-select.css
@@ -49,3 +49,36 @@ body {
   cursor: default;
   pointer-events: none;
 }
+
+#scout-title {
+  font-family: 'Bebas Neue', cursive;
+  font-size: 32px;
+  text-align: center;
+  margin: 40px 0 10px;
+}
+
+#team-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 15px;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.team-button {
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.team-button img {
+  width: 100%;
+  height: auto;
+  object-fit: contain;
+}
+
+@media (max-width: 600px) {
+  #team-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}

--- a/FrontEnd/static/mode-select.html
+++ b/FrontEnd/static/mode-select.html
@@ -23,6 +23,33 @@
       <button id="franchise-btn" class="play-button">PLAY NOW</button>
     </div>
   </div>
+  <h2 id="scout-title">SCOUT THE TEAMS</h2>
+  <div id="team-grid">
+    <button class="team-button" data-team="Bentley-Truman">
+      <img src="/static/images/homepage-logos/Bentley-Truman.png" alt="Bentley-Truman logo">
+    </button>
+    <button class="team-button" data-team="Lancaster">
+      <img src="/static/images/homepage-logos/Lancaster.png" alt="Lancaster logo">
+    </button>
+    <button class="team-button" data-team="Four Corners">
+      <img src="/static/images/homepage-logos/Four Corners.png" alt="Four Corners logo">
+    </button>
+    <button class="team-button" data-team="Ocean City">
+      <img src="/static/images/homepage-logos/Ocean City.png" alt="Ocean City logo">
+    </button>
+    <button class="team-button" data-team="Morristown">
+      <img src="/static/images/homepage-logos/Morristown.png" alt="Morristown logo">
+    </button>
+    <button class="team-button" data-team="Little York">
+      <img src="/static/images/homepage-logos/Little York.png" alt="Little York logo">
+    </button>
+    <button class="team-button" data-team="Xavien">
+      <img src="/static/images/homepage-logos/Xavien.png" alt="Xavien logo">
+    </button>
+    <button class="team-button" data-team="South Lancaster">
+      <img src="/static/images/homepage-logos/South Lancaster.png" alt="South Lancaster logo">
+    </button>
+  </div>
   <script src="./mode-select.js"></script>
 </body>
 </html>

--- a/FrontEnd/static/mode-select.js
+++ b/FrontEnd/static/mode-select.js
@@ -21,5 +21,13 @@ if (franchiseBtn) {
   franchiseBtn.addEventListener('click', () => {
     window.location.href = '/franchise/start';
   });
-  
+
 }
+
+const teamButtons = document.querySelectorAll('.team-button');
+teamButtons.forEach(btn => {
+  btn.addEventListener('click', () => {
+    const team = btn.dataset.team;
+    window.location.href = `/team-roster/${encodeURIComponent(team)}`;
+  });
+});

--- a/FrontEnd/static/team-roster/Bentley-Truman.html
+++ b/FrontEnd/static/team-roster/Bentley-Truman.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bentley-Truman Roster</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
+    #back { position:absolute; top:10px; left:10px; }
+    #back a { text-decoration:none; color:#ff9800; font-weight:bold; }
+    h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
+  </style>
+</head>
+<body>
+  <div id="back"><a href="/mode-select">Back</a></div>
+  <h1>In Development</h1>
+</body>
+</html>

--- a/FrontEnd/static/team-roster/Four Corners.html
+++ b/FrontEnd/static/team-roster/Four Corners.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Four Corners Roster</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
+    #back { position:absolute; top:10px; left:10px; }
+    #back a { text-decoration:none; color:#ff9800; font-weight:bold; }
+    h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
+  </style>
+</head>
+<body>
+  <div id="back"><a href="/mode-select">Back</a></div>
+  <h1>In Development</h1>
+</body>
+</html>

--- a/FrontEnd/static/team-roster/Lancaster.html
+++ b/FrontEnd/static/team-roster/Lancaster.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Lancaster Roster</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
+    #back { position:absolute; top:10px; left:10px; }
+    #back a { text-decoration:none; color:#ff9800; font-weight:bold; }
+    h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
+  </style>
+</head>
+<body>
+  <div id="back"><a href="/mode-select">Back</a></div>
+  <h1>In Development</h1>
+</body>
+</html>

--- a/FrontEnd/static/team-roster/Little York.html
+++ b/FrontEnd/static/team-roster/Little York.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Little York Roster</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
+    #back { position:absolute; top:10px; left:10px; }
+    #back a { text-decoration:none; color:#ff9800; font-weight:bold; }
+    h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
+  </style>
+</head>
+<body>
+  <div id="back"><a href="/mode-select">Back</a></div>
+  <h1>In Development</h1>
+</body>
+</html>

--- a/FrontEnd/static/team-roster/Morristown.html
+++ b/FrontEnd/static/team-roster/Morristown.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Morristown Roster</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
+    #back { position:absolute; top:10px; left:10px; }
+    #back a { text-decoration:none; color:#ff9800; font-weight:bold; }
+    h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
+  </style>
+</head>
+<body>
+  <div id="back"><a href="/mode-select">Back</a></div>
+  <h1>In Development</h1>
+</body>
+</html>

--- a/FrontEnd/static/team-roster/Ocean City.html
+++ b/FrontEnd/static/team-roster/Ocean City.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ocean City Roster</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
+    #back { position:absolute; top:10px; left:10px; }
+    #back a { text-decoration:none; color:#ff9800; font-weight:bold; }
+    h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
+  </style>
+</head>
+<body>
+  <div id="back"><a href="/mode-select">Back</a></div>
+  <h1>In Development</h1>
+</body>
+</html>

--- a/FrontEnd/static/team-roster/South Lancaster.html
+++ b/FrontEnd/static/team-roster/South Lancaster.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>South Lancaster Roster</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
+    #back { position:absolute; top:10px; left:10px; }
+    #back a { text-decoration:none; color:#ff9800; font-weight:bold; }
+    h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
+  </style>
+</head>
+<body>
+  <div id="back"><a href="/mode-select">Back</a></div>
+  <h1>In Development</h1>
+</body>
+</html>

--- a/FrontEnd/static/team-roster/Xavien.html
+++ b/FrontEnd/static/team-roster/Xavien.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Xavien Roster</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
+    #back { position:absolute; top:10px; left:10px; }
+    #back a { text-decoration:none; color:#ff9800; font-weight:bold; }
+    h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
+  </style>
+</head>
+<body>
+  <div id="back"><a href="/mode-select">Back</a></div>
+  <h1>In Development</h1>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Scout The Teams section to `mode-select.html`
- style new section in `mode-select.css`
- hook up team buttons in `mode-select.js`
- create placeholder roster pages for each team

## Testing
- `pip install -r requirements.txt`
- `pip install mongomock httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888fa40ca408328b55d4274f1fe8e0f