### PR TITLE
Roster: display height as feet-inches (presentation-only)

### DIFF
--- a/BackEnd/api/api.py
+++ b/BackEnd/api/api.py
@@ -15,7 +15,7 @@ from BackEnd.db import (
 )
 from BackEnd.utils.roster_loader import load_roster
 from BackEnd.utils.game_summary_builder import build_game_summary
-from BackEnd.utils.shared import clean_mongo_ids, summarize_game_state
+from BackEnd.utils.shared import clean_mongo_ids, summarize_game_state, format_height
 from pydantic import BaseModel
 from fastapi import HTTPException
 import pprint
@@ -234,12 +234,18 @@ def team_roster_page(request: Request, team: str):
     players = []
     for p in players_cursor:
         attrs = p.get("attributes", {})
+        raw_height = p.get("height")
+        try:
+            height_raw = int(float(raw_height))
+        except (TypeError, ValueError):
+            height_raw = None
         display_attributes = ["SC", "SH", "ID", "OD", "PS", "BH", "RB",
                               "AG", "ST", "ND", "IQ", "FT", "NG"]
         players.append({
             "name": f"{p.get('first_name', '')} {p.get('last_name', '')}".strip(),
             "year": p.get("year", "--"),
-            "height": p.get("height", "--"),
+            "height": format_height(raw_height),
+            "height_raw": height_raw,
             "weight": p.get("weight", "--"),
             "attributes": {attr: attrs.get(attr, "--") for attr in display_attributes},
         })

--- a/BackEnd/utils/shared.py
+++ b/BackEnd/utils/shared.py
@@ -1,6 +1,22 @@
 import random
 from BackEnd.constants import TURNOVER_CALC_DICT, POSITION_LIST, HCO_STRING_SPOTS
 
+
+def format_height(value) -> str:
+    """Convert total inches to a feet'inches" string.
+
+    Accepts numbers or numeric strings; invalid or missing values yield
+    an empty string.
+    """
+    if value in (None, ""):
+        return ""
+    try:
+        inches = int(float(value))
+    except (TypeError, ValueError):
+        return ""
+    feet, inches = divmod(inches, 12)
+    return f"{feet}'{inches}\""
+
 def weighted_random_from_dict(weight_dict: dict) -> str:
     if not weight_dict:
         raise ValueError("weighted_random_from_dict received an empty dict")

--- a/FrontEnd/static/team-roster/team-roster-Bentley-Truman.html
+++ b/FrontEnd/static/team-roster/team-roster-Bentley-Truman.html
@@ -43,7 +43,7 @@
         <tr>
           <td>{{ p.name }}</td>
           <td>{{ p.year }}</td>
-          <td>{{ p.height }}</td>
+          <td{% if p.height_raw is not none %} data-sort-value="{{ p.height_raw }}"{% endif %}>{{ p.height }}</td>
           <td>{{ p.weight }}</td>
           <td>{{ p.attributes.SC }}</td>
           <td>{{ p.attributes.SH }}</td>

--- a/FrontEnd/static/team-roster/team-roster-Four-Corners.html
+++ b/FrontEnd/static/team-roster/team-roster-Four-Corners.html
@@ -43,7 +43,7 @@
         <tr>
           <td>{{ p.name }}</td>
           <td>{{ p.year }}</td>
-          <td>{{ p.height }}</td>
+          <td{% if p.height_raw is not none %} data-sort-value="{{ p.height_raw }}"{% endif %}>{{ p.height }}</td>
           <td>{{ p.weight }}</td>
           <td>{{ p.attributes.SC }}</td>
           <td>{{ p.attributes.SH }}</td>

--- a/FrontEnd/static/team-roster/team-roster-Lancaster.html
+++ b/FrontEnd/static/team-roster/team-roster-Lancaster.html
@@ -43,7 +43,7 @@
         <tr>
           <td>{{ p.name }}</td>
           <td>{{ p.year }}</td>
-          <td>{{ p.height }}</td>
+          <td{% if p.height_raw is not none %} data-sort-value="{{ p.height_raw }}"{% endif %}>{{ p.height }}</td>
           <td>{{ p.weight }}</td>
           <td>{{ p.attributes.SC }}</td>
           <td>{{ p.attributes.SH }}</td>

