### PR TITLE
Add team roster placeholder pages

### DIFF
--- a/FrontEnd/static/team-roster/team-roster-Bentley-Truman.html
+++ b/FrontEnd/static/team-roster/team-roster-Bentley-Truman.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bentley-Truman Team Roster</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/static/tournament.css">
+  <style>
+    body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
+    #back { position:absolute; top:10px; left:10px; }
+    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
+    h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
+  </style>
+</head>
+<body>
+  <div id="back"><a href="/mode-select">Back</a></div>
+  <h1>Bentley-Truman Roster</h1>
+  <div class="scroll-x">
+    <table class="roster-table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Year</th>
+          <th>Height</th>
+          <th>Weight</th>
+          <th>SC</th>
+          <th>SH</th>
+          <th>ID</th>
+          <th>OD</th>
+          <th>PS</th>
+          <th>BH</th>
+          <th>RB</th>
+          <th>AG</th>
+          <th>ST</th>
+          <th>ND</th>
+          <th>IQ</th>
+          <th>FT</th>
+          <th>NG</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td>Player1</td><td>Junior</td><td>6'2"</td><td>180</td><td>75</td><td>80</td><td>70</td><td>65</td><td>72</td><td>74</td><td>68</td><td>76</td><td>71</td><td>69</td><td>77</td><td>85</td><td>1</td></tr>
+        <tr><td>Player2</td><td>Senior</td><td>6'4"</td><td>190</td><td>78</td><td>77</td><td>73</td><td>68</td><td>70</td><td>72</td><td>70</td><td>74</td><td>72</td><td>70</td><td>75</td><td>82</td><td>2</td></tr>
+        <tr><td>Player3</td><td>Sophomore</td><td>6'1"</td><td>175</td><td>72</td><td>74</td><td>68</td><td>67</td><td>71</td><td>73</td><td>65</td><td>75</td><td>69</td><td>68</td><td>74</td><td>80</td><td>3</td></tr>
+        <tr><td>Player4</td><td>Freshman</td><td>6'3"</td><td>185</td><td>70</td><td>72</td><td>69</td><td>66</td><td>68</td><td>70</td><td>72</td><td>73</td><td>70</td><td>67</td><td>72</td><td>78</td><td>4</td></tr>
+        <tr><td>Player5</td><td>Junior</td><td>6'5"</td><td>200</td><td>76</td><td>79</td><td>71</td><td>69</td><td>73</td><td>75</td><td>74</td><td>78</td><td>73</td><td>71</td><td>78</td><td>83</td><td>5</td></tr>
+      </tbody>
+    </table>
+  </div>
+</body>
+</html>

--- a/FrontEnd/static/team-roster/team-roster-Four-Corners.html
+++ b/FrontEnd/static/team-roster/team-roster-Four-Corners.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Four Corners Team Roster</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/static/tournament.css">
+  <style>
+    body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
+    #back { position:absolute; top:10px; left:10px; }
+    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
+    h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
+  </style>
+</head>
+<body>
+  <div id="back"><a href="/mode-select">Back</a></div>
+  <h1>Four Corners Roster</h1>
+  <div class="scroll-x">
+    <table class="roster-table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Year</th>
+          <th>Height</th>
+          <th>Weight</th>
+          <th>SC</th>
+          <th>SH</th>
+          <th>ID</th>
+          <th>OD</th>
+          <th>PS</th>
+          <th>BH</th>
+          <th>RB</th>
+          <th>AG</th>
+          <th>ST</th>
+          <th>ND</th>
+          <th>IQ</th>
+          <th>FT</th>
+          <th>NG</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td>Player1</td><td>Junior</td><td>6'2"</td><td>180</td><td>75</td><td>80</td><td>70</td><td>65</td><td>72</td><td>74</td><td>68</td><td>76</td><td>71</td><td>69</td><td>77</td><td>85</td><td>1</td></tr>
+        <tr><td>Player2</td><td>Senior</td><td>6'4"</td><td>190</td><td>78</td><td>77</td><td>73</td><td>68</td><td>70</td><td>72</td><td>70</td><td>74</td><td>72</td><td>70</td><td>75</td><td>82</td><td>2</td></tr>
+        <tr><td>Player3</td><td>Sophomore</td><td>6'1"</td><td>175</td><td>72</td><td>74</td><td>68</td><td>67</td><td>71</td><td>73</td><td>65</td><td>75</td><td>69</td><td>68</td><td>74</td><td>80</td><td>3</td></tr>
+        <tr><td>Player4</td><td>Freshman</td><td>6'3"</td><td>185</td><td>70</td><td>72</td><td>69</td><td>66</td><td>68</td><td>70</td><td>72</td><td>73</td><td>70</td><td>67</td><td>72</td><td>78</td><td>4</td></tr>
+        <tr><td>Player5</td><td>Junior</td><td>6'5"</td><td>200</td><td>76</td><td>79</td><td>71</td><td>69</td><td>73</td><td>75</td><td>74</td><td>78</td><td>73</td><td>71</td><td>78</td><td>83</td><td>5</td></tr>
+      </tbody>
+    </table>
+  </div>
+</body>
+</html>

