### PR TITLE
Franchise: send ObjectId team IDs from court; normalize ids in complete-week; schedule now finds saved games

### DIFF
--- a/BackEnd/api/franchise_routes.py
+++ b/BackEnd/api/franchise_routes.py
@@ -60,6 +60,18 @@ class CompleteWeekRequest(BaseModel):
     result: GameResult
 
 
+def _normalize_team_id(team_id: str):
+    try:
+        return ObjectId(team_id)
+    except Exception:
+        doc = db.teams.find_one(
+            {"$or": [{"_id": team_id}, {"name": team_id}, {"code": team_id}]}
+        )
+        if not doc:
+            raise HTTPException(status_code=400, detail=f"Unknown team id {team_id}")
+        return doc["_id"]
+
+
 def _apply_team_result(team1_id, team2_id, team1_score, team2_score, sign=1):
     db.teams.update_one({"_id": team1_id}, {"$inc": {"PF": sign * team1_score, "PA": sign * team2_score, "record.W": 0, "record.L": 0}})
     db.teams.update_one({"_id": team2_id}, {"$inc": {"PF": sign * team2_score, "PA": sign * team1_score, "record.W": 0, "record.L": 0}})
@@ -152,6 +164,8 @@ def play_next_game(req: PlayGameRequest):
                 matchup = {
                     "home": home_doc.get("name", ""),
                     "away": away_doc.get("name", ""),
+                    "home_id": str(home_id),
+                    "away_id": str(away_id),
                     "week": manager.week,
                 }
                 break
@@ -252,10 +266,12 @@ def complete_week(req: CompleteWeekRequest):
     results = []
 
     user = req.result
-    results.append(_save_game_result(user.team1_id, user.team2_id, user.team1_score, user.team2_score, req.week))
+    team1_id = _normalize_team_id(user.team1_id)
+    team2_id = _normalize_team_id(user.team2_id)
+    results.append(_save_game_result(team1_id, team2_id, user.team1_score, user.team2_score, req.week))
 
     for away_id, home_id in week_games:
