### PR TITLE
Handle game start errors in bootGame.js

### DIFF
--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -41,6 +41,7 @@ console.log("🏀 Tournament launch params:", {
 
 const GameScene = createGameScene(Phaser);
 let game;
+let isSimulating = false;
 
 
 async function fetchTeamRoster(teamName) {
@@ -123,12 +124,26 @@ function showPopup(score) {
 }
 
 async function handleButtonClick(animate) {
-  const [homeRoster, awayRoster] = await Promise.all([
-    fetchTeamRoster(homeTeam),
-    fetchTeamRoster(awayTeam),
-  ]);
-  const finalScore = await startGame({ homeRoster, awayRoster, animate });
-  showPopup(finalScore);
+  if (isSimulating) return;
+  isSimulating = true;
+  const playBtn = document.querySelector('.play-button');
+  const resultsBtn = document.querySelector('.results-button');
+  if (playBtn) playBtn.style.display = 'none';
+  if (resultsBtn) resultsBtn.style.display = 'none';
+
+  try {
+    const [homeRoster, awayRoster] = await Promise.all([
+      fetchTeamRoster(homeTeam),
+      fetchTeamRoster(awayTeam),
+    ]);
+    const finalScore = await startGame({ homeRoster, awayRoster, animate });
+    showPopup(finalScore);
+  } catch (err) {
+    console.error('Error starting game:', err);
+    isSimulating = false;
+    if (playBtn) playBtn.style.display = '';
+    if (resultsBtn) resultsBtn.style.display = '';
+  }
 }
 
 function initGame() {


### PR DESCRIPTION
## Summary
- Track simulation state to avoid duplicate clicks
- Wrap roster fetch and game start in try/catch and restore buttons on failure

## Testing
- `PYTHONPATH=/workspace/gob-simplified pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899074a39188328ad17e63dfd89d458