### PR TITLE
UI: unify Team tab with roster layout (POS/Year/Height/Weight, RT, sort by RT)

### DIFF
--- a/FrontEnd/static/common.js
+++ b/FrontEnd/static/common.js
@@ -6,3 +6,37 @@ function formatTeamName(name) {
     .map(w => w.split('-').map(s => s.charAt(0).toUpperCase() + s.slice(1)).join('-'))
     .join(' ');
 }
+
+// Map full year strings to abbreviations
+const yearMap = {
+  senior: 'SR',
+  junior: 'JR',
+  sophomore: 'SO',
+  freshman: 'FR',
+};
+
+// Convert a numeric height (in inches) to feet-inches format
+function formatHeight(raw) {
+  const inches = parseInt(raw, 10);
+  if (isNaN(inches)) return raw ?? '--';
+  const ft = Math.floor(inches / 12);
+  const inch = inches % 12;
+  return `${ft}'${inch}"`;
+}
+
+const positionOrder = ['PG', 'SG', 'SF', 'PF', 'C'];
+
+// Derive the best position and rating from a position_ratings object
+function getBestPosition(positionRatings = {}) {
+  let bestPos = '-';
+  let bestRating = null;
+  positionOrder.forEach(pos => {
+    const rating = positionRatings[pos];
+    if (rating == null) return;
+    if (bestRating === null || rating > bestRating) {
+      bestRating = rating;
+      bestPos = pos;
+    }
+  });
+  return { pos: bestPos, rating: bestRating };
+}

--- a/FrontEnd/static/franchise-command-center.html
+++ b/FrontEnd/static/franchise-command-center.html
@@ -69,7 +69,26 @@
         <div class="scroll-x">
           <table class="roster-table">
             <thead>
-              <tr><th>Name</th><th>SC</th><th>SH</th><th>ID</th><th>OD</th><th>PS</th><th>BH</th><th>RB</th><th>AG</th><th>ST</th><th>ND</th><th>IQ</th><th>FT</th></tr>
+              <tr>
+                <th>Name</th>
+                <th>POS</th>
+                <th>Year</th>
+                <th>Height</th>
+                <th>Weight</th>
+                <th>SC</th>
+                <th>SH</th>
+                <th>ID</th>
+                <th>OD</th>
+                <th>PS</th>
+                <th>BH</th>
+                <th>RB</th>
+                <th>AG</th>
+                <th>ST</th>
+                <th>ND</th>
+                <th>IQ</th>
+                <th>FT</th>
+                <th>RT</th>
+              </tr>
             </thead>
             <tbody id="team-body"></tbody>
           </table>

--- a/FrontEnd/static/franchise-command-center.js
+++ b/FrontEnd/static/franchise-command-center.js
@@ -10,6 +10,7 @@ async function fetchJSON(url) {
 }
 
 let franchiseId = null;
