### PR TITLE
Utils: add position ratings helper (1–100)

### DIFF
--- a/BackEnd/utils/position_ratings.py
+++ b/BackEnd/utils/position_ratings.py
@@ -1,0 +1,131 @@
+"""Helpers for computing 1–100 position ratings from a player record."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+# Weights for each position. Each sub-dict maps attribute -> weight percentage
+# (0-1). For PF, IQ intentionally totals 15% (10% + 5%).
+POSITION_WEIGHTS: Dict[str, Dict[str, float]] = {
+    "PG": {
+        "PS": 0.20,
+        "BH": 0.20,
+        "IQ": 0.20,
+        "SH": 0.10,
+        "OD": 0.10,
+        "AG": 0.10,
+        "FT": 0.05,
+        "SC": 0.05,
+    },
+    "SG": {
+        "SH": 0.20,
+        "OD": 0.20,
+        "AG": 0.20,
+        "SC": 0.10,
+        "PS": 0.10,
+        "BH": 0.10,
+        "FT": 0.05,
+        "IQ": 0.05,
+    },
+    "SF": {
+        "AG": 0.20,
+        "ST": 0.20,
+        "SC": 0.10,
+        "SH": 0.10,
+        "ID": 0.10,
+        "OD": 0.10,
+        "FT": 0.05,
+        "IQ": 0.05,
+        "PS": 0.05,
+        "RB": 0.05,
+    },
+    "PF": {
+        "ST": 0.20,
+        "RB": 0.20,
+        "SC": 0.10,
+        "ID": 0.10,
+        "IQ": 0.15,  # 10% + 5% per spec
+        "height": 0.10,
+        "FT": 0.05,
+        "PS": 0.05,
+        "SH": 0.05,
+    },
+    "C": {
+        "ST": 0.20,
+        "RB": 0.20,
+        "SC": 0.20,
+        "ID": 0.20,
+        "height": 0.20,
+    },
+}
+
+
+def _get_attr(player: dict, key: str) -> float:
+    """Retrieve an attribute value from a player dict.
+
+    Looks first under ``player['attributes']`` then falls back to the top level.
+    Missing keys default to ``0``.
+    """
+
+    attributes = player.get("attributes", {}) or {}
+    return attributes.get(key, player.get(key, 0))
+
+
+def _height_to_rating(height: float) -> float:
+    """Convert a height in inches to a 1–100 rating.
+
+    Uses a linear map where 60 inches -> 1 and 84 inches -> 100 and clamps
+    outside that range.
+    """
+
+    try:
+        h = float(height)
+    except (TypeError, ValueError):
+        h = 0
+
+    if h <= 60:
+        return 1.0
+    if h >= 84:
+        return 100.0
+    # scale proportionally between 60 and 84 inclusive
+    return 1 + (h - 60) * (99 / 24)
+
+
+def _clamp(value: float, lower: int = 1, upper: int = 100) -> int:
+    """Round and clamp a value to an integer between ``lower`` and ``upper``."""
+
+    return max(lower, min(upper, int(round(value))))
+
+
+def compute_position_ratings(player: dict) -> Dict[str, int]:
+    """Compute 1–100 ratings for each basketball position.
+
+    ``player`` is a mapping containing numeric attributes either at the top
+    level or within ``player['attributes']``.
+    """
+
+    ratings: Dict[str, int] = {}
+    height_rating = _height_to_rating(_get_attr(player, "height"))
+
+    for pos, weights in POSITION_WEIGHTS.items():
+        total = 0.0
+        for attr, weight in weights.items():
+            if attr == "height":
+                val = height_rating
+            else:
+                val = _get_attr(player, attr)
+            total += val * weight
+        ratings[pos] = _clamp(total)
+
+    return ratings
+
+
+def add_position_ratings(player: dict) -> dict:
+    """Return a shallow copy of ``player`` with computed position ratings."""
+
+    new_player = player.copy()
+    new_player["ratings"] = compute_position_ratings(player)
+    return new_player
+
+
+__all__ = ["compute_position_ratings", "add_position_ratings"]

--- a/tests/test_position_ratings.py
+++ b/tests/test_position_ratings.py
@@ -1,0 +1,32 @@
+from BackEnd.utils.position_ratings import compute_position_ratings
+
+
+def test_mid_range_ratings():
+    player = {
+        "height": 74,
+        "attributes": {
+            "SC": 65,
+            "SH": 65,
+            "ID": 65,
+            "OD": 65,
+            "PS": 65,
+            "BH": 65,
+            "RB": 65,
+            "AG": 65,
+            "ST": 65,
+            "IQ": 65,
+            "FT": 65,
+        },
+    }
+    ratings = compute_position_ratings(player)
+    for pos_rating in ratings.values():
+        assert 40 <= pos_rating <= 80
+
+
+def test_height_clamps():
+    low = {"height": 50, "attributes": {}}
+    high = {"height": 90, "attributes": {}}
+    low_center = compute_position_ratings(low)["C"]
+    high_center = compute_position_ratings(high)["C"]
+    assert low_center == 1
+    assert high_center == 20


### PR DESCRIPTION
## Summary
- add `compute_position_ratings` to calculate 1–100 ratings for each position based on weighted attributes and height
- add `add_position_ratings` convenience to attach computed ratings to player dicts
- cover height scaling and rating clamping with new tests

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a076b188083288b60452f95e2eb56