### PR TITLE
Fix game start promise timing

### DIFF
--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -47,6 +47,12 @@ async function startGameAnimation({ homeRoster, awayRoster }) {
     awayTeam,
   };
 
+  if (game.scene.isActive('GameScene')) {
+    game.scene.restart('GameScene', sceneData);
+  } else {
+    game.scene.start('GameScene', sceneData);
+  }
+
   const gs = game.scene.getScene('GameScene');
 
   gamePromise = new Promise((resolve) => {
@@ -54,12 +60,6 @@ async function startGameAnimation({ homeRoster, awayRoster }) {
       resolve(finalScore);
     });
   });
-
-  if (game.scene.isActive('GameScene')) {
-    game.scene.restart('GameScene', sceneData);
-  } else {
-    game.scene.start('GameScene', sceneData);
-  }
 
   return gamePromise;
 }


### PR DESCRIPTION
## Summary
- start or restart the Phaser scene before registering the completion listener

## Testing
- `pip install -r requirements.txt`
- `pip install pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b9fe323d48328986da302839f4297