### PR TITLE
ModeSelect: add secondary-color borders and team taglines under logos

### DIFF
--- a/FrontEnd/static/mode-select.css
+++ b/FrontEnd/static/mode-select.css
@@ -66,15 +66,25 @@ body {
 }
 
 .team-button {
-  border: none;
-  background: none;
+  border: 3px solid #ccc;
+  background: #fff;
   cursor: pointer;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .team-button img {
   width: 100%;
   height: auto;
   object-fit: contain;
+}
+
+.team-tagline {
+  margin-top: 8px;
+  font-size: 14px;
+  text-align: center;
 }
 
 @media (max-width: 600px) {

--- a/FrontEnd/static/mode-select.html
+++ b/FrontEnd/static/mode-select.html
@@ -27,27 +27,35 @@
   <div id="team-grid">
     <button class="team-button" data-team="Bentley-Truman">
       <img src="/static/images/homepage-logos/Bentley-Truman.png" alt="Bentley-Truman logo">
+      <div class="team-tagline">Top-Shelf Talent</div>
     </button>
     <button class="team-button" data-team="Lancaster">
       <img src="/static/images/homepage-logos/Lancaster.png" alt="Lancaster logo">
+      <div class="team-tagline">Muscle & Defense</div>
     </button>
     <button class="team-button" data-team="Four Corners">
       <img src="/static/images/homepage-logos/Four Corners.png" alt="Four Corners logo">
+      <div class="team-tagline">Hustle & Attitude</div>
     </button>
     <button class="team-button" data-team="Ocean City">
       <img src="/static/images/homepage-logos/Ocean City.png" alt="Ocean City logo">
+      <div class="team-tagline">Sharpshooters Galore</div>
     </button>
     <button class="team-button" data-team="Morristown">
       <img src="/static/images/homepage-logos/Morristown.png" alt="Morristown logo">
+      <div class="team-tagline">Perfectly Balanced</div>
     </button>
     <button class="team-button" data-team="Little York">
       <img src="/static/images/homepage-logos/Little York.png" alt="Little York logo">
+      <div class="team-tagline">Wicked Smart</div>
     </button>
     <button class="team-button" data-team="Xavien">
       <img src="/static/images/homepage-logos/Xavien.png" alt="Xavien logo">
+      <div class="team-tagline">Youthful Exuberance</div>
     </button>
     <button class="team-button" data-team="South Lancaster">
       <img src="/static/images/homepage-logos/South Lancaster.png" alt="South Lancaster logo">
+      <div class="team-tagline">Us vs The World</div>
     </button>
   </div>
   <script src="./mode-select.js"></script>

--- a/FrontEnd/static/mode-select.js
+++ b/FrontEnd/static/mode-select.js
@@ -26,10 +26,38 @@ if (franchiseBtn) {
 
 document.addEventListener('DOMContentLoaded', () => {
   const teamButtons = document.querySelectorAll('.team-button');
+  const taglines = {
+    'Bentley-Truman': 'Top-Shelf Talent',
+    'Lancaster': 'Muscle & Defense',
+    'Four Corners': 'Hustle & Attitude',
+    'Ocean City': 'Sharpshooters Galore',
+    'Morristown': 'Perfectly Balanced',
+    'Little York': 'Wicked Smart',
+    'Xavien': 'Youthful Exuberance',
+    'South Lancaster': 'Us vs The World'
+  };
+
   teamButtons.forEach(btn => {
+    const team = btn.dataset.team;
+
+    const taglineEl = btn.querySelector('.team-tagline');
+    if (taglineEl && taglines[team]) {
+      taglineEl.textContent = taglines[team];
+    }
+
     btn.addEventListener('click', () => {
-      const team = btn.dataset.team;
       window.location.href = `/team-roster/${encodeURIComponent(team)}`;
     });
+
+    const slug = team.toLowerCase().replace(/[\s-]/g, '_');
+    fetch(`/teams/${slug}.json`)
+      .then(resp => resp.json())
+      .then(data => {
+        const color = data.secondary_color || '#ccc';
+        btn.style.borderColor = color;
+      })
+      .catch(() => {
+        btn.style.borderColor = '#ccc';
+      });
   });
 });


### PR DESCRIPTION
## Summary
- add tagline elements under each team logo on mode-select screen
- style team tiles with 3px border and layout for logos and taglines
- load each team's secondary color to tint border, defaulting to neutral when missing

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a287de548832896b0707a7226553e