### PR TITLE
Fix roster pages to use nested player attributes

### DIFF
--- a/BackEnd/api/api.py
+++ b/BackEnd/api/api.py
@@ -216,24 +216,15 @@ def team_roster_page(request: Request, team: str):
     players_cursor = players_collection.find({"team": team})
     players = []
     for p in players_cursor:
+        attrs = p.get("attributes", {})
+        display_attributes = ["SC", "SH", "ID", "OD", "PS", "BH", "RB",
+                              "AG", "ST", "ND", "IQ", "FT", "NG"]
         players.append({
             "name": f"{p.get('first_name', '')} {p.get('last_name', '')}".strip(),
             "year": p.get("year", "--"),
             "height": p.get("height", "--"),
             "weight": p.get("weight", "--"),
-            "SC": p.get("SC", "--"),
-            "SH": p.get("SH", "--"),
-            "ID": p.get("ID", "--"),
-            "OD": p.get("OD", "--"),
-            "PS": p.get("PS", "--"),
-            "BH": p.get("BH", "--"),
-            "RB": p.get("RB", "--"),
-            "AG": p.get("AG", "--"),
-            "ST": p.get("ST", "--"),
-            "ND": p.get("ND", "--"),
-            "IQ": p.get("IQ", "--"),
-            "FT": p.get("FT", "--"),
-            "NG": p.get("NG", "--"),
+            "attributes": {attr: attrs.get(attr, "--") for attr in display_attributes},
         })
 
     template_name = f"team-roster/team-roster-{team.replace(' ', '-')}.html"

--- a/FrontEnd/static/team-roster/team-roster-Bentley-Truman.html
+++ b/FrontEnd/static/team-roster/team-roster-Bentley-Truman.html
@@ -57,7 +57,7 @@
           <td>{{ p.attributes.ND }}</td>
           <td>{{ p.attributes.IQ }}</td>
           <td>{{ p.attributes.FT }}</td>
-          <td>{{ p.NG }}</td>
+          <td>{{ p.attributes.NG }}</td>
         </tr>
       {% endfor %}
       </tbody>

--- a/FrontEnd/static/team-roster/team-roster-Four-Corners.html
+++ b/FrontEnd/static/team-roster/team-roster-Four-Corners.html
@@ -45,19 +45,19 @@
           <td>{{ p.year }}</td>
           <td>{{ p.height }}</td>
           <td>{{ p.weight }}</td>
-          <td>{{ p.SC }}</td>
-          <td>{{ p.SH }}</td>
-          <td>{{ p.ID }}</td>
-          <td>{{ p.OD }}</td>
-          <td>{{ p.PS }}</td>
-          <td>{{ p.BH }}</td>
-          <td>{{ p.RB }}</td>
-          <td>{{ p.AG }}</td>
-          <td>{{ p.ST }}</td>
-          <td>{{ p.ND }}</td>
-          <td>{{ p.IQ }}</td>
-          <td>{{ p.FT }}</td>
-          <td>{{ p.NG }}</td>
+          <td>{{ p.attributes.SC }}</td>
+          <td>{{ p.attributes.SH }}</td>
+          <td>{{ p.attributes.ID }}</td>
+          <td>{{ p.attributes.OD }}</td>
+          <td>{{ p.attributes.PS }}</td>
+          <td>{{ p.attributes.BH }}</td>
+          <td>{{ p.attributes.RB }}</td>
+          <td>{{ p.attributes.AG }}</td>
+          <td>{{ p.attributes.ST }}</td>
+          <td>{{ p.attributes.ND }}</td>
+          <td>{{ p.attributes.IQ }}</td>
+          <td>{{ p.attributes.FT }}</td>
+          <td>{{ p.attributes.NG }}</td>
         </tr>
       {% endfor %}
       </tbody>

--- a/FrontEnd/static/team-roster/team-roster-Lancaster.html
+++ b/FrontEnd/static/team-roster/team-roster-Lancaster.html
@@ -45,19 +45,19 @@
           <td>{{ p.year }}</td>
           <td>{{ p.height }}</td>
           <td>{{ p.weight }}</td>