--- a/FrontEnd/static/team-roster/team-roster-Lancaster.html
+++ b/FrontEnd/static/team-roster/team-roster-Lancaster.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Lancaster Team Roster</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/static/tournament.css">
+  <style>
+    body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
+    #back { position:absolute; top:10px; left:10px; }
+    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
+    h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
+  </style>
+</head>
+<body>
+  <div id="back"><a href="/mode-select">Back</a></div>
+  <h1>Lancaster Roster</h1>
+  <div class="scroll-x">
+    <table class="roster-table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Year</th>
+          <th>Height</th>
+          <th>Weight</th>
+          <th>SC</th>
+          <th>SH</th>
+          <th>ID</th>
+          <th>OD</th>
+          <th>PS</th>
+          <th>BH</th>
+          <th>RB</th>
+          <th>AG</th>
+          <th>ST</th>
+          <th>ND</th>
+          <th>IQ</th>
+          <th>FT</th>
+          <th>NG</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td>Player1</td><td>Junior</td><td>6'2"</td><td>180</td><td>75</td><td>80</td><td>70</td><td>65</td><td>72</td><td>74</td><td>68</td><td>76</td><td>71</td><td>69</td><td>77</td><td>85</td><td>1</td></tr>
+        <tr><td>Player2</td><td>Senior</td><td>6'4"</td><td>190</td><td>78</td><td>77</td><td>73</td><td>68</td><td>70</td><td>72</td><td>70</td><td>74</td><td>72</td><td>70</td><td>75</td><td>82</td><td>2</td></tr>
+        <tr><td>Player3</td><td>Sophomore</td><td>6'1"</td><td>175</td><td>72</td><td>74</td><td>68</td><td>67</td><td>71</td><td>73</td><td>65</td><td>75</td><td>69</td><td>68</td><td>74</td><td>80</td><td>3</td></tr>
+        <tr><td>Player4</td><td>Freshman</td><td>6'3"</td><td>185</td><td>70</td><td>72</td><td>69</td><td>66</td><td>68</td><td>70</td><td>72</td><td>73</td><td>70</td><td>67</td><td>72</td><td>78</td><td>4</td></tr>
+        <tr><td>Player5</td><td>Junior</td><td>6'5"</td><td>200</td><td>76</td><td>79</td><td>71</td><td>69</td><td>73</td><td>75</td><td>74</td><td>78</td><td>73</td><td>71</td><td>78</td><td>83</td><td>5</td></tr>
+      </tbody>
+    </table>
+  </div>
+</body>
+</html>

