### PR TITLE
Fix post-game navigation for single game mode

### DIFF
--- a/FrontEnd/static/homepage.js
+++ b/FrontEnd/static/homepage.js
@@ -131,7 +131,8 @@ playBtn.addEventListener('click', () => {
 
   const params = new URLSearchParams({
     home: homeTeam,
-    away: awayTeam
+    away: awayTeam,
+    mode: 'single'
   });
 
   if (homeCheck.checked || awayCheck.checked) {

--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -6,11 +6,13 @@ const urlParams = new URLSearchParams(window.location.search);
 const tournamentId = urlParams.get("tournament_id");
 const homeTeam = urlParams.get("home");
 const awayTeam = urlParams.get("away");
+const mode = urlParams.get("mode");
 
 console.log("🏀 Tournament launch params:", {
   tournamentId,
   homeTeam,
-  awayTeam
+  awayTeam,
+  mode
 });
 
 const GameScene = createGameScene(Phaser);  // ✅ Moved this up
@@ -52,7 +54,8 @@ async function initTournamentGame() {
     rosters: { homeRoster, awayRoster },
     tournamentId,
     homeTeam,
-    awayTeam
+    awayTeam,
+    mode
   });
 }
 

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -13,12 +13,14 @@ export function createGameScene(Phaser) {
         this.tournamentId = data.tournamentId;
         this.homeTeam = data.homeTeam;
         this.awayTeam = data.awayTeam;
+        this.mode = data.mode;
 
         console.log("🧠 Game initialized with:", {
           rosters: this.rosters,
           tournamentId: this.tournamentId,
           homeTeam: this.homeTeam,
           awayTeam: this.awayTeam,
+          mode: this.mode,
         });
       }
       
@@ -124,6 +126,14 @@ export function createGameScene(Phaser) {
         } catch (err) {
             console.error("🚨 Error during tournament result save:", err);
         }
+        }
+
+        // Show final score and navigate
+        alert(`Final Score — ${homeTeam} ${homeScore} | ${awayTeam} ${awayScore}`);
+        if (this.mode === 'single') {
+          window.location.href = 'index.html';
+        } else if (!this.tournamentId) {
+          window.location.href = '/franchise/command-center';
         }
       };
 


### PR DESCRIPTION
## Summary
- ensure single game launches with mode flag
- pass mode through phaser boot and scene
- redirect single game results back to team select instead of franchise command center

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898f45832f4832882d460a91633172c