### PR TITLE
Roster: add POS/RT from position_ratings, year abbreviations, sort by RT

### DIFF
--- a/BackEnd/api/api.py
+++ b/BackEnd/api/api.py
@@ -232,6 +232,13 @@ def team_roster_page(request: Request, team: str):
     """Render an HTML roster page for a given team."""
     players_cursor = players_collection.find({"team": team})
     players = []
+    order = ["PG", "SG", "SF", "PF", "C"]
+    year_map = {
+        "senior": "SR",
+        "junior": "JR",
+        "sophomore": "SO",
+        "freshman": "FR",
+    }
     for p in players_cursor:
         attrs = p.get("attributes", {})
         raw_height = p.get("height")
@@ -239,19 +246,55 @@ def team_roster_page(request: Request, team: str):
             height_raw = int(float(raw_height))
         except (TypeError, ValueError):
             height_raw = None
-        display_attributes = ["SC", "SH", "ID", "OD", "PS", "BH", "RB",
-                              "AG", "ST", "ND", "IQ", "FT", "NG"]
-        players.append({
-            "name": f"{p.get('first_name', '')} {p.get('last_name', '')}".strip(),
-            "year": p.get("year", "--"),
-            "height": format_height(raw_height),
-            "height_raw": height_raw,
-            "weight": p.get("weight", "--"),
-            "attributes": {attr: attrs.get(attr, "--") for attr in display_attributes},
-        })
+        display_attributes = [
+            "SC",
+            "SH",
+            "ID",
+            "OD",
+            "PS",
+            "BH",
+            "RB",
+            "AG",
+            "ST",
+            "ND",
+            "IQ",
+            "FT",
+        ]
+
+        pos_ratings = p.get("position_ratings") or {}
+        pos = "-"
+        rt_val: int | None = None
+        for o in order:
+            rating = pos_ratings.get(o)
+            if rating is None:
+                continue
+            if rt_val is None or rating > rt_val:
+                pos, rt_val = o, rating
+        rt = int(rt_val) if rt_val is not None else "-"
+
+        year_raw = p.get("year", "--")
+        year_abbr = year_map.get(str(year_raw).lower(), year_raw or "--")
+
+        players.append(
+            {
+                "name": f"{p.get('first_name', '')} {p.get('last_name', '')}".strip(),
+                "pos": pos,
+                "year": year_abbr,
+                "height": format_height(raw_height),
+                "height_raw": height_raw,
+                "weight": p.get("weight", "--"),
+                "attributes": {attr: attrs.get(attr, "--") for attr in display_attributes},
+                "rt": rt,
+                "rt_value": rt_val if rt_val is not None else -1,
+            }
+        )
+
+    players.sort(key=lambda x: x.get("rt_value", -1), reverse=True)
 
     template_name = f"team-roster/team-roster-{team.replace(' ', '-')}.html"
-    return templates.TemplateResponse(template_name, {"request": request, "team": team, "players": players})
+    return templates.TemplateResponse(
+        template_name, {"request": request, "team": team, "players": players}
+    )
 
 
 @app.get("/tournament/active")

--- a/FrontEnd/static/team-roster/team-roster-Bentley-Truman.html
+++ b/FrontEnd/static/team-roster/team-roster-Bentley-Truman.html
@@ -20,6 +20,7 @@
       <thead>
         <tr>
           <th>Name</th>
+          <th>POS</th>
           <th>Year</th>
           <th>Height</th>
           <th>Weight</th>
@@ -35,13 +36,14 @@
           <th>ND</th>
           <th>IQ</th>
           <th>FT</th>
-          <th>NG</th>
+          <th>RT</th>
         </tr>
       </thead>
       <tbody>
       {% for p in players %}
         <tr>
           <td>{{ p.name }}</td>
+          <td>{{ p.pos }}</td>
           <td>{{ p.year }}</td>
           <td{% if p.height_raw is not none %} data-sort-value="{{ p.height_raw }}"{% endif %}>{{ p.height }}</td>
           <td>{{ p.weight }}</td>
