### PR TITLE
Add Back button navigation on team roster pages

### DIFF
--- a/FrontEnd/static/mode-select.css
+++ b/FrontEnd/static/mode-select.css
@@ -82,3 +82,12 @@ body {
     grid-template-columns: repeat(2, 1fr);
   }
 }
+
+.back-button {
+  background: #ff9800;
+  color: #fff;
+  padding: 10px 20px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}

--- a/FrontEnd/static/team-roster/Bentley-Truman.html
+++ b/FrontEnd/static/team-roster/Bentley-Truman.html
@@ -5,15 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Bentley-Truman Roster</title>
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/static/mode-select.css">
   <style>
     body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
-    #back { position:absolute; top:10px; left:10px; }
-    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
     h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
   </style>
 </head>
 <body>
-  <div id="back"><a href="/mode-select">Back</a></div>
+  <button class="back-button" onclick="window.history.back()">Back</button>
   <h1>In Development</h1>
 </body>
 </html>

--- a/FrontEnd/static/team-roster/Four Corners.html
+++ b/FrontEnd/static/team-roster/Four Corners.html
@@ -5,15 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Four Corners Roster</title>
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/static/mode-select.css">
   <style>
     body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
-    #back { position:absolute; top:10px; left:10px; }
-    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
     h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
   </style>
 </head>
 <body>
-  <div id="back"><a href="/mode-select">Back</a></div>
+  <button class="back-button" onclick="window.history.back()">Back</button>
   <h1>In Development</h1>
 </body>
 </html>

--- a/FrontEnd/static/team-roster/Lancaster.html
+++ b/FrontEnd/static/team-roster/Lancaster.html
@@ -5,15 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Lancaster Roster</title>
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/static/mode-select.css">
   <style>
     body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
-    #back { position:absolute; top:10px; left:10px; }
-    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
     h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
   </style>
 </head>
 <body>
-  <div id="back"><a href="/mode-select">Back</a></div>
+  <button class="back-button" onclick="window.history.back()">Back</button>
   <h1>In Development</h1>
 </body>
 </html>

--- a/FrontEnd/static/team-roster/Little York.html
+++ b/FrontEnd/static/team-roster/Little York.html
@@ -5,15 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Little York Roster</title>
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/static/mode-select.css">
   <style>
     body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
-    #back { position:absolute; top:10px; left:10px; }
-    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
     h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
   </style>
 </head>
 <body>
-  <div id="back"><a href="/mode-select">Back</a></div>
+  <button class="back-button" onclick="window.history.back()">Back</button>
   <h1>In Development</h1>
 </body>
 </html>

--- a/FrontEnd/static/team-roster/Morristown.html
+++ b/FrontEnd/static/team-roster/Morristown.html
@@ -5,15 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Morristown Roster</title>
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/static/mode-select.css">
   <style>
     body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
-    #back { position:absolute; top:10px; left:10px; }
-    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
     h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
   </style>
 </head>
 <body>
-  <div id="back"><a href="/mode-select">Back</a></div>
+  <button class="back-button" onclick="window.history.back()">Back</button>
   <h1>In Development</h1>
 </body>
 </html>

--- a/FrontEnd/static/team-roster/Ocean City.html
+++ b/FrontEnd/static/team-roster/Ocean City.html
@@ -5,15 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Ocean City Roster</title>
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/static/mode-select.css">
   <style>
     body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
-    #back { position:absolute; top:10px; left:10px; }
-    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
     h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
   </style>
 </head>
 <body>
-  <div id="back"><a href="/mode-select">Back</a></div>
+  <button class="back-button" onclick="window.history.back()">Back</button>
   <h1>In Development</h1>
 </body>
 </html>

--- a/FrontEnd/static/team-roster/South Lancaster.html
+++ b/FrontEnd/static/team-roster/South Lancaster.html
@@ -5,15 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>South Lancaster Roster</title>
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/static/mode-select.css">
   <style>
     body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
-    #back { position:absolute; top:10px; left:10px; }
-    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
     h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
   </style>
 </head>
 <body>
-  <div id="back"><a href="/mode-select">Back</a></div>
+  <button class="back-button" onclick="window.history.back()">Back</button>
   <h1>In Development</h1>
 </body>
 </html>

--- a/FrontEnd/static/team-roster/Xavien.html
+++ b/FrontEnd/static/team-roster/Xavien.html
@@ -5,15 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Xavien Roster</title>
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/static/mode-select.css">
   <style>
     body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
-    #back { position:absolute; top:10px; left:10px; }
-    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
     h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
   </style>
 </head>
 <body>
-  <div id="back"><a href="/mode-select">Back</a></div>
+  <button class="back-button" onclick="window.history.back()">Back</button>
   <h1>In Development</h1>
 </body>
 </html>

--- a/FrontEnd/static/team-roster/team-roster-Bentley-Truman.html
+++ b/FrontEnd/static/team-roster/team-roster-Bentley-Truman.html
@@ -6,15 +6,14 @@
   <title>{{ team }} Team Roster</title>
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/static/tournament.css">
+  <link rel="stylesheet" href="/static/mode-select.css">
   <style>
     body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
-    #back { position:absolute; top:10px; left:10px; }
-    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
     h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
   </style>
 </head>
 <body>
-  <div id="back"><a href="/mode-select">Back</a></div>
+  <button class="back-button" onclick="window.history.back()">Back</button>
   <h1>{{ team }} Roster</h1>
   <div class="scroll-x">
     <table class="roster-table">

