### PR TITLE
Return franchise ID on team selection

### DIFF
--- a/BackEnd/api/franchise_routes.py
+++ b/BackEnd/api/franchise_routes.py
@@ -39,7 +39,7 @@ def select_team(selection: TeamSelection):
     franchise_state_collection.insert_one({"_id": "state", "team": selection.team_name})
     manager = FranchiseManager(db)
     manager.initialize_season()
-    return {"status": "ok"}
+    return {"status": "ok", "franchise_id": str(manager.franchise_id)}
 
 @router.get("/franchise/command-center")
 def command_center():

--- a/FrontEnd/static/franchise-select-team.js
+++ b/FrontEnd/static/franchise-select-team.js
@@ -34,6 +34,8 @@ async function selectTeam(team) {
       body: JSON.stringify({ team_name: team })
     });
     if (!res.ok) throw new Error("Failed to start franchise");
+    const data = await res.json();
+    localStorage.setItem("franchiseId", data.franchise_id);
     window.location.href = "/franchise/command-center";
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
## Summary
- include franchise ID in select team API response
- save franchise ID from selection API on the frontend

## Testing
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892359d61688328a3fbe033109306d2