### PR TITLE
Revert team buttons to 2x4 grid and enable navigation

### DIFF
--- a/FrontEnd/static/mode-select.html
+++ b/FrontEnd/static/mode-select.html
@@ -27,35 +27,27 @@
   <div id="team-grid">
     <button class="team-button" data-team="Bentley-Truman">
       <img src="/static/images/homepage-logos/Bentley-Truman.png" alt="Bentley-Truman logo">
-      <span>Bentley-Truman</span>
     </button>
     <button class="team-button" data-team="Lancaster">
       <img src="/static/images/homepage-logos/Lancaster.png" alt="Lancaster logo">
-      <span>Lancaster</span>
     </button>
     <button class="team-button" data-team="Four Corners">
       <img src="/static/images/homepage-logos/Four Corners.png" alt="Four Corners logo">
-      <span>Four Corners</span>
     </button>
     <button class="team-button" data-team="Ocean City">
       <img src="/static/images/homepage-logos/Ocean City.png" alt="Ocean City logo">
-      <span>Ocean City</span>
     </button>
     <button class="team-button" data-team="Morristown">
       <img src="/static/images/homepage-logos/Morristown.png" alt="Morristown logo">
-      <span>Morristown</span>
     </button>
     <button class="team-button" data-team="Little York">
       <img src="/static/images/homepage-logos/Little York.png" alt="Little York logo">
-      <span>Little York</span>
     </button>
     <button class="team-button" data-team="Xavien">
       <img src="/static/images/homepage-logos/Xavien.png" alt="Xavien logo">
-      <span>Xavien</span>
     </button>
     <button class="team-button" data-team="South Lancaster">
       <img src="/static/images/homepage-logos/South Lancaster.png" alt="South Lancaster logo">
-      <span>South Lancaster</span>
     </button>
   </div>
   <script src="./mode-select.js"></script>

--- a/FrontEnd/static/mode-select.js
+++ b/FrontEnd/static/mode-select.js
@@ -24,10 +24,12 @@ if (franchiseBtn) {
 
 }
 
-const teamButtons = document.querySelectorAll('.team-button');
-teamButtons.forEach(btn => {
-  btn.addEventListener('click', () => {
-    const team = btn.dataset.team;
-    window.location.href = `/team-roster/${encodeURIComponent(team)}`;
+document.addEventListener('DOMContentLoaded', () => {
+  const teamButtons = document.querySelectorAll('.team-button');
+  teamButtons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const team = btn.dataset.team;
+      window.location.href = `/team-roster/${encodeURIComponent(team)}`;
+    });
   });
 });


### PR DESCRIPTION
## Summary
- revert team buttons in `mode-select.html` to a 2x4 grid
- connect team buttons to roster pages on DOMContentLoaded

## Testing
- `pip install -r requirements.txt`
- `pip install mongomock`
- `pip install httpx`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68890d32bd9c8328917ca1fb038ae128