### PR TITLE
Franchise: save user result, sim remaining week games, and display full scoreboard in Command Center

### DIFF
--- a/BackEnd/api/franchise_routes.py
+++ b/BackEnd/api/franchise_routes.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 from pathlib import Path
 from bson import ObjectId
 import logging
+import random
 
 from BackEnd.db import db, franchise_state_collection
 from BackEnd.models.franchise_manager import FranchiseManager
@@ -44,6 +45,69 @@ class FranchiseResultRequest(BaseModel):
     franchise_id: str
     game_id: str
     winner: str
+
+
+class GameResult(BaseModel):
+    team1_id: str
+    team2_id: str
+    team1_score: int
+    team2_score: int
+
+
+class CompleteWeekRequest(BaseModel):
+    franchise_id: str
+    week: int
+    result: GameResult
+
+
+def _apply_team_result(team1_id, team2_id, team1_score, team2_score, sign=1):
+    db.teams.update_one({"_id": team1_id}, {"$inc": {"PF": sign * team1_score, "PA": sign * team2_score, "record.W": 0, "record.L": 0}})
+    db.teams.update_one({"_id": team2_id}, {"$inc": {"PF": sign * team2_score, "PA": sign * team1_score, "record.W": 0, "record.L": 0}})
+    if team1_score > team2_score:
+        db.teams.update_one({"_id": team1_id}, {"$inc": {"record.W": sign}})
+        db.teams.update_one({"_id": team2_id}, {"$inc": {"record.L": sign}})
+    elif team2_score > team1_score:
+        db.teams.update_one({"_id": team2_id}, {"$inc": {"record.W": sign}})
+        db.teams.update_one({"_id": team1_id}, {"$inc": {"record.L": sign}})
+
+
+def _save_game_result(team1_id, team2_id, team1_score, team2_score, week):
+    existing = db.games.find_one({
+        "week": week,
+        "$or": [
+            {"team1_id": team1_id, "team2_id": team2_id},
+            {"team1_id": team2_id, "team2_id": team1_id},
+        ],
+    })
+
+    if existing:
+        _apply_team_result(existing["team1_id"], existing["team2_id"], existing["team1_score"], existing["team2_score"], sign=-1)
+        filter_doc = {"_id": existing["_id"]}
+    else:
+        filter_doc = {"week": week, "team1_id": team1_id, "team2_id": team2_id}
+
+    _apply_team_result(team1_id, team2_id, team1_score, team2_score, sign=1)
+
+    db.games.update_one(
+        filter_doc,
+        {
+            "$set": {
+                "team1_id": team1_id,
+                "team2_id": team2_id,
+                "team1_score": team1_score,
+                "team2_score": team2_score,
+                "week": week,
+            }
+        },
+        upsert=True,
+    )
+
+    return {
+        "team1_id": str(team1_id),
+        "team2_id": str(team2_id),
+        "team1_score": team1_score,
+        "team2_score": team2_score,
+    }
 
 @router.post("/franchise/select-team")
 def select_team(selection: TeamSelection):
@@ -87,11 +151,10 @@ def play_next_game(req: PlayGameRequest):
                 home_doc = db.teams.find_one({"_id": home_id}, {"name": 1})
                 matchup = {
                     "home": home_doc.get("name", ""),
-                    "away": away_doc.get("name", "")
+                    "away": away_doc.get("name", ""),
+                    "week": manager.week,
                 }
                 break
-
-    manager.run_week()
 
     if not matchup:
         raise HTTPException(status_code=404, detail="User matchup not found")
@@ -168,6 +231,69 @@ def save_result(req: FranchiseResultRequest):
     )
 
     return {"status": "success"}
