### PR TITLE
Expose team objects in simulate API response

### DIFF
--- a/BackEnd/api/api.py
+++ b/BackEnd/api/api.py
@@ -89,8 +89,18 @@ def simulate_game(request: SimulationRequest):
 
     game = run_simulation(home_team, away_team)
     # print("Right before summarize_game_state")
-    # print("🧪 Turns sample:", game.turns[:3])  
+    # print("🧪 Turns sample:", game.turns[:3])
     summary = summarize_game_state(game)
+
+    # Ensure team objects exist for the frontend
+    summary["homeTeam"] = summary.get("homeTeam") or {
+        "name": summary.get("home_team", home_team),
+        "score": summary.get("score", {}).get(home_team, 0),
+    }
+    summary["awayTeam"] = summary.get("awayTeam") or {
+        "name": summary.get("away_team", away_team),
+        "score": summary.get("score", {}).get(away_team, 0),
+    }
 
     # ✅ Minimal debug visibility
     # print(f"✅ Game finished: {home_team} vs. {away_team}")

--- a/BackEnd/utils/game_summary_builder.py
+++ b/BackEnd/utils/game_summary_builder.py
@@ -9,6 +9,18 @@ def build_game_summary(game_manager):
     away = gm.away_team.name
     score = gm.score
 
+    home_obj = {
+        "name": home,
+        "team_id": gm.home_team.team_id,
+        "score": score.get(home, 0),
+    }
+
+    away_obj = {
+        "name": away,
+        "team_id": gm.away_team.team_id,
+        "score": score.get(away, 0),
+    }
+
     return {
         "home_team": home,
         "away_team": away,
@@ -17,6 +29,8 @@ def build_game_summary(game_manager):
         "quarters": gm.quarter,
         "points_by_quarter": gm.game_state["points_by_quarter"],
         "box_score": gm.get_box_score(),
-        "timestamp": datetime.utcnow().isoformat()
+        "timestamp": datetime.utcnow().isoformat(),
+        "homeTeam": home_obj,
+        "awayTeam": away_obj,
     }
 

--- a/BackEnd/utils/shared.py
+++ b/BackEnd/utils/shared.py
@@ -354,38 +354,52 @@ def summarize_game_state(game):
     print(f"Away team primary color: {game.away_team.primary_color}")
     print(f"Away team secondary color: {game.away_team.secondary_color}")
 
+    home_team_obj = {
+        "name": game.home_team.name,
+        "team_id": game.home_team.team_id,
+        "score": game.score.get(game.home_team.name, 0),
+        "colors": {
+            "primary_color": game.home_team.primary_color,
+            "secondary_color": game.home_team.secondary_color,
+        },
+    }
+
+    away_team_obj = {
+        "name": game.away_team.name,
+        "team_id": game.away_team.team_id,
+        "score": game.score.get(game.away_team.name, 0),
+        "colors": {
+            "primary_color": game.away_team.primary_color,
+            "secondary_color": game.away_team.secondary_color,
+        },
+    }
+
     return {
         "final_score": game.score,
         "points_by_quarter": game.game_state["points_by_quarter"],
         "box_score": game.get_box_score(),
         "scouting": {
             game.home_team.name: game.home_team.scouting_data,
-            game.away_team.name: game.away_team.scouting_data
+            game.away_team.name: game.away_team.scouting_data,
         },
         "team_totals": game.team_totals,
         "text_log": game.text_log,
         "turns": game.turns,
-        "home_team_name": game.home_team.name,
-        "away_team_name": game.away_team.name,
+        "home_team": game.home_team.name,
+        "away_team": game.away_team.name,
         "home_team_colors": {
             "primary_color": game.home_team.primary_color,
-            "secondary_color": game.home_team.secondary_color
+            "secondary_color": game.home_team.secondary_color,
         },
         "away_team_colors": {
             "primary_color": game.away_team.primary_color,
-            "secondary_color": game.away_team.secondary_color
+            "secondary_color": game.away_team.secondary_color,
         },
-        # "home_team_colors": {
-        #     "primary_color": getattr(game.home_team, "primary_color", "#0077cc"),
-        #     "secondary_color": getattr(game.home_team, "secondary_color", "#ffcc00")
-        # },
-        # "away_team_colors": {
-        #     "primary_color": getattr(game.away_team, "primary_color", "#ffffff"),
-        #     "secondary_color": getattr(game.away_team, "secondary_color", "#0077cc")
-        # },
         "score": game.score,
         "home_team_id": game.home_team.team_id,
-        "players": players
+        "players": players,
+        "homeTeam": home_team_obj,
+        "awayTeam": away_team_obj,
     }
 
 def check_defensive_foul(self, defender, is_three):

