### PR TITLE
Align score map handling across backend and frontend

### DIFF
--- a/BackEnd/api/api.py
+++ b/BackEnd/api/api.py
@@ -92,15 +92,22 @@ def simulate_game(request: SimulationRequest):
     # print("🧪 Turns sample:", game.turns[:3])
     summary = summarize_game_state(game)
 
-    # Ensure team objects exist for the frontend
+    # Build a consolidated score map from available sources
+    score_map = summary.get("final_score") or summary.get("score") or {}
+
+    # Ensure team objects exist for the frontend and populate scores
     summary["homeTeam"] = summary.get("homeTeam") or {
         "name": summary.get("home_team", home_team),
-        "score": summary.get("score", {}).get(home_team, 0),
     }
+    summary["homeTeam"]["score"] = score_map.get(summary["homeTeam"]["name"], 0)
+
     summary["awayTeam"] = summary.get("awayTeam") or {
         "name": summary.get("away_team", away_team),
-        "score": summary.get("score", {}).get(away_team, 0),
     }
+    summary["awayTeam"]["score"] = score_map.get(summary["awayTeam"]["name"], 0)
+
+    # Expose the score map under a consistent key
+    summary["score"] = score_map
 
     # ✅ Minimal debug visibility
     # print(f"✅ Game finished: {home_team} vs. {away_team}")

--- a/FrontEnd/static/js/phaser/finalizeGame.js
+++ b/FrontEnd/static/js/phaser/finalizeGame.js
@@ -2,8 +2,9 @@ export async function finalizeGame({ simData, tournamentId, franchiseId, game })
   // Extract score and winner
   const homeTeamObj = simData.homeTeam || { name: simData.home_team };
   const awayTeamObj = simData.awayTeam || { name: simData.away_team };
-  const homeScore = (homeTeamObj.score ?? simData.score?.[homeTeamObj.name]) || 0;
-  const awayScore = (awayTeamObj.score ?? simData.score?.[awayTeamObj.name]) || 0;
+  const scoreMap = simData.final_score || simData.score || {};
+  const homeScore = homeTeamObj.score ?? scoreMap[homeTeamObj.name] ?? 0;
+  const awayScore = awayTeamObj.score ?? scoreMap[awayTeamObj.name] ?? 0;
   const winner = homeScore > awayScore ? homeTeamObj.name : awayTeamObj.name;
 
   // POST to /tournament/save-result if needed


### PR DESCRIPTION
## Summary
- consolidate score sources in simulate_game and expose consistent summary score
- use final_score or score map in finalizeGame to derive final scores

## Testing
- `PYTHONPATH=. pytest`
- `node testFinalize.mjs` *(manual invocation removed; see logs above)*
- `curl http://localhost:8000/FrontEnd/static/court.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6898f1d4ea388328898a033cbf2c6f2e