### PR TITLE
Fix popup display after Play Game animation completion

### DIFF
--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -47,18 +47,19 @@ async function startGameAnimation({ homeRoster, awayRoster }) {
     awayTeam,
   };
 
-  if (game.scene.isActive('GameScene')) {
-    game.scene.restart('GameScene', sceneData);
-  } else {
-    game.scene.start('GameScene', sceneData);
-  }
-
   const gs = game.scene.getScene('GameScene');
+
   gamePromise = new Promise((resolve) => {
     gs.events.once('gameComplete', (finalScore) => {
       resolve(finalScore);
     });
   });
+
+  if (game.scene.isActive('GameScene')) {
+    game.scene.restart('GameScene', sceneData);
+  } else {
+    game.scene.start('GameScene', sceneData);
+  }
 
   return gamePromise;
 }


### PR DESCRIPTION
## Summary
- attach event listener for `gameComplete` before starting or restarting `GameScene`

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b9ad22840832890ab134a6786315f