+
+
+@router.post("/franchise/complete-week")
+def complete_week(req: CompleteWeekRequest):
+    try:
+        franchise_id = ObjectId(req.franchise_id)
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid ID format")
+
+    franchise_doc = db.franchises.find_one({"_id": franchise_id})
+    if not franchise_doc:
+        raise HTTPException(status_code=404, detail="Franchise not found")
+
+    schedule = franchise_doc.get("schedule", [])
+    if req.week < 1 or req.week > len(schedule):
+        raise HTTPException(status_code=400, detail="Invalid week")
+
+    week_games = schedule[req.week - 1]
+    results = []
+
+    user = req.result
+    results.append(_save_game_result(user.team1_id, user.team2_id, user.team1_score, user.team2_score, req.week))
+
+    for away_id, home_id in week_games:
+        if {str(away_id), str(home_id)} == {user.team1_id, user.team2_id}:
+            continue
+        existing = db.games.find_one({
+            "week": req.week,
+            "$or": [
+                {"team1_id": away_id, "team2_id": home_id},
+                {"team1_id": home_id, "team2_id": away_id},
+            ],
+        })
+        if existing:
+            results.append({
+                "team1_id": str(existing["team1_id"]),
+                "team2_id": str(existing["team2_id"]),
+                "team1_score": existing["team1_score"],
+                "team2_score": existing["team2_score"],
+            })
+            continue
+        team1_score = random.randint(50, 90)
+        team2_score = random.randint(50, 90)
+        results.append(_save_game_result(away_id, home_id, team1_score, team2_score, req.week))
+
+    existing_results = franchise_doc.get("results", {})
+    existing_results[str(req.week)] = results
+    db.franchises.update_one(
+        {"_id": franchise_id},
+        {"$set": {"results": existing_results, "week": req.week + 1}},
+    )
+
+    id_to_name = {str(t["_id"]): t.get("name", "") for t in db.teams.find({}, {"name": 1})}
+    scoreboard = []
+    for r in results:
+        scoreboard.append({
+            "team1": id_to_name.get(r["team1_id"], r["team1_id"]),
+            "team2": id_to_name.get(r["team2_id"], r["team2_id"]),
+            "team1_score": r["team1_score"],
+            "team2_score": r["team2_score"],
+        })
+
+    return {"week": req.week, "results": scoreboard}
 
 
 @router.get("/franchise/command-center/data")

--- a/FrontEnd/static/franchise-command-center.js
+++ b/FrontEnd/static/franchise-command-center.js
@@ -212,9 +212,9 @@ playNowBtn.addEventListener('click', async () => {
       body: JSON.stringify({ franchise_id: franchiseId })
     });
     if (!res.ok) throw new Error('Simulation failed');
-    const { home, away } = await res.json();
+    const { home, away, week } = await res.json();
     if (!home || !away) throw new Error('Matchup not found');
-    const url = `/court.html?franchise_id=${encodeURIComponent(franchiseId)}&home=${encodeURIComponent(home)}&away=${encodeURIComponent(away)}`;
+    const url = `/court.html?franchise_id=${encodeURIComponent(franchiseId)}&week=${week}&home=${encodeURIComponent(home)}&away=${encodeURIComponent(away)}`;
     console.log('Navigating to', url);
     window.location.href = url;
   } catch (err) {

--- a/FrontEnd/static/js/phaser/finalizeGame.js
+++ b/FrontEnd/static/js/phaser/finalizeGame.js
@@ -6,6 +6,8 @@ export async function finalizeGame({ simData, tournamentId, franchiseId, game })
   const homeScore = homeTeamObj.score ?? scoreMap[homeTeamObj.name] ?? 0;
   const awayScore = awayTeamObj.score ?? scoreMap[awayTeamObj.name] ?? 0;
   const winner = homeScore > awayScore ? homeTeamObj.name : awayTeamObj.name;
+  const params = new URLSearchParams(window.location.search);
+  const week = Number(params.get('week'));
 
   // POST to /tournament/save-result if needed
   if (tournamentId) {
@@ -29,25 +31,34 @@ export async function finalizeGame({ simData, tournamentId, franchiseId, game })
     }
   }
 
