### PR TITLE
Run instant simulations when users skip animations

### DIFF
--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -34,6 +34,7 @@ console.log('🏀 Launch params:', {
 const GameScene = createGameScene(Phaser);
 let game;
 let gamePromise;
+let isSimulating = false;
 
 
 async function fetchTeamRoster(teamName) {
@@ -48,7 +49,7 @@ async function fetchTeamRoster(teamName) {
   return res.json();
 }
 
-async function startGameAnimation({ homeRoster, awayRoster }) {
+async function startGame({ homeRoster, awayRoster, animate = true }) {
   if (!game) {
     game = new Phaser.Game({
       type: Phaser.AUTO,
@@ -68,6 +69,7 @@ async function startGameAnimation({ homeRoster, awayRoster }) {
     franchiseId,
     homeTeam,
     awayTeam,
+    animate,
   };
 
   if (game.scene.isActive('GameScene')) {
@@ -117,11 +119,14 @@ function showPopup(score) {
 }
 
 async function playGame() {
+  if (isSimulating) return;
+  isSimulating = true;
   playBtn.style.display = 'none';
   resultsBtn.style.display = 'none';
 
   if (!homeTeam || !awayTeam) {
     alert('Please select teams before playing.');
+    isSimulating = false;
     return;
   }
 
@@ -130,35 +135,32 @@ async function playGame() {
     fetchTeamRoster(awayTeam),
   ]);
 
-  const score = await startGameAnimation({ homeRoster, awayRoster });
+  const score = await startGame({ homeRoster, awayRoster, animate: true });
   if (score) {
     showPopup(score);
   }
 }
 
 async function showResults() {
+  if (isSimulating) return;
+  isSimulating = true;
   playBtn.style.display = 'none';
   resultsBtn.style.display = 'none';
-  try {
-    const query = buildQuery({
-      tournament_id: mode === 'tournament' ? tournamentId : null,
-      franchise_id: mode === 'franchise' ? franchiseId : null,
-    });
-    const res = await fetch(`/game/result${query}`);
-    const data = await res.json();
-    const homeObj = data.homeTeam || { name: data.home_team };
-    const awayObj = data.awayTeam || { name: data.away_team };
-    const score = {
-      homeTeam: homeObj.name || homeTeam,
-      awayTeam: awayObj.name || awayTeam,
-      homeScore: homeObj.score ?? data.score?.[homeObj.name] ?? 0,
-      awayScore: awayObj.score ?? data.score?.[awayObj.name] ?? 0,
-      homeTeamData: homeObj,
-      awayTeamData: awayObj,
-    };
+
+  if (!homeTeam || !awayTeam) {
+    alert('Please select teams before playing.');
+    isSimulating = false;
+    return;
+  }
+
+  const [homeRoster, awayRoster] = await Promise.all([
+    fetchTeamRoster(homeTeam),
+    fetchTeamRoster(awayTeam),
+  ]);
+
+  const score = await startGame({ homeRoster, awayRoster, animate: false });
+  if (score) {
     showPopup(score);
-  } catch (err) {
-    console.error('Failed to fetch results', err);
   }
 }
 

--- a/FrontEnd/static/js/phaser/finalizeGame.js
+++ b/FrontEnd/static/js/phaser/finalizeGame.js
@@ -1,0 +1,68 @@
+export async function finalizeGame({ simData, tournamentId, franchiseId, game }) {
+  // Extract score and winner
+  const homeTeamObj = simData.homeTeam || { name: simData.home_team };
+  const awayTeamObj = simData.awayTeam || { name: simData.away_team };
+  const homeScore = (homeTeamObj.score ?? simData.score?.[homeTeamObj.name]) || 0;
+  const awayScore = (awayTeamObj.score ?? simData.score?.[awayTeamObj.name]) || 0;
+  const winner = homeScore > awayScore ? homeTeamObj.name : awayTeamObj.name;
+
+  // POST to /tournament/save-result if needed
+  if (tournamentId) {
+    try {
+      const res = await fetch("/tournament/save-result", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          tournament_id: tournamentId,
+          game_id: simData._id,
+          winner: winner,
+        }),
+      });
+      if (!res.ok) {
+        console.error("❌ Failed to save tournament result:", await res.text());
+      } else {
+        console.log("✅ Tournament result saved.");
+      }
+    } catch (err) {
+      console.error("🚨 Error during tournament result save:", err);
+    }
+  }
+
+  // POST to /franchise/save-result if needed
+  if (franchiseId) {
+    try {
+      const res = await fetch("/franchise/save-result", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          franchise_id: franchiseId,
+          game_id: simData._id,
+          winner: winner,
+        }),
+      });
+      if (!res.ok) {
+        console.error("❌ Failed to save franchise result:", await res.text());
+      } else {
+        console.log("✅ Franchise result saved.");
+      }
+    } catch (err) {
+      console.error("🚨 Error during franchise result save:", err);
+    }
+  }
+
+  const finalScore = {
+    homeTeam: homeTeamObj.name,
+    awayTeam: awayTeamObj.name,
+    homeScore,
+    awayScore,
+    winner,
+    homeTeamData: homeTeamObj,
+    awayTeamData: awayTeamObj,
+  };
+
+  if (game && game.events) {
+    game.events.emit("gameComplete", finalScore);
+  }
+
+  return finalScore;
+}

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -1,6 +1,7 @@
 import { animateGameTurns } from './animation/animateGameTurns.js';
 import { loadPhaserPlayers } from './setup/loadPhaserPlayers.js';
 import { gridToPixels } from './utils/gridToPixels.js';
+import { finalizeGame } from './finalizeGame.js';
 
 export function createGameScene(Phaser) {
   return class GameScene extends Phaser.Scene {
@@ -14,6 +15,7 @@ export function createGameScene(Phaser) {
         this.franchiseId = data.franchiseId;
         this.homeTeam = data.homeTeam;
         this.awayTeam = data.awayTeam;
+        this.animate = data.animate !== false;
 
         console.log("🧠 Game initialized with:", {
           rosters: this.rosters,
@@ -21,16 +23,19 @@ export function createGameScene(Phaser) {
           franchiseId: this.franchiseId,
           homeTeam: this.homeTeam,
           awayTeam: this.awayTeam,
+          animate: this.animate,
         });
       }
       
 
     async preload() {
       console.log("✅ GameScene preloaded");
-      this.load.image("ball", "/static/images/ball.png");
-      const normalizeTeamName = (name) => name.toLowerCase().replace(/[\s\-]/g, '_');
-      const teamId = normalizeTeamName(this.homeTeam);
-      this.load.image("court-bg", `/static/images/courts/${teamId}.jpg`);
+      if (this.animate) {
+        this.load.image("ball", "/static/images/ball.png");
+        const normalizeTeamName = (name) => name.toLowerCase().replace(/[\s\-]/g, '_');
+        const teamId = normalizeTeamName(this.homeTeam);
+        this.load.image("court-bg", `/static/images/courts/${teamId}.jpg`);
+      }
 
     }
 
@@ -66,125 +71,74 @@ export function createGameScene(Phaser) {
       );
       console.log("📦 First turn:", simData.turns?.[0]);
 
-      const courtKey = "court-bg";
-
-      const startAnimation = async () => {
-        this.playerSprites = loadPhaserPlayers(this, simData.players, {
-        home: {
-            player_ids: simData.players.filter(p => p.team === "home").map(p => p.playerId),
-            primary_color: simData.home_team_colors.primary_color,
-            secondary_color: simData.home_team_colors.secondary_color
-        },
-        away: {
-            player_ids: simData.players.filter(p => p.team === "away").map(p => p.playerId),
-            primary_color: simData.away_team_colors.primary_color,
-            secondary_color: simData.away_team_colors.secondary_color
-        }
-        }, Phaser);
-
-        this.ballSprite = this.add.image(0, 0, "ball").setVisible(true).setDepth(1000).setScale(1);
-
-        this.tweens.add({
-        targets: this.ballSprite,
-        scale: { from: 1, to: 1.3 },
-        duration: 400,
-        yoyo: true,
-        repeat: -1,
-        ease: 'Sine.easeInOut'
+      const finalize = async () => {
+        const finalScore = await finalizeGame({
+          simData,
+          tournamentId: this.tournamentId,
+          franchiseId: this.franchiseId,
+          game: this.game,
         });
-
-        await animateGameTurns({
-        scene: this,
-        simData,
-        playerSprites: this.playerSprites,
-        ballSprite: this.ballSprite
-        });
-
-        console.log("✅ GameScene animation complete");
-
-        // Extract score and winner
-        const homeTeamObj = simData.homeTeam || { name: simData.home_team };
-        const awayTeamObj = simData.awayTeam || { name: simData.away_team };
-        const homeScore = (homeTeamObj.score ?? simData.score?.[homeTeamObj.name]) || 0;
-        const awayScore = (awayTeamObj.score ?? simData.score?.[awayTeamObj.name]) || 0;
-        const winner = homeScore > awayScore ? homeTeamObj.name : awayTeamObj.name;
-
-        // POST to /tournament/save-result
-        if (this.tournamentId) {
-        try {
-            const res = await fetch("/tournament/save-result", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-                tournament_id: this.tournamentId,
-                game_id: simData._id,  // make sure _id is included in your /simulate response
-                winner: winner
-            })
-            });
-
-        if (!res.ok) {
-            console.error("❌ Failed to save tournament result:", await res.text());
-            } else {
-            console.log("✅ Tournament result saved.");
-            }
-        } catch (err) {
-            console.error("🚨 Error during tournament result save:", err);
-        }
-        }
-
-        // POST to /franchise/save-result
-        if (this.franchiseId) {
-        try {
-            const res = await fetch("/franchise/save-result", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-                franchise_id: this.franchiseId,
-                game_id: simData._id,
-                winner: winner
-            })
-            });
-
-        if (!res.ok) {
-            console.error("❌ Failed to save franchise result:", await res.text());
-            } else {
-            console.log("✅ Franchise result saved.");
-            }
-        } catch (err) {
-            console.error("🚨 Error during franchise result save:", err);
-        }
-        }
-
-        // Expose final score and signal completion
-        this.finalScore = {
-            homeTeam: homeTeamObj.name,
-            awayTeam: awayTeamObj.name,
-            homeScore,
-            awayScore,
-            winner,
-            homeTeamData: homeTeamObj,
-            awayTeamData: awayTeamObj,
-        };
-        // Emit on the global game event emitter so external code can reliably
-        // listen for completion even across scene restarts
-        this.game.events.emit('gameComplete', this.finalScore);
+        this.finalScore = finalScore;
       };
 
-      if (this.textures.exists(courtKey)) {
-        this.add.image(0, 0, courtKey)
-            .setOrigin(0)
-            .setDisplaySize(this.game.config.width, this.game.config.height)
-            .setDepth(0);
-        startAnimation();
+      if (this.animate) {
+        const courtKey = "court-bg";
+
+        const startAnimation = async () => {
+          this.playerSprites = loadPhaserPlayers(this, simData.players, {
+            home: {
+              player_ids: simData.players.filter(p => p.team === "home").map(p => p.playerId),
+              primary_color: simData.home_team_colors.primary_color,
+              secondary_color: simData.home_team_colors.secondary_color
+            },
+            away: {
+              player_ids: simData.players.filter(p => p.team === "away").map(p => p.playerId),
+              primary_color: simData.away_team_colors.primary_color,
+              secondary_color: simData.away_team_colors.secondary_color
+            }
+          }, Phaser);
+
+          this.ballSprite = this.add.image(0, 0, "ball").setVisible(true).setDepth(1000).setScale(1);
+
+          this.tweens.add({
+            targets: this.ballSprite,
+            scale: { from: 1, to: 1.3 },
+            duration: 400,
+            yoyo: true,
+            repeat: -1,
+            ease: 'Sine.easeInOut'
+          });
+
+          await animateGameTurns({
+            scene: this,
+            simData,
+            playerSprites: this.playerSprites,
+            ballSprite: this.ballSprite
+          });
+
+          console.log("✅ GameScene animation complete");
+
+          await finalize();
+        };
+
+        if (this.textures.exists(courtKey)) {
+          this.add.image(0, 0, courtKey)
+              .setOrigin(0)
+              .setDisplaySize(this.game.config.width, this.game.config.height)
+              .setDepth(0);
+          startAnimation();
+        } else {
+          this.load.once("complete", () => {
+              this.add.image(0, 0, courtKey)
+              .setOrigin(0)
+              .setDisplaySize(this.game.config.width, this.game.config.height)
+              .setDepth(0);
+              startAnimation();
+          });
+          this.load.start();
+        }
       } else {
-        this.load.once("complete", () => {
-            this.add.image(0, 0, courtKey)
-            .setOrigin(0)
-            .setDisplaySize(this.game.config.width, this.game.config.height)
-            .setDepth(0);
-            startAnimation();
-        });
-        this.load.start();
+        await finalize();
       }
     }
   };


### PR DESCRIPTION
## Summary
- Allow game to simulate without animations by adding an `animate` flag
- Share end-of-game logic in new `finalizeGame` helper and reuse for instant results
- Guard against double clicks while simulations are running

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898b9bbaa2c8328a401a3bb25062f05