### PR TITLE
Fix scout header and roster links

### DIFF
--- a/FrontEnd/static/mode-select.css
+++ b/FrontEnd/static/mode-select.css
@@ -52,7 +52,7 @@ body {
 
 #scout-title {
   font-family: 'Bebas Neue', cursive;
-  font-size: 32px;
+  font-size: 36px;
   text-align: center;
   margin: 40px 0 10px;
 }

--- a/FrontEnd/static/team-roster/Bentley-Truman.html
+++ b/FrontEnd/static/team-roster/Bentley-Truman.html
@@ -8,7 +8,7 @@
   <style>
     body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
     #back { position:absolute; top:10px; left:10px; }
-    #back a { text-decoration:none; color:#ff9800; font-weight:bold; }
+    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
     h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
   </style>
 </head>

--- a/FrontEnd/static/team-roster/Four Corners.html
+++ b/FrontEnd/static/team-roster/Four Corners.html
@@ -8,7 +8,7 @@
   <style>
     body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
     #back { position:absolute; top:10px; left:10px; }
-    #back a { text-decoration:none; color:#ff9800; font-weight:bold; }
+    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
     h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
   </style>
 </head>

--- a/FrontEnd/static/team-roster/Lancaster.html
+++ b/FrontEnd/static/team-roster/Lancaster.html
@@ -8,7 +8,7 @@
   <style>
     body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
     #back { position:absolute; top:10px; left:10px; }
-    #back a { text-decoration:none; color:#ff9800; font-weight:bold; }
+    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
     h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
   </style>
 </head>

--- a/FrontEnd/static/team-roster/Little York.html
+++ b/FrontEnd/static/team-roster/Little York.html
@@ -8,7 +8,7 @@
   <style>
     body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
     #back { position:absolute; top:10px; left:10px; }
-    #back a { text-decoration:none; color:#ff9800; font-weight:bold; }
+    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
     h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
   </style>
 </head>

--- a/FrontEnd/static/team-roster/Morristown.html
+++ b/FrontEnd/static/team-roster/Morristown.html
@@ -8,7 +8,7 @@
   <style>
     body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
     #back { position:absolute; top:10px; left:10px; }
-    #back a { text-decoration:none; color:#ff9800; font-weight:bold; }
+    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
     h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
   </style>
 </head>

--- a/FrontEnd/static/team-roster/Ocean City.html
+++ b/FrontEnd/static/team-roster/Ocean City.html
@@ -8,7 +8,7 @@
   <style>
     body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
     #back { position:absolute; top:10px; left:10px; }
-    #back a { text-decoration:none; color:#ff9800; font-weight:bold; }
+    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
     h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
   </style>
 </head>

--- a/FrontEnd/static/team-roster/South Lancaster.html
+++ b/FrontEnd/static/team-roster/South Lancaster.html
@@ -8,7 +8,7 @@
   <style>
     body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
     #back { position:absolute; top:10px; left:10px; }
-    #back a { text-decoration:none; color:#ff9800; font-weight:bold; }
+    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
     h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
   </style>
 </head>

--- a/FrontEnd/static/team-roster/Xavien.html
+++ b/FrontEnd/static/team-roster/Xavien.html
@@ -8,7 +8,7 @@
   <style>
     body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
     #back { position:absolute; top:10px; left:10px; }
-    #back a { text-decoration:none; color:#ff9800; font-weight:bold; }
+    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
     h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- tweak `SCOUT THE TEAMS` styling on mode select page
- style Back buttons on team roster pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888fe7ba73083289dcbf567e02e971d