### PR TITLE
Simulate remaining tournament round and log results

### DIFF
--- a/BackEnd/api/tournament_routes.py
+++ b/BackEnd/api/tournament_routes.py
@@ -106,6 +106,14 @@ def simulate_round(request: SimulateRequest):
 
 @router.post("/tournament/save-result")
 def save_result(request: TournamentResultRequest):
+    """Save the user's game result, simulate remaining games in the round and
+    persist all results to the tournament document.
+
+    Each result entry includes home/away team, score, winner, round number and
+    match index. A log message is printed for each database write indicating
+    success or failure.
+    """
+
     from bson import ObjectId
 
     tournament_id = ObjectId(request.tournament_id)
@@ -114,19 +122,92 @@ def save_result(request: TournamentResultRequest):
     if not tournament:
         raise HTTPException(status_code=404, detail="Tournament not found")
 
-    # find and update the user’s game in the current round
-    round_key = f"round{tournament['current_round']}"
+    round_num = tournament["current_round"]
+    round_key = f"round{round_num}"
+
+    manager = TournamentManager(tournaments_collection=tournaments_collection)
+    manager.tournament = tournament
+    manager.tournament_id = tournament_id
+
+    def _log_result(result_doc):
+        try:
+            update_result = tournaments_collection.update_one(
+                {"_id": tournament_id}, {"$push": {"results": result_doc}}
+            )
+            if update_result.modified_count == 1:
+                print(
+                    f"✅ Saved result for round {result_doc['round']} match {result_doc['match_index']}"
+                )
+            else:
+                print(
+                    f"⚠️ No document updated for round {result_doc['round']} match {result_doc['match_index']}"
+                )
+        except Exception as e:
+            print(
+                f"❌ Failed to save result for round {result_doc['round']} match {result_doc['match_index']}: {e}"
+            )
+
+    # Save user's game result
+    user_match_index = None
+    home_team = away_team = None
     for i, match in enumerate(tournament["bracket"][round_key]):
         if match["game_id"] is None and request.winner in [match["home_team"], match["away_team"]]:
-            tournament["bracket"][round_key][i]["game_id"] = request.game_id
-            tournament["bracket"][round_key][i]["winner"] = request.winner
+            user_match_index = i
+            home_team = match["home_team"]
+            away_team = match["away_team"]
+            manager.save_game_result(round_key, i, request.game_id, request.winner)
             break
 
-    tournaments_collection.update_one(
-        {"_id": tournament_id},
-        {"$set": {
-            f"bracket.{round_key}": tournament["bracket"][round_key]
-        }}
-    )
+    if user_match_index is None:
+        raise HTTPException(status_code=400, detail="User matchup not found")
+
+    summary = games_collection.find_one({"_id": ObjectId(request.game_id)}) or {}
+    user_result = {
+        "home_team": home_team,
+        "away_team": away_team,
+        "score": summary.get("score", {}),
+        "winner": request.winner,
+        "round": round_num,
+        "match_index": user_match_index,
+    }
+    _log_result(user_result)
+
+    # Simulate remaining games
+    for i, match in enumerate(manager.tournament["bracket"][round_key]):
+        if match.get("game_id"):
+            continue
+
+        try:
+            game = run_simulation(match["home_team"], match["away_team"])
+            summary = summarize_game_state(game)
+            insert_result = games_collection.insert_one(summary)
+            game_id = insert_result.inserted_id
+            print(f"✅ Game document inserted for round {round_num} match {i}")
+        except Exception as e:
+            print(
+                f"❌ Failed to simulate or insert game for round {round_num} match {i}: {e}"
+            )
+            continue
+
+        home = match["home_team"]
+        away = match["away_team"]
+        winner = home if summary["score"][home] > summary["score"][away] else away
+        manager.save_game_result(round_key, i, str(game_id), winner)
+
+        result_doc = {
+            "home_team": home,
+            "away_team": away,
+            "score": summary.get("score", {}),
+            "winner": winner,
+            "round": round_num,
+            "match_index": i,
+        }
+        _log_result(result_doc)
+
+    # Reload and advance round
+    updated_doc = tournaments_collection.find_one({"_id": tournament_id})
+    if updated_doc:
+        manager.tournament = updated_doc
+        manager.advance_round()
 
     return {"status": "success"}

--- a/tests/test_tournament_save_results.py
+++ b/tests/test_tournament_save_results.py
@@ -1,0 +1,53 @@
+import pytest
+from bson import ObjectId
+from BackEnd.tournament.tournament_manager import TournamentManager
+from BackEnd.db import tournaments_collection, games_collection
+from BackEnd.api.tournament_routes import save_result, TournamentResultRequest
+
+
+def test_save_result_simulates_remaining_games(monkeypatch):
+    tournaments_collection.delete_many({})
+    games_collection.delete_many({})
+
+    manager = TournamentManager(
+        user_team_id="A",
+        tournaments_collection=tournaments_collection,
+        team_ids=["A", "B", "C", "D", "E", "F", "G", "H"],
+    )
+    tournament = manager.create_tournament()
+    tid = ObjectId(tournament["_id"])
+
+    round1 = tournament["bracket"]["round1"]
+    for idx, match in enumerate(round1):
+        if "A" in (match["home_team"], match["away_team"]):
+            user_index = idx
+            home = match["home_team"]
+            away = match["away_team"]
+            break
+
+    user_summary = {"score": {home: 100, away: 90}}
+    game_id = games_collection.insert_one(user_summary).inserted_id
+
+    def fake_run_simulation(h, a):
+        return {"home": h, "away": a}
+
+    def fake_summarize_game_state(game):
+        h = game["home"]
+        a = game["away"]
+        return {"score": {h: 60, a: 50}}
+
+    monkeypatch.setattr("BackEnd.api.tournament_routes.run_simulation", fake_run_simulation)
+    monkeypatch.setattr("BackEnd.api.tournament_routes.summarize_game_state", fake_summarize_game_state)
+
+    req = TournamentResultRequest(
+        tournament_id=str(tid),
+        game_id=str(game_id),
+        winner="A",
+    )
+    save_result(req)
+
+    updated = tournaments_collection.find_one({"_id": tid})
+    assert updated is not None
+    assert "results" in updated
+    assert len(updated["results"]) == 4
+    assert any(r["match_index"] == user_index and r["winner"] == "A" for r in updated["results"])


### PR DESCRIPTION
## Summary
- Simulate and store remaining tournament games once the user finishes their match
- Log database writes and persist home/away, score, winner, round and match index for each game
- Add tests ensuring four results are recorded for round one

## Testing
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899399eb9a48328bf5155191ea155e4