### PR TITLE
Normalize franchise command center asset paths

### DIFF
--- a/FrontEnd/static/common.js
+++ b/FrontEnd/static/common.js
@@ -1,0 +1,8 @@
+function formatTeamName(name) {
+  return (name || '')
+    .toLowerCase()
+    .replace(/_/g, ' ')
+    .split(' ')
+    .map(w => w.split('-').map(s => s.charAt(0).toUpperCase() + s.slice(1)).join('-'))
+    .join(' ');
+}

--- a/FrontEnd/static/franchise-command-center.html
+++ b/FrontEnd/static/franchise-command-center.html
@@ -101,6 +101,7 @@
     </div>
   </div>
 
+  <script src="/static/common.js"></script>
   <script src="/static/franchise-command-center.js"></script>
   <script>
     const tabButtons = document.querySelectorAll('.tab-buttons button');

--- a/FrontEnd/static/franchise-command-center.js
+++ b/FrontEnd/static/franchise-command-center.js
@@ -27,14 +27,23 @@ const teamIdNameMap = {};
 function populateTop(data) {
   if (!data) return;
   document.querySelector('.username').textContent = data.username || 'User';
-  document.getElementById('team-logo').src = `/static/images/homepage-logos/${data.team}.png`;
+  const formattedTeam = formatTeamName(data.team);
+  const logoSrc = `/static/images/homepage-logos/${formattedTeam}.png`;
+  document.getElementById('team-logo').src = logoSrc;
+  console.log('Team logo URL:', logoSrc);
 
-  const abbr = teamMap[data.team];
+  const abbr = teamMap[formattedTeam];
   const sammyEl = document.getElementById('coach-sammy');
   const dukeEl = document.getElementById('coach-duke');
   if (abbr) {
-    if (sammyEl) sammyEl.src = `/static/images/coaches/${abbr}/Sammy-${abbr}.png`;
-    if (dukeEl) dukeEl.src = `/static/images/coaches/${abbr}/Duke-${abbr}.png`;
+    if (sammyEl) {
+      sammyEl.src = `/static/images/coaches/${abbr}/Sammy-${abbr}.png`;
+      console.log('Coach Sammy URL:', sammyEl.src);
+    }
+    if (dukeEl) {
+      dukeEl.src = `/static/images/coaches/${abbr}/Duke-${abbr}.png`;
+      console.log('Coach Duke URL:', dukeEl.src);
+    }
   } else {
     if (sammyEl) sammyEl.removeAttribute('src');
     if (dukeEl) dukeEl.removeAttribute('src');

--- a/FrontEnd/static/tournament.html
+++ b/FrontEnd/static/tournament.html
@@ -112,6 +112,7 @@
 
   </div> <!-- end tournament-container -->
 
+  <script src="/static/common.js"></script>
   <script src="/static/tournament.js"></script>
   <script>
     const tabButtons = document.querySelectorAll('.tab-buttons button');

--- a/FrontEnd/static/tournament.js
+++ b/FrontEnd/static/tournament.js
@@ -13,15 +13,6 @@ const teamMap = {
   "Xavien": "Xav",
 };
 
-function formatTeamName(name) {
-  if (!name) return "";
-  return name
-    .toLowerCase()
-    .split(" ")
-    .map(w => w.split("-").map(s => s.charAt(0).toUpperCase() + s.slice(1)).join("-"))
-    .join(" ");
-}
-
 function isUserTeam(teamName) {
   return teamName === userTeamId;
 }


### PR DESCRIPTION
## Summary
- share team name normalizer across tournament and franchise pages
- compute logo and coach image URLs from normalized names and log the final paths

## Testing
- `pytest tests/test_franchise_manager.py` *(fails: ModuleNotFoundError: No module named 'BackEnd')*

------
https://chatgpt.com/codex/tasks/task_e_6897cda4893c8328ba37101e628d6824