@@ -57,7 +59,7 @@
           <td>{{ p.attributes.ND }}</td>
           <td>{{ p.attributes.IQ }}</td>
           <td>{{ p.attributes.FT }}</td>
-          <td>{{ p.attributes.NG }}</td>
+          <td>{{ p.rt }}</td>
         </tr>
       {% endfor %}
       </tbody>

--- a/FrontEnd/static/team-roster/team-roster-Four-Corners.html
+++ b/FrontEnd/static/team-roster/team-roster-Four-Corners.html
@@ -20,6 +20,7 @@
       <thead>
         <tr>
           <th>Name</th>
+          <th>POS</th>
           <th>Year</th>
           <th>Height</th>
           <th>Weight</th>
@@ -35,13 +36,14 @@
           <th>ND</th>
           <th>IQ</th>
           <th>FT</th>
-          <th>NG</th>
+          <th>RT</th>
         </tr>
       </thead>
       <tbody>
       {% for p in players %}
         <tr>
           <td>{{ p.name }}</td>
+          <td>{{ p.pos }}</td>
           <td>{{ p.year }}</td>
           <td{% if p.height_raw is not none %} data-sort-value="{{ p.height_raw }}"{% endif %}>{{ p.height }}</td>
           <td>{{ p.weight }}</td>
@@ -57,7 +59,7 @@
           <td>{{ p.attributes.ND }}</td>
           <td>{{ p.attributes.IQ }}</td>
           <td>{{ p.attributes.FT }}</td>
-          <td>{{ p.attributes.NG }}</td>
+          <td>{{ p.rt }}</td>
         </tr>
       {% endfor %}
       </tbody>

--- a/FrontEnd/static/team-roster/team-roster-Lancaster.html
+++ b/FrontEnd/static/team-roster/team-roster-Lancaster.html
@@ -20,6 +20,7 @@
       <thead>
         <tr>
           <th>Name</th>
+          <th>POS</th>
           <th>Year</th>
           <th>Height</th>
           <th>Weight</th>
@@ -35,13 +36,14 @@
           <th>ND</th>
           <th>IQ</th>
           <th>FT</th>
-          <th>NG</th>
+          <th>RT</th>
         </tr>
       </thead>
       <tbody>
       {% for p in players %}
         <tr>
           <td>{{ p.name }}</td>
+          <td>{{ p.pos }}</td>
           <td>{{ p.year }}</td>
           <td{% if p.height_raw is not none %} data-sort-value="{{ p.height_raw }}"{% endif %}>{{ p.height }}</td>
           <td>{{ p.weight }}</td>
@@ -57,7 +59,7 @@
           <td>{{ p.attributes.ND }}</td>
           <td>{{ p.attributes.IQ }}</td>
           <td>{{ p.attributes.FT }}</td>
-          <td>{{ p.attributes.NG }}</td>
+          <td>{{ p.rt }}</td>
         </tr>
       {% endfor %}
       </tbody>

--- a/FrontEnd/static/team-roster/team-roster-Little-York.html
+++ b/FrontEnd/static/team-roster/team-roster-Little-York.html
@@ -20,6 +20,7 @@
       <thead>
         <tr>
           <th>Name</th>
+          <th>POS</th>
           <th>Year</th>
           <th>Height</th>
           <th>Weight</th>
@@ -35,13 +36,14 @@
           <th>ND</th>
           <th>IQ</th>
           <th>FT</th>
-          <th>NG</th>
+          <th>RT</th>
         </tr>
       </thead>
       <tbody>
       {% for p in players %}
         <tr>
           <td>{{ p.name }}</td>
+          <td>{{ p.pos }}</td>
           <td>{{ p.year }}</td>
           <td{% if p.height_raw is not none %} data-sort-value="{{ p.height_raw }}"{% endif %}>{{ p.height }}</td>
           <td>{{ p.weight }}</td>
