### PR TITLE
Tournament UI: show 'Exit' button after completion → navigate to Mode Select

### DIFF
--- a/FrontEnd/static/tournament.css
+++ b/FrontEnd/static/tournament.css
@@ -102,7 +102,7 @@ h1, h2, h3, h4, h5, h6 {
 #top-right {
   display: flex;
   align-items: center;
-  justify-content: space-evenly;
+  justify-content: flex-start;
   gap: 10px;
 }
 

--- a/FrontEnd/static/tournament.html
+++ b/FrontEnd/static/tournament.html
@@ -41,10 +41,11 @@
           <img id="coach-duke" src="" alt="Coach Duke" class="coach-img">
           <div class="coach-bonus">+ID / +OD</div>
         </div>
-        <div class="play-now-container">
+        <div class="play-now-container" style="margin-left: auto;">
           <button id="play-now" class="play-now-btn">Play Now</button>
           <button id="sim-remaining" class="play-now-btn" style="display: none;">Sim Remaining Games</button>
         </div>
+        <button id="exit-tournament" class="play-now-btn" style="display: none; margin-left: auto;">Exit</button>
       </div>
   </div>
 

--- a/FrontEnd/static/tournament.js
+++ b/FrontEnd/static/tournament.js
@@ -244,8 +244,20 @@ function renderLeaderboards() {
 function updateCTA() {
   const playBtn = document.getElementById('play-now');
   const simBtn = document.getElementById('sim-remaining');
+  const exitBtn = document.getElementById('exit-tournament');
   const container = document.querySelector('.play-now-container');
-  if (!container || !playBtn || !simBtn || !tournament) return;
+  if (!container || !playBtn || !simBtn || !exitBtn || !tournament) return;
+
+  if (tournament.completed) {
+    playBtn.style.display = 'none';
+    simBtn.style.display = 'none';
+    container.style.display = 'none';
+    exitBtn.style.display = 'inline-block';
+    return;
+  }
+
+  exitBtn.style.display = 'none';
+  container.style.display = 'block';
 
   const roundKey = tournament.current_round === 3 ? 'final' : `round${tournament.current_round}`;
   const matchups = tournament.bracket?.[roundKey] || [];
@@ -258,11 +270,7 @@ function updateCTA() {
     simBtn.style.display = 'none';
   } else {
     playBtn.style.display = 'none';
-    if (tournament.completed) {
-      simBtn.style.display = 'none';
-    } else {
-      simBtn.style.display = 'inline-block';
-    }
+    simBtn.style.display = 'inline-block';
   }
 }
 
@@ -401,6 +409,13 @@ document.addEventListener("DOMContentLoaded", async () => {
         alert('Unable to simulate remaining games');
         simBtn.disabled = false;
       }
+    });
+  }
+
+  const exitBtn = document.getElementById('exit-tournament');
+  if (exitBtn) {
+    exitBtn.addEventListener('click', () => {
+      window.location.href = '/static/mode-select.html';
     });
   }
 });


### PR DESCRIPTION
## Summary
- Show an **Exit** button in the tournament header once a champion is crowned
- Hide play/sim controls when the tournament is complete and align header controls
- Route the Exit button back to Mode Select

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a204e16fc8328a1a0cb5611244314