-          <td>{{ p.SC }}</td>
-          <td>{{ p.SH }}</td>
-          <td>{{ p.ID }}</td>
-          <td>{{ p.OD }}</td>
-          <td>{{ p.PS }}</td>
-          <td>{{ p.BH }}</td>
-          <td>{{ p.RB }}</td>
-          <td>{{ p.AG }}</td>
-          <td>{{ p.ST }}</td>
-          <td>{{ p.ND }}</td>
-          <td>{{ p.IQ }}</td>
-          <td>{{ p.FT }}</td>
-          <td>{{ p.NG }}</td>
+          <td>{{ p.attributes.SC }}</td>
+          <td>{{ p.attributes.SH }}</td>
+          <td>{{ p.attributes.ID }}</td>
+          <td>{{ p.attributes.OD }}</td>
+          <td>{{ p.attributes.PS }}</td>
+          <td>{{ p.attributes.BH }}</td>
+          <td>{{ p.attributes.RB }}</td>
+          <td>{{ p.attributes.AG }}</td>
+          <td>{{ p.attributes.ST }}</td>
+          <td>{{ p.attributes.ND }}</td>
+          <td>{{ p.attributes.IQ }}</td>
+          <td>{{ p.attributes.FT }}</td>
+          <td>{{ p.attributes.NG }}</td>
         </tr>
       {% endfor %}
       </tbody>

--- a/FrontEnd/static/team-roster/team-roster-Little-York.html
+++ b/FrontEnd/static/team-roster/team-roster-Little-York.html
@@ -45,19 +45,19 @@
           <td>{{ p.year }}</td>
           <td>{{ p.height }}</td>
           <td>{{ p.weight }}</td>
-          <td>{{ p.SC }}</td>
-          <td>{{ p.SH }}</td>
-          <td>{{ p.ID }}</td>
-          <td>{{ p.OD }}</td>
-          <td>{{ p.PS }}</td>
-          <td>{{ p.BH }}</td>
-          <td>{{ p.RB }}</td>
-          <td>{{ p.AG }}</td>
-          <td>{{ p.ST }}</td>
-          <td>{{ p.ND }}</td>
-          <td>{{ p.IQ }}</td>
-          <td>{{ p.FT }}</td>
-          <td>{{ p.NG }}</td>
+          <td>{{ p.attributes.SC }}</td>
+          <td>{{ p.attributes.SH }}</td>
+          <td>{{ p.attributes.ID }}</td>
+          <td>{{ p.attributes.OD }}</td>
+          <td>{{ p.attributes.PS }}</td>
+          <td>{{ p.attributes.BH }}</td>
+          <td>{{ p.attributes.RB }}</td>
+          <td>{{ p.attributes.AG }}</td>
+          <td>{{ p.attributes.ST }}</td>
+          <td>{{ p.attributes.ND }}</td>
+          <td>{{ p.attributes.IQ }}</td>
+          <td>{{ p.attributes.FT }}</td>
+          <td>{{ p.attributes.NG }}</td>
         </tr>
       {% endfor %}
       </tbody>

--- a/FrontEnd/static/team-roster/team-roster-Morristown.html
+++ b/FrontEnd/static/team-roster/team-roster-Morristown.html
@@ -45,19 +45,19 @@
           <td>{{ p.year }}</td>
           <td>{{ p.height }}</td>
           <td>{{ p.weight }}</td>
-          <td>{{ p.SC }}</td>
-          <td>{{ p.SH }}</td>
-          <td>{{ p.ID }}</td>
-          <td>{{ p.OD }}</td>
-          <td>{{ p.PS }}</td>
-          <td>{{ p.BH }}</td>
-          <td>{{ p.RB }}</td>
-          <td>{{ p.AG }}</td>
-          <td>{{ p.ST }}</td>
-          <td>{{ p.ND }}</td>
-          <td>{{ p.IQ }}</td>
-          <td>{{ p.FT }}</td>
-          <td>{{ p.NG }}</td>
+          <td>{{ p.attributes.SC }}</td>
+          <td>{{ p.attributes.SH }}</td>
+          <td>{{ p.attributes.ID }}</td>
+          <td>{{ p.attributes.OD }}</td>
+          <td>{{ p.attributes.PS }}</td>
+          <td>{{ p.attributes.BH }}</td>
+          <td>{{ p.attributes.RB }}</td>
+          <td>{{ p.attributes.AG }}</td>
+          <td>{{ p.attributes.ST }}</td>
+          <td>{{ p.attributes.ND }}</td>
+          <td>{{ p.attributes.IQ }}</td>
+          <td>{{ p.attributes.FT }}</td>
+          <td>{{ p.attributes.NG }}</td>
         </tr>
       {% endfor %}
       </tbody>

--- a/FrontEnd/static/team-roster/team-roster-Ocean-City.html
+++ b/FrontEnd/static/team-roster/team-roster-Ocean-City.html
@@ -45,19 +45,19 @@
           <td>{{ p.year }}</td>
           <td>{{ p.height }}</td>
           <td>{{ p.weight }}</td>
