### PR TITLE
Use stored franchiseId for navigation

### DIFF
--- a/FrontEnd/static/franchise-command-center.js
+++ b/FrontEnd/static/franchise-command-center.js
@@ -193,11 +193,18 @@ async function init() {
 }
 
 const playNowBtn = document.getElementById('play-now');
+playNowBtn.disabled = true;
 playNowBtn.addEventListener('click', async () => {
   console.log('Play Now click search:', window.location.search);
   const originalText = playNowBtn.textContent;
   playNowBtn.disabled = true;
   playNowBtn.textContent = 'Loading...';
+  if (!franchiseId) {
+    alert('Franchise not loaded');
+    playNowBtn.disabled = false;
+    playNowBtn.textContent = originalText;
+    return;
+  }
   try {
     const res = await fetch('/franchise/play-next-game', {
       method: 'POST',
@@ -220,5 +227,8 @@ playNowBtn.addEventListener('click', async () => {
 
 window.addEventListener('DOMContentLoaded', () => {
   franchiseId = localStorage.getItem('franchiseId');
+  if (franchiseId) {
+    playNowBtn.disabled = false;
+  }
   init();
 });

--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -18,7 +18,10 @@ function buildQuery(params = {}) {
 
 const urlParams = new URLSearchParams(window.location.search);
 const tournamentId = urlParams.get('tournament_id');
-const franchiseId = urlParams.get('franchise_id');
+let franchiseId = urlParams.get('franchise_id');
+if (!franchiseId) {
+  franchiseId = localStorage.getItem('franchiseId');
+}
 const homeTeam = urlParams.get('home');
 const awayTeam = urlParams.get('away');
 const mode = getMode({ tournamentId, franchiseId });

--- a/tests/test_frontend_navigation.py
+++ b/tests/test_frontend_navigation.py
@@ -1,0 +1,34 @@
+import json
+import subprocess
+from pathlib import Path
+
+def test_game_returns_to_command_center_when_franchise_id_missing():
+    boot_path = Path('FrontEnd/static/js/phaser/bootGame.js').resolve()
+    node_script = f"""
+const fs = require('fs');
+let script = fs.readFileSync({json.dumps(str(boot_path))}, 'utf8');
+script = script.replace(/^import[^\\n]*\\n/gm, '');
+const localStorageStore = {{ franchiseId: 'test123' }};
+global.localStorage = {{ getItem: (k) => localStorageStore[k] }};
+const container = {{ appended: null, appendChild(el) {{ this.appended = el; }} }};
+global.document = {{
+  getElementById(id) {{ if (id === 'phaser-container') return container; return null; }},
+  createElement(tag) {{ return {{ className: '', innerHTML: '', appendChild(){{}} }}; }},
+  querySelector(sel) {{ return null; }}
+}};
+ global.window = {{ location: {{ search: '' }} }};
+ global.createGameScene = () => function GameScene(){{}};
+ global.Phaser = {{}};
+ const originalLog = console.log;
+ console.log = () => {{}};
+ require('vm').runInThisContext(script);
+ showPopup({{homeTeam:'A',homeScore:1,awayTeam:'B',awayScore:2}});
+ const href = container.appended.innerHTML.match(/href=\\"([^\\"]+)/)[1];
+ console.log = originalLog;
+ console.log(JSON.stringify({{ mode, href }}));
+"""
+    result = subprocess.check_output(['node', '-e', node_script])
+    data = json.loads(result.decode().strip())
+    assert data['mode'] == 'franchise'
+    assert data['href'] == '/franchise/command-center?franchise_id=test123'
+


### PR DESCRIPTION
## Summary
- fall back to localStorage franchiseId when query param missing in court boot
- disable Play Now until franchiseId loads and guard against missing IDs
- add regression test ensuring command center navigation retains franchise context

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898e889d53c8328bda686629652eaca