### PR TITLE
Align command center headers

### DIFF
--- a/FrontEnd/static/franchise-command-center.css
+++ b/FrontEnd/static/franchise-command-center.css
@@ -1,7 +1,8 @@
 #franchise-container #top-left {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
+  justify-content: flex-start;
   height: 200px;
 }
 

--- a/FrontEnd/static/tournament.css
+++ b/FrontEnd/static/tournament.css
@@ -27,6 +27,7 @@ h1, h2, h3, h4, h5, h6 {
   margin-bottom: 20px;
   position: relative;
   z-index: 1;
+  align-items: center;
 }
 
 #top-left {
@@ -56,7 +57,7 @@ h1, h2, h3, h4, h5, h6 {
 .left-info {
   display: flex;
   width: 100%;
-  justify-content: space-between;
+  justify-content: flex-start;
   font-weight: bold;
 }
 
@@ -64,6 +65,7 @@ h1, h2, h3, h4, h5, h6 {
   display: flex;
   flex-direction: column;
   justify-content: center;
+  align-items: center;
 }
 
 .chemistry-label {


### PR DESCRIPTION
## Summary
- left-align team logo and coach label in franchise command center
- center chemistry bar and ratings and coach section around team logo

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898ad561ba48328bdb54f8b7fcfe45a