### PR TITLE
Fix game animation by handling missing team params with user alert

### DIFF
--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -95,7 +95,7 @@ async function playGame() {
   resultsBtn.style.display = 'none';
 
   if (!homeTeam || !awayTeam) {
-    console.error('Missing team data in URL');
+    alert('Please select teams before playing.');
     return;
   }
 


### PR DESCRIPTION
## Summary
- update bootGame to alert when `home` or `away` query params are missing

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ae84c3c4483289e19d69e40236933