--- a/FrontEnd/static/team-roster/team-roster-Little-York.html
+++ b/FrontEnd/static/team-roster/team-roster-Little-York.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Little York Team Roster</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/static/tournament.css">
+  <style>
+    body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
+    #back { position:absolute; top:10px; left:10px; }
+    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
+    h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
+  </style>
+</head>
+<body>
+  <div id="back"><a href="/mode-select">Back</a></div>
+  <h1>Little York Roster</h1>
+  <div class="scroll-x">
+    <table class="roster-table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Year</th>
+          <th>Height</th>
+          <th>Weight</th>
+          <th>SC</th>
+          <th>SH</th>
+          <th>ID</th>
+          <th>OD</th>
+          <th>PS</th>
+          <th>BH</th>
+          <th>RB</th>
+          <th>AG</th>
+          <th>ST</th>
+          <th>ND</th>
+          <th>IQ</th>
+          <th>FT</th>
+          <th>NG</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td>Player1</td><td>Junior</td><td>6'2"</td><td>180</td><td>75</td><td>80</td><td>70</td><td>65</td><td>72</td><td>74</td><td>68</td><td>76</td><td>71</td><td>69</td><td>77</td><td>85</td><td>1</td></tr>
+        <tr><td>Player2</td><td>Senior</td><td>6'4"</td><td>190</td><td>78</td><td>77</td><td>73</td><td>68</td><td>70</td><td>72</td><td>70</td><td>74</td><td>72</td><td>70</td><td>75</td><td>82</td><td>2</td></tr>
+        <tr><td>Player3</td><td>Sophomore</td><td>6'1"</td><td>175</td><td>72</td><td>74</td><td>68</td><td>67</td><td>71</td><td>73</td><td>65</td><td>75</td><td>69</td><td>68</td><td>74</td><td>80</td><td>3</td></tr>
+        <tr><td>Player4</td><td>Freshman</td><td>6'3"</td><td>185</td><td>70</td><td>72</td><td>69</td><td>66</td><td>68</td><td>70</td><td>72</td><td>73</td><td>70</td><td>67</td><td>72</td><td>78</td><td>4</td></tr>
+        <tr><td>Player5</td><td>Junior</td><td>6'5"</td><td>200</td><td>76</td><td>79</td><td>71</td><td>69</td><td>73</td><td>75</td><td>74</td><td>78</td><td>73</td><td>71</td><td>78</td><td>83</td><td>5</td></tr>
+      </tbody>
+    </table>
+  </div>
+</body>
+</html>

--- a/FrontEnd/static/team-roster/team-roster-Morristown.html
+++ b/FrontEnd/static/team-roster/team-roster-Morristown.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Morristown Team Roster</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/static/tournament.css">
+  <style>
+    body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
+    #back { position:absolute; top:10px; left:10px; }
+    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
+    h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
+  </style>
+</head>
+<body>
+  <div id="back"><a href="/mode-select">Back</a></div>
+  <h1>Morristown Roster</h1>
+  <div class="scroll-x">
+    <table class="roster-table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Year</th>
+          <th>Height</th>
+          <th>Weight</th>
+          <th>SC</th>
+          <th>SH</th>
+          <th>ID</th>
+          <th>OD</th>
+          <th>PS</th>
+          <th>BH</th>
+          <th>RB</th>
+          <th>AG</th>
+          <th>ST</th>
+          <th>ND</th>
+          <th>IQ</th>
+          <th>FT</th>
+          <th>NG</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td>Player1</td><td>Junior</td><td>6'2"</td><td>180</td><td>75</td><td>80</td><td>70</td><td>65</td><td>72</td><td>74</td><td>68</td><td>76</td><td>71</td><td>69</td><td>77</td><td>85</td><td>1</td></tr>
+        <tr><td>Player2</td><td>Senior</td><td>6'4"</td><td>190</td><td>78</td><td>77</td><td>73</td><td>68</td><td>70</td><td>72</td><td>70</td><td>74</td><td>72</td><td>70</td><td>75</td><td>82</td><td>2</td></tr>
+        <tr><td>Player3</td><td>Sophomore</td><td>6'1"</td><td>175</td><td>72</td><td>74</td><td>68</td><td>67</td><td>71</td><td>73</td><td>65</td><td>75</td><td>69</td><td>68</td><td>74</td><td>80</td><td>3</td></tr>
+        <tr><td>Player4</td><td>Freshman</td><td>6'3"</td><td>185</td><td>70</td><td>72</td><td>69</td><td>66</td><td>68</td><td>70</td><td>72</td><td>73</td><td>70</td><td>67</td><td>72</td><td>78</td><td>4</td></tr>
+        <tr><td>Player5</td><td>Junior</td><td>6'5"</td><td>200</td><td>76</td><td>79</td><td>71</td><td>69</td><td>73</td><td>75</td><td>74</td><td>78</td><td>73</td><td>71</td><td>78</td><td>83</td><td>5</td></tr>
+      </tbody>
+    </table>
+  </div>
+</body>
+</html>