+const ATTR_HEADERS = ["SC","SH","ID","OD","PS","BH","RB","AG","ST","ND","IQ","FT"];
 
 const teamMap = {
   "Four Corners": "FC",
@@ -127,16 +128,27 @@ function renderTeam(data) {
   const tbody = document.getElementById('team-body');
   if (!tbody) return;
   tbody.innerHTML = '';
-  const headers = ["SC","SH","ID","OD","PS","BH","RB","AG","ST","ND","IQ","FT","NG"];
-  (data.players || []).forEach(p => {
+  let players = (data.players || []).map(p => {
+    const best = getBestPosition(p.position_ratings || {});
+    return {
+      name: p.name,
+      pos: best.pos,
+      year: yearMap[p.year?.toLowerCase()] || p.year || '--',
+      height: formatHeight(p.height),
+      weight: p.weight ?? '--',
+      attributes: p.attributes || {},
+      rt: best.rating,
+    };
+  });
+  players.sort((a, b) => (b.rt ?? -1) - (a.rt ?? -1));
+  players.forEach(p => {
     const tr = document.createElement('tr');
-    let html = `<td>${p.name}</td>`;
-    headers.forEach(h => {
-      let val = p.attributes ? p.attributes[h] : null;
-      if (h === 'NG') val = (val ?? 0).toFixed(2);
-      else val = Math.round(val ?? 0);
-      html += `<td>${val}</td>`;
+    let html = `<td>${p.name}</td><td>${p.pos}</td><td>${p.year}</td><td>${p.height}</td><td>${p.weight}</td>`;
+    ATTR_HEADERS.forEach(h => {
+      const val = p.attributes ? p.attributes[h] : undefined;
+      html += `<td>${val ?? '--'}</td>`;
     });
+    html += `<td>${p.rt ?? '-'}</td>`;
     tr.innerHTML = html;
     tbody.appendChild(tr);
   });

--- a/FrontEnd/static/tournament.html
+++ b/FrontEnd/static/tournament.html
@@ -65,7 +65,11 @@
         <table class="roster-table">
           <thead>
             <tr>
-              <th>Player</th>
+              <th>Name</th>
+              <th>POS</th>
+              <th>Year</th>
+              <th>Height</th>
+              <th>Weight</th>
               <th>SC</th>
               <th>SH</th>
               <th>ID</th>
@@ -73,11 +77,12 @@
               <th>PS</th>
               <th>BH</th>
               <th>RB</th>
-              <th>ST</th>
               <th>AG</th>
+              <th>ST</th>
               <th>ND</th>
               <th>IQ</th>
               <th>FT</th>
+              <th>RT</th>
             </tr>
           </thead>
           <tbody id="roster-body"></tbody>

--- a/FrontEnd/static/tournament.js
+++ b/FrontEnd/static/tournament.js
@@ -32,6 +32,7 @@ const logoMap = {
 // tournament is preloaded from localStorage above; always refreshed from API.
 let roster = [];
 let stats = [];
+const ATTR_HEADERS = ["SC", "SH", "ID", "OD", "PS", "BH", "RB", "AG", "ST", "ND", "IQ", "FT"];
 
 const leaderBoards = [
   { title: "Points", key: "PTS" },
@@ -187,11 +188,13 @@ function renderRoster() {
   tbody.innerHTML = "";
   roster.forEach(p => {
     const tr = document.createElement("tr");
-    tr.innerHTML = `
-      <td>${p.name}</td>
-      <td>${p.SC}</td><td>${p.SH}</td><td>${p.ID}</td><td>${p.OD}</td>
-      <td>${p.PS}</td><td>${p.BH}</td><td>${p.RB}</td><td>${p.ST}</td>
-      <td>${p.AG}</td><td>${p.ND}</td><td>${p.IQ}</td><td>${p.FT}</td>`;
+    let html = `<td>${p.name}</td><td>${p.pos}</td><td>${p.year}</td><td>${p.height}</td><td>${p.weight}</td>`;
+    ATTR_HEADERS.forEach(h => {
+      const val = p.attributes ? p.attributes[h] : undefined;
+      html += `<td>${val ?? '--'}</td>`;
+    });
+    html += `<td>${p.rt ?? '-'}</td>`;
+    tr.innerHTML = html;
     tbody.appendChild(tr);
   });
 }
@@ -303,7 +306,19 @@ async function loadRoster() {
     const res = await fetch(`/teams/${encodeURIComponent(formatTeamName(userTeamId))}/players`);
     const data = await res.json();
     console.log("Team player data loads", data);
-    roster = data.players.map(p => Object.assign({ name: p.name }, p.attributes));
+    roster = (data.players || []).map(p => {
+      const best = getBestPosition(p.position_ratings || {});
+      return {
+        name: p.name,
+        pos: best.pos,
+        year: yearMap[p.year?.toLowerCase()] || p.year || '--',
+        height: formatHeight(p.height),
+        weight: p.weight ?? '--',
+        attributes: p.attributes || {},
+        rt: best.rating,
+      };
+    });
+    roster.sort((a, b) => (b.rt ?? -1) - (a.rt ?? -1));
     stats = roster.map(p => ({
       name: p.name,
       PTS: 0, FGM: 0, FGA: 0, TPM: 0, TPA: 0,


### PR DESCRIPTION
## Summary
- Add shared helpers for year abbreviations, height formatting, and best position/rating lookup
- Render Team tabs in Tournament and Franchise Command Centers with roster-style columns and RT sorting
- Format heights as feet-inches and derive POS/RT from position ratings for both views

## Testing
- `PYTHONPATH=/workspace/gob-simplified pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a184f202c8328bae9d6f83cc2966e