-          <td>{{ p.SC }}</td>
-          <td>{{ p.SH }}</td>
-          <td>{{ p.ID }}</td>
-          <td>{{ p.OD }}</td>
-          <td>{{ p.PS }}</td>
-          <td>{{ p.BH }}</td>
-          <td>{{ p.RB }}</td>
-          <td>{{ p.AG }}</td>
-          <td>{{ p.ST }}</td>
-          <td>{{ p.ND }}</td>
-          <td>{{ p.IQ }}</td>
-          <td>{{ p.FT }}</td>
-          <td>{{ p.NG }}</td>
+          <td>{{ p.attributes.SC }}</td>
+          <td>{{ p.attributes.SH }}</td>
+          <td>{{ p.attributes.ID }}</td>
+          <td>{{ p.attributes.OD }}</td>
+          <td>{{ p.attributes.PS }}</td>
+          <td>{{ p.attributes.BH }}</td>
+          <td>{{ p.attributes.RB }}</td>
+          <td>{{ p.attributes.AG }}</td>
+          <td>{{ p.attributes.ST }}</td>
+          <td>{{ p.attributes.ND }}</td>
+          <td>{{ p.attributes.IQ }}</td>
+          <td>{{ p.attributes.FT }}</td>
+          <td>{{ p.attributes.NG }}</td>
         </tr>
       {% endfor %}
       </tbody>

--- a/FrontEnd/static/team-roster/team-roster-South-Lancaster.html
+++ b/FrontEnd/static/team-roster/team-roster-South-Lancaster.html
@@ -45,19 +45,19 @@
           <td>{{ p.year }}</td>
           <td>{{ p.height }}</td>
           <td>{{ p.weight }}</td>
-          <td>{{ p.SC }}</td>
-          <td>{{ p.SH }}</td>
-          <td>{{ p.ID }}</td>
-          <td>{{ p.OD }}</td>
-          <td>{{ p.PS }}</td>
-          <td>{{ p.BH }}</td>
-          <td>{{ p.RB }}</td>
-          <td>{{ p.AG }}</td>
-          <td>{{ p.ST }}</td>
-          <td>{{ p.ND }}</td>
-          <td>{{ p.IQ }}</td>
-          <td>{{ p.FT }}</td>
-          <td>{{ p.NG }}</td>
+          <td>{{ p.attributes.SC }}</td>
+          <td>{{ p.attributes.SH }}</td>
+          <td>{{ p.attributes.ID }}</td>
+          <td>{{ p.attributes.OD }}</td>
+          <td>{{ p.attributes.PS }}</td>
+          <td>{{ p.attributes.BH }}</td>
+          <td>{{ p.attributes.RB }}</td>
+          <td>{{ p.attributes.AG }}</td>
+          <td>{{ p.attributes.ST }}</td>
+          <td>{{ p.attributes.ND }}</td>
+          <td>{{ p.attributes.IQ }}</td>
+          <td>{{ p.attributes.FT }}</td>
+          <td>{{ p.attributes.NG }}</td>
         </tr>
       {% endfor %}
       </tbody>

--- a/FrontEnd/static/team-roster/team-roster-Xavien.html
+++ b/FrontEnd/static/team-roster/team-roster-Xavien.html
@@ -45,19 +45,19 @@
           <td>{{ p.year }}</td>
           <td>{{ p.height }}</td>
           <td>{{ p.weight }}</td>
-          <td>{{ p.SC }}</td>
-          <td>{{ p.SH }}</td>
-          <td>{{ p.ID }}</td>
-          <td>{{ p.OD }}</td>
-          <td>{{ p.PS }}</td>
-          <td>{{ p.BH }}</td>
-          <td>{{ p.RB }}</td>
-          <td>{{ p.AG }}</td>
-          <td>{{ p.ST }}</td>
-          <td>{{ p.ND }}</td>
-          <td>{{ p.IQ }}</td>
-          <td>{{ p.FT }}</td>
-          <td>{{ p.NG }}</td>
+          <td>{{ p.attributes.SC }}</td>
+          <td>{{ p.attributes.SH }}</td>
+          <td>{{ p.attributes.ID }}</td>
+          <td>{{ p.attributes.OD }}</td>
+          <td>{{ p.attributes.PS }}</td>
+          <td>{{ p.attributes.BH }}</td>
+          <td>{{ p.attributes.RB }}</td>
+          <td>{{ p.attributes.AG }}</td>
+          <td>{{ p.attributes.ST }}</td>
+          <td>{{ p.attributes.ND }}</td>
+          <td>{{ p.attributes.IQ }}</td>
+          <td>{{ p.attributes.FT }}</td>
+          <td>{{ p.attributes.NG }}</td>
         </tr>
       {% endfor %}
       </tbody>


### PR DESCRIPTION
## Summary
- serve player attributes to roster templates via dedicated `attributes` dictionary
- render all team roster pages using nested attribute values

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fcea790548328a057336377349e5a