### PR TITLE
Wire Team tabs with roster metadata and rating sort

### DIFF
--- a/BackEnd/api/api.py
+++ b/BackEnd/api/api.py
@@ -165,9 +165,15 @@ def get_team_roster(team_name: str, tournament_id: str | None = None):
     for p in player_objects:
         attributes = p.get("attributes", {})  # safely get nested attributes dict
         players.append({
-            "_id": str(p["_id"]),  # ✅ Add this line
+            "_id": str(p.get("_id")),
+            "first_name": p.get("first_name", ""),
+            "last_name": p.get("last_name", ""),
             "name": f"{p.get('first_name', '')} {p.get('last_name', '')}".strip(),
-            "attributes": {attr: attributes.get(attr, "--") for attr in display_attributes}
+            "year": p.get("year"),
+            "height": p.get("height"),
+            "weight": p.get("weight"),
+            "position_ratings": p.get("position_ratings", {}),
+            "attributes": {attr: attributes.get(attr, "--") for attr in display_attributes},
         })
 
     return {
@@ -217,7 +223,13 @@ def get_team_players(team_id: str):
         attributes = p.get("attributes", {})
         players_data.append({
             "_id": str(p.get("_id")),
+            "first_name": p.get("first_name", ""),
+            "last_name": p.get("last_name", ""),
             "name": f"{p.get('first_name', '')} {p.get('last_name', '')}".strip(),
+            "year": p.get("year"),
+            "height": p.get("height"),
+            "weight": p.get("weight"),
+            "position_ratings": p.get("position_ratings", {}),
             "attributes": {attr: attributes.get(attr, "--") for attr in display_attributes},
         })
 

--- a/FrontEnd/static/franchise-command-center.js
+++ b/FrontEnd/static/franchise-command-center.js
@@ -130,8 +130,9 @@ function renderTeam(data) {
   tbody.innerHTML = '';
   let players = (data.players || []).map(p => {
     const best = getBestPosition(p.position_ratings || {});
+    const fullName = `${p.first_name || ''} ${p.last_name || ''}`.trim() || p.name || '';
     return {
-      name: p.name,
+      name: fullName,
       pos: best.pos,
       year: yearMap[p.year?.toLowerCase()] || p.year || '--',
       height: formatHeight(p.height),

--- a/FrontEnd/static/tournament.js
+++ b/FrontEnd/static/tournament.js
@@ -308,8 +308,9 @@ async function loadRoster() {
     console.log("Team player data loads", data);
     roster = (data.players || []).map(p => {
       const best = getBestPosition(p.position_ratings || {});
+      const fullName = `${p.first_name || ''} ${p.last_name || ''}`.trim() || p.name || '';
       return {
-        name: p.name,
+        name: fullName,
         pos: best.pos,
         year: yearMap[p.year?.toLowerCase()] || p.year || '--',
         height: formatHeight(p.height),


### PR DESCRIPTION
## Summary
- extend roster APIs to return year, height, weight and position ratings for each player
- show real player name/POS/year/height/weight and sort by best position rating on franchise & tournament team tabs

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a1cf5dae483288e3ca71b538198c1