### PR TITLE
Add test verifying RecruitManager default names loading

### DIFF
--- a/tests/test_recruit_manager.py
+++ b/tests/test_recruit_manager.py
@@ -1,0 +1,19 @@
+import json
+from importlib import resources
+
+from BackEnd.models.franchise_manager import RecruitManager
+
+
+def test_recruit_manager_loads_default_names():
+    rm = RecruitManager(db=None)
+    resource_path = resources.files("BackEnd").joinpath("data", "names", "franchise_names.json")
+    with resource_path.open("r") as f:
+        payload = json.load(f)
+
+    fallback_first = ["Jalen", "Marcus", "Tyrese", "Zion", "Cade"]
+    fallback_last = ["Walker", "Jackson", "Robinson", "Wright", "Anderson"]
+
+    assert rm.first_names == payload["first_names"]
+    assert rm.last_names == payload["last_names"]
+    assert rm.first_names != fallback_first
+    assert rm.last_names != fallback_last


### PR DESCRIPTION
## Summary
- add unit test for RecruitManager to ensure it loads first/last names from bundled franchise_names.json when no custom file is provided and ignores fallback names

## Testing
- `PYTHONPATH=. pytest tests/test_recruit_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68992848340c8328aec359256dd1db75