### PR TITLE
Franchise: ensure week is always supplied; always save user result and finish week sims

### DIFF
--- a/FrontEnd/static/franchise-command-center.js
+++ b/FrontEnd/static/franchise-command-center.js
@@ -214,6 +214,9 @@ playNowBtn.addEventListener('click', async () => {
     if (!res.ok) throw new Error('Simulation failed');
     const { home, away, week } = await res.json();
     if (!home || !away) throw new Error('Matchup not found');
+    try {
+      localStorage.setItem('franchise_week', week);
+    } catch {}
     const url = `/court.html?franchise_id=${encodeURIComponent(franchiseId)}&week=${week}&home=${encodeURIComponent(home)}&away=${encodeURIComponent(away)}`;
     console.log('Navigating to', url);
     window.location.href = url;

--- a/FrontEnd/static/js/phaser/finalizeGame.js
+++ b/FrontEnd/static/js/phaser/finalizeGame.js
@@ -6,8 +6,17 @@ export async function finalizeGame({ simData, tournamentId, franchiseId, game })
   const homeScore = homeTeamObj.score ?? scoreMap[homeTeamObj.name] ?? 0;
   const awayScore = awayTeamObj.score ?? scoreMap[awayTeamObj.name] ?? 0;
   const winner = homeScore > awayScore ? homeTeamObj.name : awayTeamObj.name;
-  const params = new URLSearchParams(window.location.search);
-  const week = Number(params.get('week'));
+  let week = null;
+  if (typeof localStorage !== 'undefined') {
+    week = Number(localStorage.getItem('franchise_week'));
+  }
+  if (!week) {
+    const params = new URLSearchParams(window.location.search);
+    week = Number(params.get('week'));
+  }
+  if (!week && simData && simData.week) {
+    week = Number(simData.week);
+  }
 
   // POST to /tournament/save-result if needed
   if (tournamentId) {
@@ -38,6 +47,9 @@ export async function finalizeGame({ simData, tournamentId, franchiseId, game })
         awayTeamObj.team_id || awayTeamObj.teamId || simData.away_team_id || simData.awayTeamId;
       const team2Id =
         homeTeamObj.team_id || homeTeamObj.teamId || simData.home_team_id || simData.homeTeamId;
+      console.log(
+        `📡 Saving franchise game: franchiseId=${franchiseId}, week=${week}, away=${awayTeamObj.name}, home=${homeTeamObj.name}`
+      );
       const res = await fetch("/franchise/complete-week", {
         method: "POST",
         headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- Persist franchise week in localStorage and include in court URL when launching a game
- Save franchise game results with a reliable week value and add logging for easier debugging

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a12ac9bdc83288f204e24e3685275