### PR TITLE
Fix scoreboard popup after animation

### DIFF
--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -53,10 +53,10 @@ async function startGameAnimation({ homeRoster, awayRoster }) {
     game.scene.start('GameScene', sceneData);
   }
 
-  const gs = game.scene.getScene('GameScene');
-
   gamePromise = new Promise((resolve) => {
-    gs.events.once('gameComplete', (finalScore) => {
+    // Listen on the global event emitter so we don't lose the listener when
+    // GameScene is restarted or recreated
+    game.events.once('gameComplete', (finalScore) => {
       resolve(finalScore);
     });
   });

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -134,7 +134,9 @@ export function createGameScene(Phaser) {
             awayScore,
             winner
         };
-        this.events.emit('gameComplete', this.finalScore);
+        // Emit on the global game event emitter so external code can reliably
+        // listen for completion even across scene restarts
+        this.game.events.emit('gameComplete', this.finalScore);
       };
 
       if (this.textures.exists(courtKey)) {


### PR DESCRIPTION
## Summary
- use Phaser's global event emitter so the `gameComplete` event isn't lost
- listen on `game.events` to show the popup after the GameScene restarts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b9eab264c8328955494afb1dc12e6