-        if {str(away_id), str(home_id)} == {user.team1_id, user.team2_id}:
+        if {str(away_id), str(home_id)} == {str(team1_id), str(team2_id)}:
             continue
         existing = db.games.find_one({
             "week": req.week,

--- a/FrontEnd/static/franchise-command-center.js
+++ b/FrontEnd/static/franchise-command-center.js
@@ -225,12 +225,12 @@ playNowBtn.addEventListener('click', async () => {
       body: JSON.stringify({ franchise_id: franchiseId })
     });
     if (!res.ok) throw new Error('Simulation failed');
-    const { home, away, week } = await res.json();
+    const { home, away, week, home_id, away_id } = await res.json();
     if (!home || !away) throw new Error('Matchup not found');
     try {
       localStorage.setItem('franchise_week', week);
     } catch {}
-    const url = `/court.html?franchise_id=${encodeURIComponent(franchiseId)}&week=${week}&home=${encodeURIComponent(home)}&away=${encodeURIComponent(away)}`;
+    const url = `/court.html?franchise_id=${encodeURIComponent(franchiseId)}&week=${week}&home=${encodeURIComponent(home)}&away=${encodeURIComponent(away)}&home_id=${encodeURIComponent(home_id)}&away_id=${encodeURIComponent(away_id)}`;
     console.log('Navigating to', url);
     window.location.href = url;
   } catch (err) {

--- a/FrontEnd/static/js/phaser/finalizeGame.js
+++ b/FrontEnd/static/js/phaser/finalizeGame.js
@@ -6,7 +6,10 @@ export async function finalizeGame({ simData, tournamentId, franchiseId, game })
   const homeScore = homeTeamObj.score ?? scoreMap[homeTeamObj.name] ?? 0;
   const awayScore = awayTeamObj.score ?? scoreMap[awayTeamObj.name] ?? 0;
   const winner = homeScore > awayScore ? homeTeamObj.name : awayTeamObj.name;
-  let week = parseInt(new URLSearchParams(window.location.search).get('week'), 10);
+  const params = new URLSearchParams(window.location.search);
+  let week = parseInt(params.get('week'), 10);
+  const homeIdParam = params.get('home_id');
+  const awayIdParam = params.get('away_id');
   if (!week || Number.isNaN(week)) {
     if (typeof localStorage !== 'undefined') {
       week = parseInt(localStorage.getItem('franchise_week'), 10);
@@ -44,9 +47,21 @@ export async function finalizeGame({ simData, tournamentId, franchiseId, game })
   if (franchiseId && Number.isInteger(week) && week >= 1) {
     try {
       const team1Id =
-        awayTeamObj.team_id || awayTeamObj.teamId || simData.away_team_id || simData.awayTeamId;
+        awayIdParam ||
+        awayTeamObj.team_id ||
+        awayTeamObj.teamId ||
+        simData.away_team_id ||
+        simData.awayTeamId ||
+        awayTeamObj.name ||
+        simData.away_team;
       const team2Id =
-        homeTeamObj.team_id || homeTeamObj.teamId || simData.home_team_id || simData.homeTeamId;
+        homeIdParam ||
+        homeTeamObj.team_id ||
+        homeTeamObj.teamId ||
+        simData.home_team_id ||
+        simData.homeTeamId ||
+        homeTeamObj.name ||
+        simData.home_team;
       console.log(
         `📡 Saving franchise game: franchiseId=${franchiseId}, week=${week}, away=${awayTeamObj.name}, home=${homeTeamObj.name}`
       );

--- a/tests/test_franchise_complete_week.py
+++ b/tests/test_franchise_complete_week.py
@@ -1,6 +1,7 @@
 from fastapi.testclient import TestClient
 from BackEnd.api.api import app
 from BackEnd.db import db
+from bson import ObjectId
 
 client = TestClient(app)
 
@@ -8,19 +9,20 @@ def setup_franchise():
     db.games.delete_many({})
     db.teams.delete_many({})
     db.franchises.delete_many({})
+    ids = [ObjectId() for _ in range(4)]
     teams = [
-        {"_id": "A", "name": "A", "record": {"W": 0, "L": 0}, "PF": 0, "PA": 0},
-        {"_id": "B", "name": "B", "record": {"W": 0, "L": 0}, "PF": 0, "PA": 0},
-        {"_id": "C", "name": "C", "record": {"W": 0, "L": 0}, "PF": 0, "PA": 0},
-        {"_id": "D", "name": "D", "record": {"W": 0, "L": 0}, "PF": 0, "PA": 0},
+        {"_id": ids[0], "name": "A", "record": {"W": 0, "L": 0}, "PF": 0, "PA": 0},
+        {"_id": ids[1], "name": "B", "record": {"W": 0, "L": 0}, "PF": 0, "PA": 0},
+        {"_id": ids[2], "name": "C", "record": {"W": 0, "L": 0}, "PF": 0, "PA": 0},
+        {"_id": ids[3], "name": "D", "record": {"W": 0, "L": 0}, "PF": 0, "PA": 0},
     ]
     db.teams.insert_many(teams)
-    schedule = [[("A", "B"), ("C", "D")]]
+    schedule = [[(ids[0], ids[1]), (ids[2], ids[3])]]
     fid = db.franchises.insert_one({"schedule": schedule, "week": 1}).inserted_id
-    return str(fid)
+    return str(fid), ids
 
 def test_complete_week_saves_and_simulates():
-    franchise_id = setup_franchise()
+    franchise_id, ids = setup_franchise()
     payload = {
         "franchise_id": franchise_id,
         "week": 1,
@@ -31,8 +33,8 @@ def test_complete_week_saves_and_simulates():
     data = res.json()
     assert len(data["results"]) == 2
 
-    team_a = db.teams.find_one({"_id": "A"})
-    team_b = db.teams.find_one({"_id": "B"})
+    team_a = db.teams.find_one({"_id": ids[0]})
+    team_b = db.teams.find_one({"_id": ids[1]})
     assert team_a["record"]["W"] == 1
     assert team_b["record"]["L"] == 1
     assert team_a["PF"] == 70
@@ -41,12 +43,12 @@ def test_complete_week_saves_and_simulates():
     # Idempotent second call
     res2 = client.post("/franchise/complete-week", json=payload)
     assert res2.status_code == 200
-    team_a2 = db.teams.find_one({"_id": "A"})
+    team_a2 = db.teams.find_one({"_id": ids[0]})
     assert team_a2["record"]["W"] == 1
-    games = list(db.games.find({"week": 1, "$or": [{"team1_id": "A", "team2_id": "B"}, {"team1_id": "B", "team2_id": "A"}]}))
+    games = list(db.games.find({"week": 1, "$or": [{"team1_id": ids[0], "team2_id": ids[1]}, {"team1_id": ids[1], "team2_id": ids[0]}]}))
     assert len(games) == 1
 
-    franchise_doc = db.franchises.find_one({"_id": db.franchises.find_one({})["_id"]})
+    franchise_doc = db.franchises.find_one({"_id": ObjectId(franchise_id)})
     assert franchise_doc["week"] == 2
     assert "1" in franchise_doc.get("results", {})
     db.games.delete_many({})


### PR DESCRIPTION
## Summary
- Pass home and away ObjectId strings in court links so franchise games post team IDs
- Parse those IDs in finalizeGame with fallbacks to team names when missing
- Normalize team IDs on `/franchise/complete-week` and return ObjectIds from play-next-game to match schedule

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a1ff38aa083289c93175fb29a78f3