### PR TITLE
Ensure animated game finalization emits completion event

### DIFF
--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -117,43 +117,8 @@ export function createGameScene(Phaser) {
           });
 
           console.log("✅ GameScene animation complete");
-
-        // Extract score and winner
-        const homeScore = simData.score?.[simData.home_team] || 0;
-        const awayScore = simData.score?.[simData.away_team] || 0;
-        const winner = homeScore > awayScore ? simData.home_team : simData.away_team;
-
-        // POST to /tournament/save-result
-        if (this.tournamentId) {
-        try {
-            const res = await fetch("/tournament/save-result", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-                tournament_id: this.tournamentId,
-                game_id: simData._id,  // make sure _id is included in your /simulate response
-                winner: winner
-            })
-            });
-
-            if (!res.ok) {
-            console.error("❌ Failed to save tournament result:", await res.text());
-            } else {
-            console.log("✅ Tournament result saved.");
-            }
-        } catch (err) {
-            console.error("🚨 Error during tournament result save:", err);
-        }
-        }
-
-        // Show final score and navigate
-        alert(`Final Score — ${homeTeam} ${homeScore} | ${awayTeam} ${awayScore}`);
-        if (this.mode === 'single') {
-          window.location.href = 'index.html';
-        } else if (!this.tournamentId) {
-          window.location.href = '/franchise/command-center';
-        }
-      };
+          await finalize();
+        };
 
         if (this.textures.exists(courtKey)) {
           this.add.image(0, 0, courtKey)


### PR DESCRIPTION
## Summary
- Call `finalize()` after `animateGameTurns` so animated games emit `gameComplete`
- Remove manual score handling and redirects; rely on `finalizeGame`

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689904fdcb748328b47fae3f92d7b760