--- a/FrontEnd/static/team-roster/team-roster-Ocean-City.html
+++ b/FrontEnd/static/team-roster/team-roster-Ocean-City.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ocean City Team Roster</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/static/tournament.css">
+  <style>
+    body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
+    #back { position:absolute; top:10px; left:10px; }
+    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
+    h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
+  </style>
+</head>
+<body>
+  <div id="back"><a href="/mode-select">Back</a></div>
+  <h1>Ocean City Roster</h1>
+  <div class="scroll-x">
+    <table class="roster-table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Year</th>
+          <th>Height</th>
+          <th>Weight</th>
+          <th>SC</th>
+          <th>SH</th>
+          <th>ID</th>
+          <th>OD</th>
+          <th>PS</th>
+          <th>BH</th>
+          <th>RB</th>
+          <th>AG</th>
+          <th>ST</th>
+          <th>ND</th>
+          <th>IQ</th>
+          <th>FT</th>
+          <th>NG</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td>Player1</td><td>Junior</td><td>6'2"</td><td>180</td><td>75</td><td>80</td><td>70</td><td>65</td><td>72</td><td>74</td><td>68</td><td>76</td><td>71</td><td>69</td><td>77</td><td>85</td><td>1</td></tr>
+        <tr><td>Player2</td><td>Senior</td><td>6'4"</td><td>190</td><td>78</td><td>77</td><td>73</td><td>68</td><td>70</td><td>72</td><td>70</td><td>74</td><td>72</td><td>70</td><td>75</td><td>82</td><td>2</td></tr>
+        <tr><td>Player3</td><td>Sophomore</td><td>6'1"</td><td>175</td><td>72</td><td>74</td><td>68</td><td>67</td><td>71</td><td>73</td><td>65</td><td>75</td><td>69</td><td>68</td><td>74</td><td>80</td><td>3</td></tr>
+        <tr><td>Player4</td><td>Freshman</td><td>6'3"</td><td>185</td><td>70</td><td>72</td><td>69</td><td>66</td><td>68</td><td>70</td><td>72</td><td>73</td><td>70</td><td>67</td><td>72</td><td>78</td><td>4</td></tr>
+        <tr><td>Player5</td><td>Junior</td><td>6'5"</td><td>200</td><td>76</td><td>79</td><td>71</td><td>69</td><td>73</td><td>75</td><td>74</td><td>78</td><td>73</td><td>71</td><td>78</td><td>83</td><td>5</td></tr>
+      </tbody>
+    </table>
+  </div>
+</body>
+</html>

