### PR TITLE
Advance tournament bracket using saved results

### DIFF
--- a/BackEnd/api/tournament_routes.py
+++ b/BackEnd/api/tournament_routes.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 from BackEnd.db import tournaments_collection, teams_collection, games_collection
 from BackEnd.tournament.tournament_manager import TournamentManager
+from BackEnd.tournament.bracket_logic import update_bracket_from_results
 from BackEnd.main import run_simulation
 from BackEnd.utils.shared import summarize_game_state
 from bson import ObjectId
@@ -207,10 +208,8 @@ def save_result(request: TournamentResultRequest):
         }
         _log_result(result_doc)
 
-    # Reload and advance round
-    updated_doc = tournaments_collection.find_one({"_id": tournament_id})
-    if updated_doc:
-        manager.tournament = updated_doc
-        manager.advance_round()
+    # Use saved results to advance the bracket to the next round.  This relies
+    # solely on the stored results and is safe to re-run (idempotent).
+    update_bracket_from_results(tournament_id, tournaments_collection=tournaments_collection)
 
     return {"status": "success"}

--- a/BackEnd/tournament/bracket_logic.py
+++ b/BackEnd/tournament/bracket_logic.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+"""Helpers for manipulating tournament brackets.
+
+This module currently provides a utility to advance the bracket to the next
+round based on saved game results.  The function is designed to be idempotent
+so repeated invocations (e.g. on page refresh) do not duplicate work or advance
+multiple rounds.
+"""
+
+from typing import Any
+from bson import ObjectId
+
+from BackEnd.db import tournaments_collection as default_tournaments_collection
+
+
+def update_bracket_from_results(
+    tournament_id: str | ObjectId,
+    *,
+    tournaments_collection=default_tournaments_collection,
+) -> dict[str, Any] | None:
+    """Advance the bracket using saved results.
+
+    Parameters
+    ----------
+    tournament_id:
+        Identifier for the tournament document.
+    tournaments_collection:
+        Optional Mongo collection to operate on.  Defaults to the primary
+        ``tournaments_collection`` used by the application.
+
+    Returns
+    -------
+    dict | None
+        The updated tournament document if found, otherwise ``None``.
+
+    Notes
+    -----
+    The round and match indexing scheme is zero based.  ``match_index`` values
+    from the saved results determine pairing in the next round: winners from
+    match ``0`` and ``1`` advance to match ``0`` in the following round,
+    ``2`` and ``3`` advance to match ``1`` and so on.  This provides a stable
+    mapping that can be re‑applied without recomputation.
+    """
+
+    tid = ObjectId(tournament_id) if not isinstance(tournament_id, ObjectId) else tournament_id
+    tournament = tournaments_collection.find_one({"_id": tid})
+    if not tournament:
+        return None
+
+    current_round: int = tournament.get("current_round", 1)
+    round_key = f"round{current_round}" if current_round < 3 else "final"
+    bracket = tournament.get("bracket", {})
+    matchups = bracket.get(round_key, [])
+
+    # Gather all results for the current round and order them by match index
+    results = [r for r in tournament.get("results", []) if r.get("round") == current_round]
+    if len(results) < len(matchups):
+        # Round not complete – nothing to advance
+        return tournament
+
+    results.sort(key=lambda r: r["match_index"])
+    winners = [r["winner"] for r in results]
+
+    next_round_num = current_round + 1
+    next_key = "final" if next_round_num == 3 else f"round{next_round_num}"
+
+    # If next round already populated, treat as a no‑op (idempotency)
+    if bracket.get(next_key):
+        return tournament
+
+    next_matchups = []
+    for i in range(0, len(winners), 2):
+        next_matchups.append(
+            {
+                "home_team": winners[i],
+                "away_team": winners[i + 1],
+                "game_id": None,
+                "winner": None,
+            }
+        )
+
+    tournaments_collection.update_one(
+        {"_id": tid},
+        {"$set": {f"bracket.{next_key}": next_matchups, "current_round": next_round_num}},
+    )
+
+    tournament.setdefault("bracket", {})[next_key] = next_matchups
+    tournament["current_round"] = next_round_num
+    return tournament

--- a/tests/test_tournament_bracket_update.py
+++ b/tests/test_tournament_bracket_update.py
@@ -1,0 +1,66 @@
+import pytest
+from bson import ObjectId
+
+from BackEnd.tournament.tournament_manager import TournamentManager
+from BackEnd.api.tournament_routes import save_result, TournamentResultRequest
+from BackEnd.db import tournaments_collection, games_collection
+from BackEnd.tournament.bracket_logic import update_bracket_from_results
+
+
+def test_update_bracket_uses_saved_results(monkeypatch):
+    tournaments_collection.delete_many({})
+    games_collection.delete_many({})
+
+    manager = TournamentManager(
+        user_team_id="A",
+        tournaments_collection=tournaments_collection,
+        team_ids=["A", "B", "C", "D", "E", "F", "G", "H"],
+    )
+    tournament = manager.create_tournament()
+    tid = ObjectId(tournament["_id"])
+
+    round1 = tournament["bracket"]["round1"]
+    for idx, match in enumerate(round1):
+        if "A" in (match["home_team"], match["away_team"]):
+            user_index = idx
+            home = match["home_team"]
+            away = match["away_team"]
+            break
+
+    user_summary = {"score": {home: 100, away: 90}}
+    game_id = games_collection.insert_one(user_summary).inserted_id
+
+    def fake_run_simulation(h, a):
+        return {"home": h, "away": a}
+
+    def fake_summarize_game_state(game):
+        h = game["home"]
+        a = game["away"]
+        return {"score": {h: 60, a: 50}}
+
+    monkeypatch.setattr("BackEnd.api.tournament_routes.run_simulation", fake_run_simulation)
+    monkeypatch.setattr("BackEnd.api.tournament_routes.summarize_game_state", fake_summarize_game_state)
+
+    req = TournamentResultRequest(
+        tournament_id=str(tid),
+        game_id=str(game_id),
+        winner="A",
+    )
+    save_result(req)
+
+    updated = tournaments_collection.find_one({"_id": tid})
+    assert updated is not None
+    assert updated["current_round"] == 2
+    assert len(updated["bracket"]["round2"]) == 2
+
+    winners = [m["winner"] for m in updated["bracket"]["round1"]]
+    assert updated["bracket"]["round2"][0]["home_team"] == winners[0]
+    assert updated["bracket"]["round2"][0]["away_team"] == winners[1]
+    assert updated["bracket"]["round2"][1]["home_team"] == winners[2]
+    assert updated["bracket"]["round2"][1]["away_team"] == winners[3]
+
+    # Ensure running the bracket update again does not duplicate or advance
+    update_bracket_from_results(str(tid))
+    again = tournaments_collection.find_one({"_id": tid})
+    assert again["current_round"] == 2
+    assert again["bracket"]["round2"] == updated["bracket"]["round2"]


### PR DESCRIPTION
## Summary
- add helper to build next round bracket from stored match results
- use saved results when saving a tournament round to populate round 2 slots
- test round advancement and idempotent re-run

## Testing
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_689944870bcc83289059b598157f5ba8