### PR TITLE
Tournament: add 'Sim Remaining Games' and finish bracket when user eliminated

### DIFF
--- a/BackEnd/api/tournament_routes.py
+++ b/BackEnd/api/tournament_routes.py
@@ -252,3 +252,98 @@ def tournament_state(tournament_id: str):
         raise HTTPException(status_code=404, detail="Tournament not found")
     doc["_id"] = str(doc["_id"])
     return doc
+
+
+@router.post("/tournament/sim-remaining")
+def sim_remaining(request: SimulateRequest):
+    """Simulate all remaining games until the bracket is complete.
+
+    The endpoint is idempotent; already simulated games are skipped and existing
+    results are preserved.  The updated tournament document is returned."""
+
+    try:
+        tid = ObjectId(request.tournament_id)
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid tournament_id")
+
+    tournament = tournaments_collection.find_one({"_id": tid})
+    if not tournament:
+        raise HTTPException(status_code=404, detail="Tournament not found")
+
+    manager = TournamentManager(tournaments_collection=tournaments_collection)
+    manager.tournament_id = tid
+
+    def _log_result(result_doc):
+        exists = tournaments_collection.find_one(
+            {
+                "_id": tid,
+                "results": {
+                    "$elemMatch": {
+                        "round": result_doc["round"],
+                        "match_index": result_doc["match_index"],
+                    }
+                },
+            }
+        )
+        if not exists:
+            tournaments_collection.update_one(
+                {"_id": tid}, {"$push": {"results": result_doc}}
+            )
+
+    while True:
+        tournament = tournaments_collection.find_one({"_id": tid})
+        if not tournament or tournament.get("completed"):
+            break
+
+        round_num = tournament.get("current_round", 1)
+        round_key = "final" if round_num == 3 else f"round{round_num}"
+        matchups = tournament.get("bracket", {}).get(round_key, [])
+        manager.tournament = tournament
+
+        for i, match in enumerate(matchups):
+            if match.get("game_id"):
+                exists = tournaments_collection.find_one(
+                    {
+                        "_id": tid,
+                        "results": {
+                            "$elemMatch": {"round": round_num, "match_index": i}
+                        },
+                    }
+                )
+                if not exists:
+                    summary = games_collection.find_one({"_id": ObjectId(match["game_id"])}) or {}
+                    result_doc = {
+                        "home_team": match["home_team"],
+                        "away_team": match["away_team"],
+                        "score": summary.get("score", {}),
+                        "winner": match.get("winner"),
+                        "round": round_num,
+                        "match_index": i,
+                    }
+                    _log_result(result_doc)
+                continue
+
+            game = run_simulation(match["home_team"], match["away_team"])
+            summary = summarize_game_state(game)
+            game_id = games_collection.insert_one(summary).inserted_id
+            home = match["home_team"]
+            away = match["away_team"]
+            winner = home if summary["score"][home] > summary["score"][away] else away
+            manager.save_game_result(round_key, i, str(game_id), winner, summary.get("score"))
+            result_doc = {
+                "home_team": home,
+                "away_team": away,
+                "score": summary.get("score", {}),
+                "winner": winner,
+                "round": round_num,
+                "match_index": i,
+            }
+            _log_result(result_doc)
+
+        update_bracket_from_results(tid, tournaments_collection=tournaments_collection)
+
+    final_doc = tournaments_collection.find_one({"_id": tid})
+    if not final_doc:
+        raise HTTPException(status_code=404, detail="Tournament not found")
+    final_doc["_id"] = str(final_doc["_id"])
+    return final_doc

--- a/FrontEnd/static/tournament.html
+++ b/FrontEnd/static/tournament.html
@@ -43,6 +43,7 @@
         </div>
         <div class="play-now-container">
           <button id="play-now" class="play-now-btn">Play Now</button>
+          <button id="sim-remaining" class="play-now-btn" style="display: none;">Sim Remaining Games</button>
         </div>
       </div>
   </div>

