### PR TITLE
Include franchise in standings and schedule calls

### DIFF
--- a/FrontEnd/static/franchise-command-center.js
+++ b/FrontEnd/static/franchise-command-center.js
@@ -172,8 +172,12 @@ async function init() {
   if (topData && topData.team) {
     renderTeam(await fetchJSON(`/roster/${encodeURIComponent(topData.team)}`));
   }
-  renderStandings(await fetchJSON('/franchise/standings'));
-  renderSchedule(await fetchJSON('/franchise/schedule'));
+  const standingsData = await fetchJSON(`/franchise/standings?franchise_id=${franchiseId}`);
+  console.log("standings keys", Object.keys(standingsData || {}));
+  renderStandings(standingsData);
+  const scheduleData = await fetchJSON(`/franchise/schedule?franchise_id=${franchiseId}`);
+  console.log("schedule keys", Object.keys(scheduleData || {}));
+  renderSchedule(scheduleData);
   renderLeaders(await fetchJSON('/franchise/leaders'));
   renderTeamStats(await fetchJSON('/franchise/team-stats'));
   renderRecruits(await fetchJSON('/franchise/recruits'));


### PR DESCRIPTION
## Summary
- Pass franchise ID when fetching standings and schedule data
- Log returned standings and schedule keys for debugging

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897d08ad7b48328b63feb2fc24c7c88