### PR TITLE
Franchise: always include &week in court URLs and make finalizeGame save robust

### DIFF
--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -29,6 +29,10 @@ const franchiseId = queryFranchiseId || storedFranchiseId;
 if (queryFranchiseId && typeof localStorage !== 'undefined') {
   localStorage.setItem('franchise_id', queryFranchiseId);
 }
+const weekParam = parseInt(urlParams.get('week'), 10);
+if (weekParam && !Number.isNaN(weekParam) && typeof localStorage !== 'undefined') {
+  localStorage.setItem('franchise_week', weekParam);
+}
 const mode = urlParams.get('mode') || getMode({ tournamentId, franchiseId });
 
 console.log("🏀 Tournament launch params:", {

--- a/FrontEnd/static/js/phaser/finalizeGame.js
+++ b/FrontEnd/static/js/phaser/finalizeGame.js
@@ -6,16 +6,16 @@ export async function finalizeGame({ simData, tournamentId, franchiseId, game })
   const homeScore = homeTeamObj.score ?? scoreMap[homeTeamObj.name] ?? 0;
   const awayScore = awayTeamObj.score ?? scoreMap[awayTeamObj.name] ?? 0;
   const winner = homeScore > awayScore ? homeTeamObj.name : awayTeamObj.name;
-  let week = null;
-  if (typeof localStorage !== 'undefined') {
-    week = Number(localStorage.getItem('franchise_week'));
+  let week = parseInt(new URLSearchParams(window.location.search).get('week'), 10);
+  if (!week || Number.isNaN(week)) {
+    if (typeof localStorage !== 'undefined') {
+      week = parseInt(localStorage.getItem('franchise_week'), 10);
+    }
   }
-  if (!week) {
-    const params = new URLSearchParams(window.location.search);
-    week = Number(params.get('week'));
-  }
-  if (!week && simData && simData.week) {
-    week = Number(simData.week);
+  if (!week || Number.isNaN(week)) {
+    if (simData && simData.week) {
+      week = parseInt(simData.week, 10);
+    }
   }
 
   // POST to /tournament/save-result if needed
@@ -41,7 +41,7 @@ export async function finalizeGame({ simData, tournamentId, franchiseId, game })
   }
 
   // POST to /franchise/complete-week if needed
-  if (franchiseId && week) {
+  if (franchiseId && Number.isInteger(week) && week >= 1) {
     try {
       const team1Id =
         awayTeamObj.team_id || awayTeamObj.teamId || simData.away_team_id || simData.awayTeamId;


### PR DESCRIPTION
## Summary
- Persist `week` from court URL into local storage so franchise sessions always know the current week
- Harden `finalizeGame` by reading week from query params, coercing to int, and gating saves on `franchiseId && week >= 1`

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a169069988328a1b41ab572fab99a