--- a/FrontEnd/static/team-roster/team-roster-Little-York.html
+++ b/FrontEnd/static/team-roster/team-roster-Little-York.html
@@ -43,7 +43,7 @@
         <tr>
           <td>{{ p.name }}</td>
           <td>{{ p.year }}</td>
-          <td>{{ p.height }}</td>
+          <td{% if p.height_raw is not none %} data-sort-value="{{ p.height_raw }}"{% endif %}>{{ p.height }}</td>
           <td>{{ p.weight }}</td>
           <td>{{ p.attributes.SC }}</td>
           <td>{{ p.attributes.SH }}</td>

--- a/FrontEnd/static/team-roster/team-roster-Morristown.html
+++ b/FrontEnd/static/team-roster/team-roster-Morristown.html
@@ -43,7 +43,7 @@
         <tr>
           <td>{{ p.name }}</td>
           <td>{{ p.year }}</td>
-          <td>{{ p.height }}</td>
+          <td{% if p.height_raw is not none %} data-sort-value="{{ p.height_raw }}"{% endif %}>{{ p.height }}</td>
           <td>{{ p.weight }}</td>
           <td>{{ p.attributes.SC }}</td>
           <td>{{ p.attributes.SH }}</td>

--- a/FrontEnd/static/team-roster/team-roster-Ocean-City.html
+++ b/FrontEnd/static/team-roster/team-roster-Ocean-City.html
@@ -43,7 +43,7 @@
         <tr>
           <td>{{ p.name }}</td>
           <td>{{ p.year }}</td>
-          <td>{{ p.height }}</td>
+          <td{% if p.height_raw is not none %} data-sort-value="{{ p.height_raw }}"{% endif %}>{{ p.height }}</td>
           <td>{{ p.weight }}</td>
           <td>{{ p.attributes.SC }}</td>
           <td>{{ p.attributes.SH }}</td>

--- a/FrontEnd/static/team-roster/team-roster-South-Lancaster.html
+++ b/FrontEnd/static/team-roster/team-roster-South-Lancaster.html
@@ -43,7 +43,7 @@
         <tr>
           <td>{{ p.name }}</td>
           <td>{{ p.year }}</td>
-          <td>{{ p.height }}</td>
+          <td{% if p.height_raw is not none %} data-sort-value="{{ p.height_raw }}"{% endif %}>{{ p.height }}</td>
           <td>{{ p.weight }}</td>
           <td>{{ p.attributes.SC }}</td>
           <td>{{ p.attributes.SH }}</td>

--- a/FrontEnd/static/team-roster/team-roster-Xavien.html
+++ b/FrontEnd/static/team-roster/team-roster-Xavien.html
@@ -43,7 +43,7 @@
         <tr>
           <td>{{ p.name }}</td>
           <td>{{ p.year }}</td>
-          <td>{{ p.height }}</td>
+          <td{% if p.height_raw is not none %} data-sort-value="{{ p.height_raw }}"{% endif %}>{{ p.height }}</td>
           <td>{{ p.weight }}</td>
           <td>{{ p.attributes.SC }}</td>
           <td>{{ p.attributes.SH }}</td>

--- a/tests/test_team_roster_page.py
+++ b/tests/test_team_roster_page.py
@@ -1,0 +1,31 @@
+from fastapi.testclient import TestClient
+from BackEnd.api.api import app
+from BackEnd.db import players_collection, teams_collection
+from html import unescape
+
+client = TestClient(app)
+
+
+def _attrs():
+    return {k: 1 for k in ["SC", "SH", "ID", "OD", "PS", "BH", "RB", "AG", "ST", "ND", "IQ", "FT", "NG"]}
+
+
+def test_height_formatted():
+    players_collection.delete_many({})
+    teams_collection.delete_many({})
+    players_collection.insert_one(
+        {
+            "_id": "p1",
+            "first_name": "Tall",
+            "last_name": "Player",
+            "team": "Lancaster",
+            "height": "82",
+            "weight": 200,
+            "attributes": _attrs(),
+        }
+    )
+    teams_collection.insert_one({"name": "Lancaster", "player_ids": ["p1"]})
+
+    resp = client.get("/team-roster/Lancaster")
+    assert resp.status_code == 200
+    assert "6'10\"" in unescape(resp.text)


### PR DESCRIPTION
## Summary
- show player height as feet/inches while keeping raw inch value for sorting
- add test for roster page height formatting

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899f5d37cb08328bb57936380f2706e