--- a/FrontEnd/static/team-roster/team-roster-Four-Corners.html
+++ b/FrontEnd/static/team-roster/team-roster-Four-Corners.html
@@ -6,15 +6,14 @@
   <title>{{ team }} Team Roster</title>
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/static/tournament.css">
+  <link rel="stylesheet" href="/static/mode-select.css">
   <style>
     body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
-    #back { position:absolute; top:10px; left:10px; }
-    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
     h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
   </style>
 </head>
 <body>
-  <div id="back"><a href="/mode-select">Back</a></div>
+  <button class="back-button" onclick="window.history.back()">Back</button>
   <h1>{{ team }} Roster</h1>
   <div class="scroll-x">
     <table class="roster-table">

--- a/FrontEnd/static/team-roster/team-roster-Lancaster.html
+++ b/FrontEnd/static/team-roster/team-roster-Lancaster.html
@@ -6,15 +6,14 @@
   <title>{{ team }} Team Roster</title>
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/static/tournament.css">
+  <link rel="stylesheet" href="/static/mode-select.css">
   <style>
     body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
-    #back { position:absolute; top:10px; left:10px; }
-    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
     h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
   </style>
 </head>
 <body>
-  <div id="back"><a href="/mode-select">Back</a></div>
+  <button class="back-button" onclick="window.history.back()">Back</button>
   <h1>{{ team }} Roster</h1>
   <div class="scroll-x">
     <table class="roster-table">

--- a/FrontEnd/static/team-roster/team-roster-Little-York.html
+++ b/FrontEnd/static/team-roster/team-roster-Little-York.html
@@ -6,15 +6,14 @@
   <title>{{ team }} Team Roster</title>
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/static/tournament.css">
+  <link rel="stylesheet" href="/static/mode-select.css">
   <style>
     body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
-    #back { position:absolute; top:10px; left:10px; }
-    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
     h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
   </style>
 </head>
 <body>
-  <div id="back"><a href="/mode-select">Back</a></div>
+  <button class="back-button" onclick="window.history.back()">Back</button>
   <h1>{{ team }} Roster</h1>
   <div class="scroll-x">
     <table class="roster-table">

--- a/FrontEnd/static/team-roster/team-roster-Morristown.html
+++ b/FrontEnd/static/team-roster/team-roster-Morristown.html
@@ -6,15 +6,14 @@
   <title>{{ team }} Team Roster</title>
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/static/tournament.css">
+  <link rel="stylesheet" href="/static/mode-select.css">
   <style>
     body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
-    #back { position:absolute; top:10px; left:10px; }
-    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
     h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
   </style>
 </head>
 <body>
-  <div id="back"><a href="/mode-select">Back</a></div>
+  <button class="back-button" onclick="window.history.back()">Back</button>
   <h1>{{ team }} Roster</h1>
   <div class="scroll-x">
     <table class="roster-table">

--- a/FrontEnd/static/team-roster/team-roster-Ocean-City.html
+++ b/FrontEnd/static/team-roster/team-roster-Ocean-City.html
@@ -6,15 +6,14 @@
   <title>{{ team }} Team Roster</title>
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/static/tournament.css">
+  <link rel="stylesheet" href="/static/mode-select.css">
   <style>
     body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
-    #back { position:absolute; top:10px; left:10px; }
-    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
     h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
   </style>
 </head>
 <body>
-  <div id="back"><a href="/mode-select">Back</a></div>
+  <button class="back-button" onclick="window.history.back()">Back</button>
   <h1>{{ team }} Roster</h1>
   <div class="scroll-x">
     <table class="roster-table">

--- a/FrontEnd/static/team-roster/team-roster-South-Lancaster.html
+++ b/FrontEnd/static/team-roster/team-roster-South-Lancaster.html
@@ -6,15 +6,14 @@
   <title>{{ team }} Team Roster</title>
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/static/tournament.css">
+  <link rel="stylesheet" href="/static/mode-select.css">
   <style>
     body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
-    #back { position:absolute; top:10px; left:10px; }
-    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
     h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
   </style>
 </head>
 <body>
-  <div id="back"><a href="/mode-select">Back</a></div>
+  <button class="back-button" onclick="window.history.back()">Back</button>
   <h1>{{ team }} Roster</h1>
   <div class="scroll-x">
     <table class="roster-table">

--- a/FrontEnd/static/team-roster/team-roster-Xavien.html
+++ b/FrontEnd/static/team-roster/team-roster-Xavien.html
@@ -6,15 +6,14 @@
   <title>{{ team }} Team Roster</title>
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/static/tournament.css">
+  <link rel="stylesheet" href="/static/mode-select.css">
   <style>
     body { font-family: 'Inter', sans-serif; background:#f5f5f5; margin:0; padding:20px; }
-    #back { position:absolute; top:10px; left:10px; }
-    #back a { text-decoration:none; background:#ff9800; color:#fff; padding:6px 12px; border-radius:4px; font-weight:bold; }
     h1 { font-family:'Bebas Neue', cursive; text-align:center; margin-top:40px; }
   </style>
 </head>
 <body>
-  <div id="back"><a href="/mode-select">Back</a></div>
+  <button class="back-button" onclick="window.history.back()">Back</button>
   <h1>{{ team }} Roster</h1>
   <div class="scroll-x">
     <table class="roster-table">


### PR DESCRIPTION
## Summary
- allow roster pages to return to previous page
- style new Back button in `mode-select.css`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a5de394b083289878c252c80770b8