--- a/FrontEnd/static/team-roster/team-roster-South-Lancaster.html
+++ b/FrontEnd/static/team-roster/team-roster-South-Lancaster.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>South Lancaster Team Roster</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/static/tournament.css">
+  <style>
+    body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
+    #back { position:absolute; top:10px; left:10px; }
+    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
+    h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
+  </style>
+</head>
+<body>
+  <div id="back"><a href="/mode-select">Back</a></div>
+  <h1>South Lancaster Roster</h1>
+  <div class="scroll-x">
+    <table class="roster-table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Year</th>
+          <th>Height</th>
+          <th>Weight</th>
+          <th>SC</th>
+          <th>SH</th>
+          <th>ID</th>
+          <th>OD</th>
+          <th>PS</th>
+          <th>BH</th>
+          <th>RB</th>
+          <th>AG</th>
+          <th>ST</th>
+          <th>ND</th>
+          <th>IQ</th>
+          <th>FT</th>
+          <th>NG</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td>Player1</td><td>Junior</td><td>6'2"</td><td>180</td><td>75</td><td>80</td><td>70</td><td>65</td><td>72</td><td>74</td><td>68</td><td>76</td><td>71</td><td>69</td><td>77</td><td>85</td><td>1</td></tr>
+        <tr><td>Player2</td><td>Senior</td><td>6'4"</td><td>190</td><td>78</td><td>77</td><td>73</td><td>68</td><td>70</td><td>72</td><td>70</td><td>74</td><td>72</td><td>70</td><td>75</td><td>82</td><td>2</td></tr>
+        <tr><td>Player3</td><td>Sophomore</td><td>6'1"</td><td>175</td><td>72</td><td>74</td><td>68</td><td>67</td><td>71</td><td>73</td><td>65</td><td>75</td><td>69</td><td>68</td><td>74</td><td>80</td><td>3</td></tr>
+        <tr><td>Player4</td><td>Freshman</td><td>6'3"</td><td>185</td><td>70</td><td>72</td><td>69</td><td>66</td><td>68</td><td>70</td><td>72</td><td>73</td><td>70</td><td>67</td><td>72</td><td>78</td><td>4</td></tr>
+        <tr><td>Player5</td><td>Junior</td><td>6'5"</td><td>200</td><td>76</td><td>79</td><td>71</td><td>69</td><td>73</td><td>75</td><td>74</td><td>78</td><td>73</td><td>71</td><td>78</td><td>83</td><td>5</td></tr>
+      </tbody>
+    </table>
+  </div>
+</body>
+</html>

--- a/FrontEnd/static/team-roster/team-roster-Xavien.html
+++ b/FrontEnd/static/team-roster/team-roster-Xavien.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Xavien Team Roster</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/static/tournament.css">
+  <style>
+    body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
+    #back { position:absolute; top:10px; left:10px; }
+    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
+    h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
+  </style>
+</head>
+<body>
+  <div id="back"><a href="/mode-select">Back</a></div>
+  <h1>Xavien Roster</h1>
+  <div class="scroll-x">
+    <table class="roster-table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Year</th>
+          <th>Height</th>
+          <th>Weight</th>
+          <th>SC</th>
+          <th>SH</th>
+          <th>ID</th>
+          <th>OD</th>
+          <th>PS</th>
+          <th>BH</th>
+          <th>RB</th>
+          <th>AG</th>
+          <th>ST</th>
+          <th>ND</th>
+          <th>IQ</th>
+          <th>FT</th>
+          <th>NG</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td>Player1</td><td>Junior</td><td>6'2"</td><td>180</td><td>75</td><td>80</td><td>70</td><td>65</td><td>72</td><td>74</td><td>68</td><td>76</td><td>71</td><td>69</td><td>77</td><td>85</td><td>1</td></tr>
+        <tr><td>Player2</td><td>Senior</td><td>6'4"</td><td>190</td><td>78</td><td>77</td><td>73</td><td>68</td><td>70</td><td>72</td><td>70</td><td>74</td><td>72</td><td>70</td><td>75</td><td>82</td><td>2</td></tr>
+        <tr><td>Player3</td><td>Sophomore</td><td>6'1"</td><td>175</td><td>72</td><td>74</td><td>68</td><td>67</td><td>71</td><td>73</td><td>65</td><td>75</td><td>69</td><td>68</td><td>74</td><td>80</td><td>3</td></tr>
+        <tr><td>Player4</td><td>Freshman</td><td>6'3"</td><td>185</td><td>70</td><td>72</td><td>69</td><td>66</td><td>68</td><td>70</td><td>72</td><td>73</td><td>70</td><td>67</td><td>72</td><td>78</td><td>4</td></tr>
+        <tr><td>Player5</td><td>Junior</td><td>6'5"</td><td>200</td><td>76</td><td>79</td><td>71</td><td>69</td><td>73</td><td>75</td><td>74</td><td>78</td><td>73</td><td>71</td><td>78</td><td>83</td><td>5</td></tr>
+      </tbody>
+    </table>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add placeholder roster pages for Bentley-Truman, Lancaster, Four Corners, Ocean City, Morristown, Little York, Xavien and South Lancaster

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688901e21a148328917a522b6ea3b96a