--- a/FrontEnd/static/tournament.js
+++ b/FrontEnd/static/tournament.js
@@ -240,26 +240,25 @@ function renderLeaderboards() {
 
 function updateCTA() {
   const playBtn = document.getElementById('play-now');
+  const simBtn = document.getElementById('sim-remaining');
   const container = document.querySelector('.play-now-container');
-  if (!container || !playBtn || !tournament) return;
+  if (!container || !playBtn || !simBtn || !tournament) return;
 
   const roundKey = tournament.current_round === 3 ? 'final' : `round${tournament.current_round}`;
   const matchups = tournament.bracket?.[roundKey] || [];
   const userMatch = matchups.find(m => m.home_team === userTeamId || m.away_team === userTeamId);
 
-  const eliminatedMsg = document.getElementById('eliminated-msg');
   if (userMatch) {
     const opponent = userMatch.home_team === userTeamId ? userMatch.away_team : userMatch.home_team;
     playBtn.style.display = 'inline-block';
     playBtn.textContent = `Play Next Game vs ${opponent}`;
-    if (eliminatedMsg) eliminatedMsg.remove();
+    simBtn.style.display = 'none';
   } else {
     playBtn.style.display = 'none';
-    if (!eliminatedMsg) {
-      const msg = document.createElement('div');
-      msg.id = 'eliminated-msg';
-      msg.textContent = 'Eliminated';
-      container.appendChild(msg);
+    if (tournament.completed) {
+      simBtn.style.display = 'none';
+    } else {
+      simBtn.style.display = 'inline-block';
     }
   }
 }
@@ -357,6 +356,34 @@ document.addEventListener("DOMContentLoaded", async () => {
         console.error('Failed to start game', err);
         alert('Unable to start game');
         playBtn.disabled = false;
+      }
+    });
+  }
+
+  const simBtn = document.getElementById('sim-remaining');
+  if (simBtn) {
+    simBtn.addEventListener('click', async () => {
+      if (!tournament || !tournament._id) {
+        alert('Tournament not loaded');
+        return;
+      }
+      simBtn.disabled = true;
+      try {
+        const res = await fetch('/tournament/sim-remaining', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ tournament_id: tournament._id })
+        });
+        if (!res.ok) throw new Error('Request failed');
+        const data = await res.json();
+        tournament = data;
+        localStorage.setItem('activeTournament', JSON.stringify(tournament));
+        renderBracket();
+        updateCTA();
+      } catch (err) {
+        console.error('Failed to simulate remaining games', err);
+        alert('Unable to simulate remaining games');
+        simBtn.disabled = false;
       }
     });
   }

--- a/tests/test_tournament_sim_remaining.py
+++ b/tests/test_tournament_sim_remaining.py
@@ -1,0 +1,59 @@
+from bson import ObjectId
+
+from BackEnd.tournament.tournament_manager import TournamentManager
+from BackEnd.api.tournament_routes import save_result, TournamentResultRequest, sim_remaining, SimulateRequest
+from BackEnd.db import tournaments_collection, games_collection
+
+
+def test_sim_remaining_completes_bracket(monkeypatch):
+    tournaments_collection.delete_many({})
+    games_collection.delete_many({})
+
+    manager = TournamentManager(
+        user_team_id="A",
+        tournaments_collection=tournaments_collection,
+        team_ids=["A", "B", "C", "D", "E", "F", "G", "H"],
+    )
+    tournament = manager.create_tournament()
+    tid = ObjectId(tournament["_id"])
+
+    round1 = tournament["bracket"]["round1"]
+    for match in round1:
+        if "A" in (match["home_team"], match["away_team"]):
+            home = match["home_team"]
+            away = match["away_team"]
+            opponent = away if home == "A" else home
+            break
+
+    user_summary = {"score": {home: 90, away: 100}}
+    game_id = games_collection.insert_one(user_summary).inserted_id
+
+    def fake_run_simulation(h, a):
+        return {"home": h, "away": a}
+
+    def fake_summarize(game):
+        h = game["home"]
+        a = game["away"]
+        return {"score": {h: 80, a: 70}}
+
+    monkeypatch.setattr("BackEnd.api.tournament_routes.run_simulation", fake_run_simulation)
+    monkeypatch.setattr("BackEnd.api.tournament_routes.summarize_game_state", fake_summarize)
+
+    req = TournamentResultRequest(
+        tournament_id=str(tid),
+        game_id=str(game_id),
+        winner=opponent,
+    )
+    save_result(req)
+
+    sim_remaining(SimulateRequest(tournament_id=str(tid)))
+    updated = tournaments_collection.find_one({"_id": tid})
+    assert updated["completed"] is True
+    assert len(updated.get("results", [])) == 7
+    assert updated.get("champion")
+
+    # idempotency
+    sim_remaining(SimulateRequest(tournament_id=str(tid)))
+    again = tournaments_collection.find_one({"_id": tid})
+    assert len(again.get("results", [])) == 7
+    assert again["completed"] is True


### PR DESCRIPTION
## Summary
- add backend endpoint to simulate all remaining tournament games idempotently
- show **Sim Remaining Games** button when user is eliminated and wire it to new endpoint
- cover sim-remaining flow with tests

## Testing
- `PYTHONPATH=. pytest tests/test_tournament_bracket_update.py tests/test_tournament_save_results.py tests/test_tournament_active_returns_progress.py tests/test_tournament_manager.py tests/test_tournament_sim_remaining.py`

------
https://chatgpt.com/codex/tasks/task_e_6899f6dd7f7083289d5854254e8aad96