### PR TITLE
Remove seed display and enlarge team logo on Franchise Command Center

### DIFF
--- a/FrontEnd/static/franchise-command-center.css
+++ b/FrontEnd/static/franchise-command-center.css
@@ -1,0 +1,26 @@
+#franchise-container #top-left {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: 200px;
+}
+
+#franchise-container #top-left .team-logo {
+  height: 70%;
+  width: auto;
+  margin-bottom: 10px;
+  object-fit: contain;
+}
+
+#franchise-container #top-left .left-info {
+  width: 100%;
+  display: flex;
+  justify-content: flex-start;
+  font-weight: bold;
+}
+
+@media (max-width: 600px) {
+  #franchise-container #top-left {
+    height: 150px;
+  }
+}

--- a/FrontEnd/static/franchise-command-center.html
+++ b/FrontEnd/static/franchise-command-center.html
@@ -6,6 +6,7 @@
   <title>Franchise Command Center</title>
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/static/tournament.css">
+  <link rel="stylesheet" href="/static/franchise-command-center.css">
 </head>
 <body>
   <div id="franchise-container">
@@ -14,7 +15,6 @@
         <img id="team-logo" src="" alt="Team Logo" class="team-logo">
         <div class="left-info">
           <span class="username">Username</span>
-          <span class="seed">Seed: --</span>
         </div>
       </div>
       <div id="top-center">

--- a/FrontEnd/static/franchise-command-center.js
+++ b/FrontEnd/static/franchise-command-center.js
@@ -27,7 +27,6 @@ const teamIdNameMap = {};
 function populateTop(data) {
   if (!data) return;
   document.querySelector('.username').textContent = data.username || 'User';
-  document.querySelector('.seed').textContent = `Seed: ${data.seed || '--'}`;
   document.getElementById('team-logo').src = `/static/images/homepage-logos/${data.team}.png`;
 
   const abbr = teamMap[data.team];


### PR DESCRIPTION
## Summary
- remove seed identifier from franchise command center UI
- add scoped styles so team logo fills 70% of its section and stays centered
- keep coach label left aligned under the logo

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897c39ecf6883288d3e1e9eeae4553b