### PR TITLE
Add diagnostics for recruit name loading

### DIFF
--- a/BackEnd/flask_app.py
+++ b/BackEnd/flask_app.py
@@ -1,8 +1,8 @@
-from flask import Flask, request, redirect, send_from_directory
+from flask import Flask, request, redirect, send_from_directory, jsonify
 from pathlib import Path
 
 from BackEnd.db import db, franchise_state_collection
-from BackEnd.models.franchise_manager import FranchiseManager
+from BackEnd.models.franchise_manager import FranchiseManager, RecruitManager
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 STATIC_DIR = BASE_DIR / "FrontEnd" / "static"
@@ -46,6 +46,13 @@ def franchise_play_next_game():
     manager.week = state.get('week', 1)
     manager.run_week()
     return redirect('/animation')
+
+
+@app.route('/franchise/debug/names')
+def franchise_debug_names():
+    manager = RecruitManager(db)
+    data = manager.diagnostics or {"detail": "NAMES_DIAG not enabled"}
+    return jsonify(data)
 
 @app.route('/animation')
 def animation_page():

--- a/BackEnd/models/franchise_manager.py
+++ b/BackEnd/models/franchise_manager.py
@@ -5,6 +5,7 @@ from importlib import resources
 from pathlib import Path
 import json
 import logging
+import os
 import sys
 
 
@@ -149,28 +150,56 @@ class RecruitManager:
         self.first_names = ["Jalen", "Marcus", "Tyrese", "Zion", "Cade"]
         self.last_names  = ["Walker", "Jackson", "Robinson", "Wright", "Anderson"]
 
+        self.diagnostics = None
+        diag_enabled = os.environ.get("NAMES_DIAG") == "1"
+        if diag_enabled:
+            self.diagnostics = {
+                "file": __file__,
+                "cwd": os.getcwd(),
+                "sys_path": sys.path[:5],
+            }
+
         payload = None
 
         # 1) Try local path relative to this file: BackEnd/data/names/franchise_names.json
         default_path = (Path(__file__).resolve().parents[1]
                         / "data" / "names" / "franchise_names.json")
         path = Path(names_file).expanduser() if names_file else default_path
+        if diag_enabled and self.diagnostics is not None:
+            self.diagnostics.update({
+                "expected_path": str(path.resolve()),
+                "expected_path_exists": path.exists(),
+            })
         try:
             with path.open("r", encoding="utf-8") as f:
                 payload = json.load(f)
             logger.info("Recruit names loaded from %s", path)
+            if diag_enabled and self.diagnostics is not None:
+                self.diagnostics["code_path"] = "filesystem"
         except Exception as exc:
             logger.warning("Failed to load recruit names from %s: %s", path, exc)
+            if diag_enabled and self.diagnostics is not None:
+                self.diagnostics["filesystem_error"] = str(exc)
 
         # 2) Fallback: importlib.resources (works when BackEnd is on sys.path)
         if payload is None:
             try:
-                with resources.open_text("BackEnd.data.names",
+                pkg = "BackEnd.data.names"
+                if diag_enabled and self.diagnostics is not None:
+                    try:
+                        self.diagnostics["resources_files"] = str(resources.files(pkg))
+                    except Exception as exc:  # pragma: no cover - diagnostic only
+                        self.diagnostics["resources_files"] = f"<error: {exc}>"
+                with resources.open_text(pkg,
                                         "franchise_names.json", encoding="utf-8") as f:
                     payload = json.load(f)
                 logger.info("Recruit names loaded from package BackEnd.data.names")
+                if diag_enabled and self.diagnostics is not None:
+                    self.diagnostics["code_path"] = "importlib.resources"
             except Exception as exc:
                 logger.warning("Could not load recruit names via package resources: %s", exc)
+                if diag_enabled and self.diagnostics is not None:
+                    self.diagnostics["resource_error"] = str(exc)
 
         # 3) If we got data, validate keys and apply
         if isinstance(payload, dict):
@@ -180,8 +209,19 @@ class RecruitManager:
                 self.first_names, self.last_names = fn, ln
             else:
                 logger.warning("Names JSON missing non-empty 'first_names'/'last_names'; using fallback lists.")
+            if diag_enabled and self.diagnostics is not None:
+                self.diagnostics.update({
+                    "first_names_count": len(fn) if isinstance(fn, list) else 0,
+                    "last_names_count": len(ln) if isinstance(ln, list) else 0,
+                })
         else:
             logger.warning("Could not load franchise_names.json from disk or package; using fallback lists.")
+            if diag_enabled and self.diagnostics is not None:
+                self.diagnostics["parsed"] = False
+
+        if diag_enabled and self.diagnostics is not None and "parsed" not in self.diagnostics:
+            self.diagnostics["parsed"] = True
+            logger.info("NAMES_DIAG: %s", self.diagnostics)
 
     def generate_recruits(self, count=40):
         recruits = []


### PR DESCRIPTION
## Summary
- instrument `RecruitManager` to log recruit name loading details when `NAMES_DIAG=1`
- expose `/franchise/debug/names` to return diagnostics

## Testing
- `python -m pytest`
- `python - <<'PY'
import os, json
os.environ['NAMES_DIAG'] = '1'
from BackEnd.models.franchise_manager import RecruitManager
m = RecruitManager(None)
print(json.dumps(m.diagnostics, indent=2))
PY`
- `python - <<'PY'
import os, json, sys
sys.path.insert(0, '/tmp/prod_repo')
os.environ['NAMES_DIAG']='1'
from BackEnd.models.franchise_manager import RecruitManager
m = RecruitManager(None)
print(json.dumps(m.diagnostics, indent=2))
PY`
- `python - <<'PY'
import os
os.environ['NAMES_DIAG']='1'
from BackEnd.flask_app import app
with app.test_client() as client:
    resp = client.get('/franchise/debug/names')
    print(resp.get_json())
PY`


------
https://chatgpt.com/codex/tasks/task_e_6899fd5bd5548328bd86edb9e786bbc5