### PR TITLE
Fix game animation by resolving /simulate 404 error with backend route

### DIFF
--- a/BackEnd/api/api.py
+++ b/BackEnd/api/api.py
@@ -67,6 +67,7 @@ def get_team_names():
     return sorted([team["name"] for team in teams])
 
 
+@app.post("/api/simulate")
 @app.post("/simulate")
 def simulate_game(request: SimulationRequest):
     home_team = request.home_team

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -41,9 +41,9 @@ export function createGameScene(Phaser) {
       const homeTeam = this.rosters.homeRoster.team_name;
       const awayTeam = this.rosters.awayRoster.team_name;
 
-    console.log("📨 Sending /simulate request for:", homeTeam, "vs", awayTeam);
+    console.log("📨 Sending /api/simulate request for:", homeTeam, "vs", awayTeam);
 
-      const res = await fetch('/simulate', {
+      const res = await fetch('/api/simulate', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ home_team: homeTeam, away_team: awayTeam })


### PR DESCRIPTION
## Summary
- update GameScene to post to `/api/simulate`
- expose `/api/simulate` FastAPI route while keeping `/simulate` for compatibility

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b83b32c048328a26663529c92be59