### PR TITLE
Fix game animation by starting GameScene before retrieving instance

### DIFF
--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -40,29 +40,25 @@ async function startGameAnimation({ homeRoster, awayRoster }) {
     game.scene.add('GameScene', GameScene);
   }
 
+  const sceneData = {
+    rosters: { homeRoster, awayRoster },
+    tournamentId,
+    homeTeam,
+    awayTeam,
+  };
+
+  if (game.scene.isActive('GameScene')) {
+    game.scene.restart('GameScene', sceneData);
+  } else {
+    game.scene.start('GameScene', sceneData);
+  }
+
   const gs = game.scene.getScene('GameScene');
-  console.log("gs =", gs);
   gamePromise = new Promise((resolve) => {
     gs.events.once('gameComplete', (finalScore) => {
       resolve(finalScore);
     });
   });
-
-  if (gs.scene.isActive()) {
-    gs.scene.restart({
-      rosters: { homeRoster, awayRoster },
-      tournamentId,
-      homeTeam,
-      awayTeam,
-    });
-  } else {
-    gs.scene.start('GameScene', {
-      rosters: { homeRoster, awayRoster },
-      tournamentId,
-      homeTeam,
-      awayTeam,
-    });
-  }
 
   return gamePromise;
 }


### PR DESCRIPTION
## Summary
- ensure GameScene is started or restarted before retrieving the scene instance
- attach the `gameComplete` listener after starting the scene

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b96218b7c8328b2e20421f09b3d92