### PR TITLE
Fix recruit name loading

### DIFF
--- a/BackEnd/models/franchise_manager.py
+++ b/BackEnd/models/franchise_manager.py
@@ -151,11 +151,20 @@ class RecruitManager:
         self.first_names, self.last_names = fallback_first, fallback_last
 
         try:
-            resource_path = Path(names_file) if names_file is not None else resources.files("BackEnd").joinpath(
-                "data", "names", "franchise_names.json"
-            )
-            with resource_path.open("r") as f:
+            if names_file is not None:
+                resource_path = Path(names_file)
+            else:
+                try:
+                    resource_path = resources.files("BackEnd").joinpath(
+                        "data", "names", "franchise_names.json"
+                    )
+                except Exception:
+                    # Fallback to filesystem path relative to this file
+                    resource_path = Path(__file__).resolve().parent.parent / "data" / "names" / "franchise_names.json"
+
+            with resource_path.open("r", encoding="utf-8") as f:
                 payload = json.load(f)
+
             # Expect keys: "first_names", "last_names"
             fn = payload.get("first_names") or []
             ln = payload.get("last_names") or []


### PR DESCRIPTION
## Summary
- ensure `RecruitManager` loads `franchise_names.json` reliably
- support fallback to module-relative path and explicit UTF-8 decoding

## Testing
- `PYTHONPATH=. pytest tests/test_recruit_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68992c54e608832888f365349fec4d29