### PR TITLE
Fix Bentley-Truman roster attribute access

### DIFF
--- a/FrontEnd/static/team-roster/team-roster-Bentley-Truman.html
+++ b/FrontEnd/static/team-roster/team-roster-Bentley-Truman.html
@@ -45,18 +45,19 @@
           <td>{{ p.year }}</td>
           <td>{{ p.height }}</td>
           <td>{{ p.weight }}</td>
-          <td>{{ p.SC }}</td>
-          <td>{{ p.SH }}</td>
-          <td>{{ p.ID }}</td>
-          <td>{{ p.OD }}</td>
-          <td>{{ p.PS }}</td> 
-          <td>{{ p.BH }}</td>
-          <td>{{ p.RB }}</td>
-          <td>{{ p.AG }}</td>
-          <td>{{ p.ST }}</td>
-          <td>{{ p.IQ }}</td>
-          <td>{{ p.FT }}</td>
-          <td>{{ p.NG }}</td>
+          <td>{{ p.attributes.SC }}</td>
+          <td>{{ p.attributes.SH }}</td>
+          <td>{{ p.attributes.ID }}</td>
+          <td>{{ p.attributes.OD }}</td>
+          <td>{{ p.attributes.PS }}</td>
+          <td>{{ p.attributes.BH }}</td>
+          <td>{{ p.attributes.RB }}</td>
+          <td>{{ p.attributes.AG }}</td>
+          <td>{{ p.attributes.ST }}</td>
+          <td>{{ p.attributes.ND }}</td>
+          <td>{{ p.attributes.IQ }}</td>
+          <td>{{ p.attributes.FT }}</td>
+          <td>{{ p.attributes.NG }}</td>
         </tr>
       {% endfor %}
       </tbody>


### PR DESCRIPTION
## Summary
- fix player attribute references on Bentley-Truman team roster page

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fda73028c8328a5427f82c0dee598