### PR TITLE
Add franchise id to play-next-game request

### DIFF
--- a/BackEnd/api/franchise_routes.py
+++ b/BackEnd/api/franchise_routes.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, HTTPException
 from fastapi.responses import FileResponse, RedirectResponse
 from pydantic import BaseModel
 from pathlib import Path
+from bson import ObjectId
 
 from BackEnd.db import db, franchise_state_collection
 from BackEnd.models.franchise_manager import FranchiseManager
@@ -33,6 +34,9 @@ def get_select_team_page():
 class TeamSelection(BaseModel):
     team_name: str
 
+class PlayGameRequest(BaseModel):
+    franchise_id: str
+
 @router.post("/franchise/select-team")
 def select_team(selection: TeamSelection):
     franchise_state_collection.delete_many({})
@@ -52,11 +56,16 @@ def get_animation_page():
 
 
 @router.post("/franchise/play-next-game")
-def play_next_game():
+def play_next_game(req: PlayGameRequest):
     state = franchise_state_collection.find_one({"_id": "state"}) or {}
+    franchise_doc = db.franchises.find_one({"_id": ObjectId(req.franchise_id)})
+    if not franchise_doc:
+        raise HTTPException(status_code=404, detail="Franchise not found")
+
     manager = FranchiseManager(db)
-    manager.schedule = state.get("schedule", [])
-    manager.week = state.get("week", 1)
+    manager.schedule = franchise_doc.get("schedule", [])
+    manager.week = franchise_doc.get("week", 1)
+    manager.franchise_id = franchise_doc.get("_id")
 
     user_team_name = state.get("team")
     user_team_doc = db.teams.find_one({"name": user_team_name})

--- a/FrontEnd/static/franchise-command-center.js
+++ b/FrontEnd/static/franchise-command-center.js
@@ -9,6 +9,8 @@ async function fetchJSON(url) {
   }
 }
 
+let franchiseId = null;
+
 const teamMap = {
   "Four Corners": "FC",
   "Bentley-Truman": "BT",
@@ -184,7 +186,11 @@ playNowBtn.addEventListener('click', async () => {
   playNowBtn.disabled = true;
   playNowBtn.textContent = 'Loading...';
   try {
-    const res = await fetch('/franchise/play-next-game', { method: 'POST' });
+    const res = await fetch('/franchise/play-next-game', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ franchise_id: franchiseId })
+    });
     if (!res.ok) throw new Error('Simulation failed');
     const { home, away } = await res.json();
     if (!home || !away) throw new Error('Matchup not found');
@@ -197,4 +203,7 @@ playNowBtn.addEventListener('click', async () => {
   }
 });
 
-window.addEventListener('DOMContentLoaded', init);
+window.addEventListener('DOMContentLoaded', () => {
+  franchiseId = localStorage.getItem('franchiseId');
+  init();
+});


### PR DESCRIPTION
## Summary
- Retrieve franchise ID from local storage on the command center page and include it in the Play Game request.
- Add `PlayGameRequest` model and load franchise state from the `franchises` collection before running simulations.

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68923ea33b248328b3d6a2e0b3715283