-  // POST to /franchise/save-result if needed
-  if (franchiseId) {
+  // POST to /franchise/complete-week if needed
+  if (franchiseId && week) {
     try {
-      const res = await fetch("/franchise/save-result", {
+      const team1Id =
+        awayTeamObj.team_id || awayTeamObj.teamId || simData.away_team_id || simData.awayTeamId;
+      const team2Id =
+        homeTeamObj.team_id || homeTeamObj.teamId || simData.home_team_id || simData.homeTeamId;
+      const res = await fetch("/franchise/complete-week", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           franchise_id: franchiseId,
-          game_id: simData._id,
-          winner: winner,
+          week: week,
+          result: {
+            team1_id: team1Id,
+            team2_id: team2Id,
+            team1_score: awayScore,
+            team2_score: homeScore,
+          },
         }),
       });
       if (!res.ok) {
-        console.error("❌ Failed to save franchise result:", await res.text());
+        console.error("❌ Failed to complete franchise week:", await res.text());
       } else {
-        console.log("✅ Franchise result saved.");
+        console.log("✅ Franchise week completed.");
       }
     } catch (err) {
-      console.error("🚨 Error during franchise result save:", err);
+      console.error("🚨 Error during franchise week completion:", err);
     }
   }
 

--- a/tests/test_franchise_complete_week.py
+++ b/tests/test_franchise_complete_week.py
@@ -1,0 +1,55 @@
+from fastapi.testclient import TestClient
+from BackEnd.api.api import app
+from BackEnd.db import db
+
+client = TestClient(app)
+
+def setup_franchise():
+    db.games.delete_many({})
+    db.teams.delete_many({})
+    db.franchises.delete_many({})
+    teams = [
+        {"_id": "A", "name": "A", "record": {"W": 0, "L": 0}, "PF": 0, "PA": 0},
+        {"_id": "B", "name": "B", "record": {"W": 0, "L": 0}, "PF": 0, "PA": 0},
+        {"_id": "C", "name": "C", "record": {"W": 0, "L": 0}, "PF": 0, "PA": 0},
+        {"_id": "D", "name": "D", "record": {"W": 0, "L": 0}, "PF": 0, "PA": 0},
+    ]
+    db.teams.insert_many(teams)
+    schedule = [[("A", "B"), ("C", "D")]]
+    fid = db.franchises.insert_one({"schedule": schedule, "week": 1}).inserted_id
+    return str(fid)
+
+def test_complete_week_saves_and_simulates():
+    franchise_id = setup_franchise()
+    payload = {
+        "franchise_id": franchise_id,
+        "week": 1,
+        "result": {"team1_id": "A", "team2_id": "B", "team1_score": 70, "team2_score": 60},
+    }
+    res = client.post("/franchise/complete-week", json=payload)
+    assert res.status_code == 200
+    data = res.json()
+    assert len(data["results"]) == 2
+
+    team_a = db.teams.find_one({"_id": "A"})
+    team_b = db.teams.find_one({"_id": "B"})
+    assert team_a["record"]["W"] == 1
+    assert team_b["record"]["L"] == 1
+    assert team_a["PF"] == 70
+    assert team_b["PF"] == 60
+
+    # Idempotent second call
+    res2 = client.post("/franchise/complete-week", json=payload)
+    assert res2.status_code == 200
+    team_a2 = db.teams.find_one({"_id": "A"})
+    assert team_a2["record"]["W"] == 1
+    games = list(db.games.find({"week": 1, "$or": [{"team1_id": "A", "team2_id": "B"}, {"team1_id": "B", "team2_id": "A"}]}))
+    assert len(games) == 1
+
+    franchise_doc = db.franchises.find_one({"_id": db.franchises.find_one({})["_id"]})
+    assert franchise_doc["week"] == 2
+    assert "1" in franchise_doc.get("results", {})
+    db.games.delete_many({})
+    db.teams.delete_many({})
+    db.franchises.delete_many({})
+


### PR DESCRIPTION
## Summary
- Add backend endpoint to record user franchise game, simulate remaining games, and persist weekly results
- Pass current week to court UI and post completed week with scores
- Wire command center to supply week parameter when launching franchise games
- Add coverage for completing a franchise week and ensuring idempotent results

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899fa8bd310832894c85e2d56344aaf