### PR TITLE
Implement tournament bracket progression and scoring

### DIFF
--- a/BackEnd/api/tournament_routes.py
+++ b/BackEnd/api/tournament_routes.py
@@ -134,6 +134,19 @@ def save_result(request: TournamentResultRequest):
     manager.tournament_id = tournament_id
 
     def _log_result(result_doc):
+        exists = tournaments_collection.find_one(
+            {
+                "_id": tournament_id,
+                "results": {
+                    "$elemMatch": {
+                        "round": result_doc["round"],
+                        "match_index": result_doc["match_index"],
+                    }
+                },
+            }
+        )
+        if exists:
+            return
         try:
             update_result = tournaments_collection.update_one(
                 {"_id": tournament_id}, {"$push": {"results": result_doc}}
@@ -155,30 +168,42 @@ def save_result(request: TournamentResultRequest):
     user_match_index = None
     home_team = away_team = None
     for i, match in enumerate(tournament["bracket"][round_key]):
-        if match["game_id"] is None and request.winner in [match["home_team"], match["away_team"]]:
+        if request.winner in [match["home_team"], match["away_team"]]:
             user_match_index = i
             home_team = match["home_team"]
             away_team = match["away_team"]
-            manager.save_game_result(round_key, i, request.game_id, request.winner)
+            summary = games_collection.find_one({"_id": ObjectId(request.game_id)}) or {}
+            manager.save_game_result(round_key, i, request.game_id, request.winner, summary.get("score"))
+            user_result = {
+                "home_team": home_team,
+                "away_team": away_team,
+                "score": summary.get("score", {}),
+                "winner": request.winner,
+                "round": round_num,
+                "match_index": i,
+            }
+            _log_result(user_result)
             break
 
     if user_match_index is None:
         raise HTTPException(status_code=400, detail="User matchup not found")
 
-    summary = games_collection.find_one({"_id": ObjectId(request.game_id)}) or {}
-    user_result = {
-        "home_team": home_team,
-        "away_team": away_team,
-        "score": summary.get("score", {}),
-        "winner": request.winner,
-        "round": round_num,
-        "match_index": user_match_index,
-    }
-    _log_result(user_result)
-
-    # Simulate remaining games
+    # Ensure all match results are recorded
     for i, match in enumerate(manager.tournament["bracket"][round_key]):
+        if i == user_match_index:
+            continue
         if match.get("game_id"):
+            summary = games_collection.find_one({"_id": ObjectId(match["game_id"])} ) or {}
+            manager.save_game_result(round_key, i, match["game_id"], match["winner"], summary.get("score"))
+            result_doc = {
+                "home_team": match["home_team"],
+                "away_team": match["away_team"],
+                "score": summary.get("score", {}),
+                "winner": match["winner"],
+                "round": round_num,
+                "match_index": i,
+            }
+            _log_result(result_doc)
             continue
 
         try:
@@ -196,7 +221,7 @@ def save_result(request: TournamentResultRequest):
         home = match["home_team"]
         away = match["away_team"]
         winner = home if summary["score"][home] > summary["score"][away] else away
-        manager.save_game_result(round_key, i, str(game_id), winner)
+        manager.save_game_result(round_key, i, str(game_id), winner, summary.get("score"))
 
         result_doc = {
             "home_team": home,
@@ -213,3 +238,17 @@ def save_result(request: TournamentResultRequest):
     update_bracket_from_results(tournament_id, tournaments_collection=tournaments_collection)
 
     return {"status": "success"}
+
+
+@router.get("/tournament/state/{tournament_id}")
+def tournament_state(tournament_id: str):
+    """Return the current bracket state for a tournament."""
+    try:
+        tid = ObjectId(tournament_id)
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid tournament_id")
+    doc = tournaments_collection.find_one({"_id": tid})
+    if not doc:
+        raise HTTPException(status_code=404, detail="Tournament not found")
+    doc["_id"] = str(doc["_id"])
+    return doc

--- a/BackEnd/tournament/bracket_logic.py
+++ b/BackEnd/tournament/bracket_logic.py
@@ -61,6 +61,16 @@ def update_bracket_from_results(
     results.sort(key=lambda r: r["match_index"])
     winners = [r["winner"] for r in results]
 
+    # Final round complete – mark tournament finished
+    if current_round >= 3:
+        champion = winners[0] if winners else None
+        tournaments_collection.update_one(
+            {"_id": tid}, {"$set": {"completed": True, "champion": champion}}
+        )
+        tournament["completed"] = True
+        tournament["champion"] = champion
+        return tournament
+
     next_round_num = current_round + 1
     next_key = "final" if next_round_num == 3 else f"round{next_round_num}"
 
@@ -76,6 +86,7 @@ def update_bracket_from_results(
                 "away_team": winners[i + 1],
                 "game_id": None,
                 "winner": None,
+                "score": {},
             }
         )
 

--- a/BackEnd/tournament/tournament_manager.py
+++ b/BackEnd/tournament/tournament_manager.py
@@ -62,19 +62,32 @@ class TournamentManager:
             (sorted_teams[1][0], sorted_teams[6][0]),
             (sorted_teams[2][0], sorted_teams[5][0])
         ]
-        return [{"home_team": home, "away_team": away, "game_id": None, "winner": None} for home, away in matchups]
+        return [
+            {
+                "home_team": home,
+                "away_team": away,
+                "game_id": None,
+                "winner": None,
+                "score": {},
+            }
+            for home, away in matchups
+        ]
 
-    def save_game_result(self, round_name, matchup_index, game_id, winner_id):
-        self.tournament["bracket"][round_name][matchup_index]["game_id"] = game_id
-        self.tournament["bracket"][round_name][matchup_index]["winner"] = winner_id
+    def save_game_result(self, round_name, matchup_index, game_id, winner_id, score=None):
+        match = self.tournament["bracket"][round_name][matchup_index]
+        match["game_id"] = game_id
+        match["winner"] = winner_id
+        if score is not None:
+            match["score"] = score
+        update_fields = {
+            f"bracket.{round_name}.{matchup_index}.game_id": game_id,
+            f"bracket.{round_name}.{matchup_index}.winner": winner_id,
+        }
+        if score is not None:
+            update_fields[f"bracket.{round_name}.{matchup_index}.score"] = score
         self.tournaments_collection.update_one(
             {"_id": self.tournament_id},
-            {
-                "$set": {
-                    f"bracket.{round_name}.{matchup_index}.game_id": game_id,
-                    f"bracket.{round_name}.{matchup_index}.winner": winner_id,
-                }
-            },
+            {"$set": update_fields},
         )
 
     def advance_round(self):
@@ -82,15 +95,33 @@ class TournamentManager:
         if current_round == 1:
             r1_winners = [m["winner"] for m in self.tournament["bracket"]["round1"]]
             r2 = [
-                {"home_team": r1_winners[0], "away_team": r1_winners[1], "game_id": None, "winner": None},
-                {"home_team": r1_winners[2], "away_team": r1_winners[3], "game_id": None, "winner": None}
+                {
+                    "home_team": r1_winners[0],
+                    "away_team": r1_winners[1],
+                    "game_id": None,
+                    "winner": None,
+                    "score": {},
+                },
+                {
+                    "home_team": r1_winners[2],
+                    "away_team": r1_winners[3],
+                    "game_id": None,
+                    "winner": None,
+                    "score": {},
+                },
             ]
             self.tournament["bracket"]["round2"] = r2
             self.tournament["current_round"] = 2
         elif current_round == 2:
             r2_winners = [m["winner"] for m in self.tournament["bracket"]["round2"]]
             final = [
-                {"home_team": r2_winners[0], "away_team": r2_winners[1], "game_id": None, "winner": None}
+                {
+                    "home_team": r2_winners[0],
+                    "away_team": r2_winners[1],
+                    "game_id": None,
+                    "winner": None,
+                    "score": {},
+                }
             ]
             self.tournament["bracket"]["final"] = final
             self.tournament["current_round"] = 3

--- a/FrontEnd/static/tournament.js
+++ b/FrontEnd/static/tournament.js
@@ -284,7 +284,13 @@ function initTopAssets(teamName) {
 
 async function loadTournament() {
   try {
-    const res = await fetch(`/tournament/active?user_team_id=${encodeURIComponent(userTeamId)}`);
+    let url;
+    if (tournament && tournament._id) {
+      url = `/tournament/state/${encodeURIComponent(tournament._id)}`;
+    } else {
+      url = `/tournament/active?user_team_id=${encodeURIComponent(userTeamId)}`;
+    }
+    const res = await fetch(url);
     tournament = await res.json();
     localStorage.setItem("activeTournament", JSON.stringify(tournament));
     console.log("Bracket data arrives", tournament);

--- a/tests/test_tournament_manager.py
+++ b/tests/test_tournament_manager.py
@@ -41,9 +41,14 @@ def test_save_game_result_and_advance_round(mock_collection):
 
     # simulate round 1 results
     for i in range(4):
-        manager.save_game_result("round1", i, f"game{i}", f"Winner{i}")
+        match = manager.tournament["bracket"]["round1"][i]
+        home = match["home_team"]
+        away = match["away_team"]
+        score = {home: i + 1, away: i}
+        manager.save_game_result("round1", i, f"game{i}", f"Winner{i}", score)
         assert manager.tournament["bracket"]["round1"][i]["game_id"] == f"game{i}"
         assert manager.tournament["bracket"]["round1"][i]["winner"] == f"Winner{i}"
+        assert manager.tournament["bracket"]["round1"][i]["score"] == score
 
     manager.advance_round()
     assert manager.tournament["current_round"] == 2


### PR DESCRIPTION
## Summary
- track scores when saving tournament game results
- advance bracket using saved results and mark champion
- expose API and UI support to reload bracket state by tournament id

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899dd5d4fcc8328978ea2160966781e