@@ -57,7 +59,7 @@
           <td>{{ p.attributes.ND }}</td>
           <td>{{ p.attributes.IQ }}</td>
           <td>{{ p.attributes.FT }}</td>
-          <td>{{ p.attributes.NG }}</td>
+          <td>{{ p.rt }}</td>
         </tr>
       {% endfor %}
       </tbody>

--- a/FrontEnd/static/team-roster/team-roster-Morristown.html
+++ b/FrontEnd/static/team-roster/team-roster-Morristown.html
@@ -20,6 +20,7 @@
       <thead>
         <tr>
           <th>Name</th>
+          <th>POS</th>
           <th>Year</th>
           <th>Height</th>
           <th>Weight</th>
@@ -35,13 +36,14 @@
           <th>ND</th>
           <th>IQ</th>
           <th>FT</th>
-          <th>NG</th>
+          <th>RT</th>
         </tr>
       </thead>
       <tbody>
       {% for p in players %}
         <tr>
           <td>{{ p.name }}</td>
+          <td>{{ p.pos }}</td>
           <td>{{ p.year }}</td>
           <td{% if p.height_raw is not none %} data-sort-value="{{ p.height_raw }}"{% endif %}>{{ p.height }}</td>
           <td>{{ p.weight }}</td>
@@ -57,7 +59,7 @@
           <td>{{ p.attributes.ND }}</td>
           <td>{{ p.attributes.IQ }}</td>
           <td>{{ p.attributes.FT }}</td>
-          <td>{{ p.attributes.NG }}</td>
+          <td>{{ p.rt }}</td>
         </tr>
       {% endfor %}
       </tbody>

--- a/FrontEnd/static/team-roster/team-roster-Ocean-City.html
+++ b/FrontEnd/static/team-roster/team-roster-Ocean-City.html
@@ -20,6 +20,7 @@
       <thead>
         <tr>
           <th>Name</th>
+          <th>POS</th>
           <th>Year</th>
           <th>Height</th>
           <th>Weight</th>
@@ -35,13 +36,14 @@
           <th>ND</th>
           <th>IQ</th>
           <th>FT</th>
-          <th>NG</th>
+          <th>RT</th>
         </tr>
       </thead>
       <tbody>
       {% for p in players %}
         <tr>
           <td>{{ p.name }}</td>
+          <td>{{ p.pos }}</td>
           <td>{{ p.year }}</td>
           <td{% if p.height_raw is not none %} data-sort-value="{{ p.height_raw }}"{% endif %}>{{ p.height }}</td>
           <td>{{ p.weight }}</td>
@@ -57,7 +59,7 @@
           <td>{{ p.attributes.ND }}</td>
           <td>{{ p.attributes.IQ }}</td>
           <td>{{ p.attributes.FT }}</td>
-          <td>{{ p.attributes.NG }}</td>
+          <td>{{ p.rt }}</td>
         </tr>
       {% endfor %}
       </tbody>

--- a/FrontEnd/static/team-roster/team-roster-South-Lancaster.html
+++ b/FrontEnd/static/team-roster/team-roster-South-Lancaster.html
@@ -20,6 +20,7 @@
       <thead>
         <tr>
           <th>Name</th>
+          <th>POS</th>
           <th>Year</th>
           <th>Height</th>
           <th>Weight</th>
@@ -35,13 +36,14 @@
           <th>ND</th>
           <th>IQ</th>
           <th>FT</th>
-          <th>NG</th>
+          <th>RT</th>
         </tr>
       </thead>
       <tbody>
       {% for p in players %}
         <tr>
           <td>{{ p.name }}</td>
+          <td>{{ p.pos }}</td>
           <td>{{ p.year }}</td>
           <td{% if p.height_raw is not none %} data-sort-value="{{ p.height_raw }}"{% endif %}>{{ p.height }}</td>
           <td>{{ p.weight }}</td>