--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -115,11 +115,15 @@ async function showResults() {
   try {
     const res = await fetch(`/game/result?tournament_id=${tournamentId}`);
     const data = await res.json();
+    const homeObj = data.homeTeam || { name: data.home_team };
+    const awayObj = data.awayTeam || { name: data.away_team };
     const score = {
-      homeTeam: data.home_team || homeTeam,
-      awayTeam: data.away_team || awayTeam,
-      homeScore: data.score?.[data.home_team] ?? 0,
-      awayScore: data.score?.[data.away_team] ?? 0,
+      homeTeam: homeObj.name || homeTeam,
+      awayTeam: awayObj.name || awayTeam,
+      homeScore: homeObj.score ?? data.score?.[homeObj.name] ?? 0,
+      awayScore: awayObj.score ?? data.score?.[awayObj.name] ?? 0,
+      homeTeamData: homeObj,
+      awayTeamData: awayObj,
     };
     showPopup(score);
   } catch (err) {

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -57,8 +57,10 @@ export function createGameScene(Phaser) {
 
       const simData = await res.json();
       console.log("📦 simData received:", simData);
+      const logHome = simData.homeTeam?.name || simData.home_team;
+      const logAway = simData.awayTeam?.name || simData.away_team;
       console.log(
-        `✅ Simulated matchup: ${simData.home_team} vs ${simData.away_team}`
+        `✅ Simulated matchup: ${logHome} vs ${logAway}`
       );
       console.log("📦 First turn:", simData.turns?.[0]);
 
@@ -99,9 +101,11 @@ export function createGameScene(Phaser) {
         console.log("✅ GameScene animation complete");
 
         // Extract score and winner
-        const homeScore = simData.score?.[simData.home_team] || 0;
-        const awayScore = simData.score?.[simData.away_team] || 0;
-        const winner = homeScore > awayScore ? simData.home_team : simData.away_team;
+        const homeTeamObj = simData.homeTeam || { name: simData.home_team };
+        const awayTeamObj = simData.awayTeam || { name: simData.away_team };
+        const homeScore = homeTeamObj.score ?? simData.score?.[homeTeamObj.name] || 0;
+        const awayScore = awayTeamObj.score ?? simData.score?.[awayTeamObj.name] || 0;
+        const winner = homeScore > awayScore ? homeTeamObj.name : awayTeamObj.name;
 
         // POST to /tournament/save-result
         if (this.tournamentId) {
@@ -128,11 +132,13 @@ export function createGameScene(Phaser) {
 
         // Expose final score and signal completion
         this.finalScore = {
-            homeTeam: simData.home_team,
-            awayTeam: simData.away_team,
+            homeTeam: homeTeamObj.name,
+            awayTeam: awayTeamObj.name,
             homeScore,
             awayScore,
-            winner
+            winner,
+            homeTeamData: homeTeamObj,
+            awayTeamData: awayTeamObj,
         };
         // Emit on the global game event emitter so external code can reliably
         // listen for completion even across scene restarts


### PR DESCRIPTION
## Summary
- Return `homeTeam` and `awayTeam` objects from `/api/simulate` and summary builders
- Include team objects (name, score, colors, id) in game summaries stored in Mongo
- Update Phaser game scenes to consume the new team objects and surface them with final score

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fdc05124c8328ba875ca89b594e98