### PR TITLE
Capture animate flag for GameScene

### DIFF
--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -15,6 +15,7 @@ export function createGameScene(Phaser) {
         this.franchiseId = data.franchiseId;
         this.homeTeam = data.homeTeam;
         this.awayTeam = data.awayTeam;
+        this.animate = data.animate;
         this.mode = data.mode;
 
         console.log("🧠 Game initialized with:", {


### PR DESCRIPTION
## Summary
- pass along animate flag in GameScene init to control playback
- preload and create methods respect animate for Play Game vs. See Results modes

## Testing
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_68990d0f7ce08328a3ffc9fd48dea9b3