### PR TITLE
Add game control buttons with results popup

### DIFF
--- a/FrontEnd/static/court.html
+++ b/FrontEnd/static/court.html
@@ -15,11 +15,56 @@
     #phaser-container {
       width: 100%;
       height: 100vh;
+      position: relative;
+    }
+
+    .play-button,
+    .back-button {
+      background-color: #ff6200;
+      color: #fff;
+      border: none;
+      padding: 10px 20px;
+      border-radius: 4px;
+      cursor: pointer;
+      margin: 5px;
+    }
+
+    .results-button {
+      background-color: #007bff;
+      color: #fff;
+      border: none;
+      padding: 10px 20px;
+      border-radius: 4px;
+      cursor: pointer;
+      margin: 5px;
+    }
+
+    .result-popup {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0, 0, 0, 0.8);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .popup-content {
+      background: #222;
+      color: #fff;
+      padding: 20px;
+      border-radius: 8px;
+      text-align: center;
     }
   </style>
 </head>
 <body>
-  <div id="phaser-container"></div>
+  <div id="phaser-container">
+    <button class="play-button">Play Game</button>
+    <button class="results-button">See Results</button>
+  </div>
 
   <!-- <script type="module" src="./js/phaser/bootGame.js"></script> -->
   <script type="module" src="/static/js/phaser/bootGame.js"></script>

--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -1,62 +1,115 @@
 import * as Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.60.0/dist/phaser.esm.js';
 import { createGameScene } from './gameScene.js';
 
-// ✅ STEP 1: Read tournament info from URL
 const urlParams = new URLSearchParams(window.location.search);
-const tournamentId = urlParams.get("tournament_id");
-const homeTeam = urlParams.get("home");
-const awayTeam = urlParams.get("away");
+const tournamentId = urlParams.get('tournament_id');
+const franchise = urlParams.get('franchise');
+const homeTeam = urlParams.get('home');
+const awayTeam = urlParams.get('away');
 
-console.log("🏀 Tournament launch params:", {
+console.log('🏀 Tournament launch params:', {
   tournamentId,
   homeTeam,
-  awayTeam
+  awayTeam,
 });
 
-const GameScene = createGameScene(Phaser);  // ✅ Moved this up
+const GameScene = createGameScene(Phaser);
+
+function getBackUrl() {
+  if (tournamentId) return '/tournament';
+  if (franchise) return '/franchise/command-center';
+  return '/mode-select';
+}
 
 async function fetchTeamRoster(teamName) {
-    const res = await fetch(`/roster/${encodeURIComponent(teamName)}?tournament_id=${tournamentId}`);
-    if (!res.ok) {
-      throw new Error(`Failed to load roster for ${teamName}`);
-    }
-    return res.json();
+  const res = await fetch(`/roster/${encodeURIComponent(teamName)}?tournament_id=${tournamentId}`);
+  if (!res.ok) {
+    throw new Error(`Failed to load roster for ${teamName}`);
   }
-  
+  return res.json();
+}
 
-async function initTournamentGame() {
+async function startGameAnimation() {
   if (!homeTeam || !awayTeam) {
-    console.error("Missing team data in URL");
-    return;
+    console.error('Missing team data in URL');
+    return null;
   }
-  
+
   const [homeRoster, awayRoster] = await Promise.all([
     fetchTeamRoster(homeTeam),
-    fetchTeamRoster(awayTeam)
+    fetchTeamRoster(awayTeam),
   ]);
-
-  console.log("✅ Loaded rosters:", { homeRoster, awayRoster });
 
   const game = new Phaser.Game({
     type: Phaser.AUTO,
     width: 1229,
     height: 768,
-    backgroundColor: "#1e1e1e",
-    parent: "phaser-container",
-    // Disable audio to avoid AudioContext warnings in automated testing
+    backgroundColor: '#1e1e1e',
+    parent: 'phaser-container',
     audio: { noAudio: true },
-    scene: GameScene
+    scene: GameScene,
   });
 
-  game.scene.start('GameScene', {
-    rosters: { homeRoster, awayRoster },
-    tournamentId,
-    homeTeam,
-    awayTeam
+  return new Promise((resolve) => {
+    const gs = game.scene.getScene('GameScene');
+    gs.events.once('gameComplete', (finalScore) => {
+      resolve(finalScore);
+    });
+    game.scene.start('GameScene', {
+      rosters: { homeRoster, awayRoster },
+      tournamentId,
+      homeTeam,
+      awayTeam,
+    });
   });
 }
 
-initTournamentGame();  // ✅ This stays last
+function showPopup(score) {
+  const container = document.getElementById('phaser-container');
+  const popup = document.createElement('div');
+  popup.className = 'result-popup';
+  const backUrl = getBackUrl();
+  popup.innerHTML = `
+    <div class="popup-content">
+      <h2>Final Score</h2>
+      <p>${score.homeTeam} ${score.homeScore} - ${score.awayScore} ${score.awayTeam}</p>
+      <a href="${backUrl}" class="back-button">Back To Locker Room</a>
+    </div>
+  `;
+  container.appendChild(popup);
+}
+
+async function playGame() {
+  playBtn.style.display = 'none';
+  resultsBtn.style.display = 'none';
+  const score = await startGameAnimation();
+  if (score) {
+    showPopup(score);
+  }
+}
+
+async function showResults() {
+  playBtn.style.display = 'none';
+  resultsBtn.style.display = 'none';
+  try {
+    const res = await fetch(`/game/result?tournament_id=${tournamentId}`);
+    const data = await res.json();
+    const score = {
+      homeTeam: data.home_team || homeTeam,
+      awayTeam: data.away_team || awayTeam,
+      homeScore: data.score?.[data.home_team] ?? 0,
+      awayScore: data.score?.[data.away_team] ?? 0,
+    };
+    showPopup(score);
+  } catch (err) {
+    console.error('Failed to fetch results', err);
+  }
+}
+
+const playBtn = document.querySelector('.play-button');
+const resultsBtn = document.querySelector('.results-button');
+if (playBtn) playBtn.addEventListener('click', playGame);
+if (resultsBtn) resultsBtn.addEventListener('click', showResults);
 
 
 // new Phaser.Game(config);

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -116,7 +116,7 @@ export function createGameScene(Phaser) {
             })
             });
 
-            if (!res.ok) {
+        if (!res.ok) {
             console.error("❌ Failed to save tournament result:", await res.text());
             } else {
             console.log("✅ Tournament result saved.");
@@ -125,6 +125,16 @@ export function createGameScene(Phaser) {
             console.error("🚨 Error during tournament result save:", err);
         }
         }
+
+        // Expose final score and signal completion
+        this.finalScore = {
+            homeTeam: simData.home_team,
+            awayTeam: simData.away_team,
+            homeScore,
+            awayScore,
+            winner
+        };
+        this.events.emit('gameComplete', this.finalScore);
       };
 
       if (this.textures.exists(courtKey)) {


### PR DESCRIPTION
## Summary
- update the court page with Play Game and See Results buttons
- style buttons and popup
- emit `gameComplete` from GameScene and show popup via BootGame
- support skipping animation and fetching score directly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889046458c483289b0d83d02670a8d4