@@ -57,7 +59,7 @@
           <td>{{ p.attributes.ND }}</td>
           <td>{{ p.attributes.IQ }}</td>
           <td>{{ p.attributes.FT }}</td>
-          <td>{{ p.attributes.NG }}</td>
+          <td>{{ p.rt }}</td>
         </tr>
       {% endfor %}
       </tbody>

--- a/FrontEnd/static/team-roster/team-roster-Xavien.html
+++ b/FrontEnd/static/team-roster/team-roster-Xavien.html
@@ -20,6 +20,7 @@
       <thead>
         <tr>
           <th>Name</th>
+          <th>POS</th>
           <th>Year</th>
           <th>Height</th>
           <th>Weight</th>
@@ -35,13 +36,14 @@
           <th>ND</th>
           <th>IQ</th>
           <th>FT</th>
-          <th>NG</th>
+          <th>RT</th>
         </tr>
       </thead>
       <tbody>
       {% for p in players %}
         <tr>
           <td>{{ p.name }}</td>
+          <td>{{ p.pos }}</td>
           <td>{{ p.year }}</td>
           <td{% if p.height_raw is not none %} data-sort-value="{{ p.height_raw }}"{% endif %}>{{ p.height }}</td>
           <td>{{ p.weight }}</td>
@@ -57,7 +59,7 @@
           <td>{{ p.attributes.ND }}</td>
           <td>{{ p.attributes.IQ }}</td>
           <td>{{ p.attributes.FT }}</td>
-          <td>{{ p.attributes.NG }}</td>
+          <td>{{ p.rt }}</td>
         </tr>
       {% endfor %}
       </tbody>

--- a/tests/test_team_roster_page.py
+++ b/tests/test_team_roster_page.py
@@ -19,8 +19,10 @@ def test_height_formatted():
             "first_name": "Tall",
             "last_name": "Player",
             "team": "Lancaster",
+            "year": "senior",
             "height": "82",
             "weight": 200,
+            "position_ratings": {"PG": 50},
             "attributes": _attrs(),
         }
     )
@@ -29,3 +31,42 @@ def test_height_formatted():
     resp = client.get("/team-roster/Lancaster")
     assert resp.status_code == 200
     assert "6'10\"" in unescape(resp.text)
+
+
+def test_position_and_year_and_sorting():
+    players_collection.delete_many({})
+    teams_collection.delete_many({})
+    players_collection.insert_many(
+        [
+            {
+                "_id": "p1",
+                "first_name": "Alpha",
+                "last_name": "One",
+                "team": "Lancaster",
+                "year": "senior",
+                "height": "70",
+                "weight": 180,
+                "position_ratings": {"PG": 80, "SG": 75},
+                "attributes": _attrs(),
+            },
+            {
+                "_id": "p2",
+                "first_name": "Beta",
+                "last_name": "Two",
+                "team": "Lancaster",
+                "year": "junior",
+                "height": "71",
+                "weight": 185,
+                "position_ratings": {"PG": 85, "SG": 80},
+                "attributes": _attrs(),
+            },
+        ]
+    )
+    teams_collection.insert_one({"name": "Lancaster", "player_ids": ["p1", "p2"]})
+
+    resp = client.get("/team-roster/Lancaster")
+    assert resp.status_code == 200
+    text = unescape(resp.text)
+    assert "<th>POS</th>" in text and "<th>RT</th>" in text
+    assert "SR" in text and "JR" in text
+    assert text.index("Beta Two") < text.index("Alpha One")


### PR DESCRIPTION
## Summary
- compute each player's top position rating and use it to abbreviate year and sort roster
- expose new POS and RT columns on team roster pages
- cover roster rendering with tests for year abbreviations, sorting and column headers

## Testing
- `PYTHONPATH=/workspace/gob-simplified pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a12c8ccc08328a8e6eaacfb8f0676