### PR TITLE
ModeSelect: fill tiles with secondary color; taglines in Bebas Neue bold white

### DIFF
--- a/FrontEnd/static/mode-select.css
+++ b/FrontEnd/static/mode-select.css
@@ -85,6 +85,9 @@ body {
   margin-top: 8px;
   font-size: 14px;
   text-align: center;
+  font-family: 'Bebas Neue', sans-serif;
+  font-weight: 700;
+  color: #fff;
 }
 
 @media (max-width: 600px) {

--- a/FrontEnd/static/mode-select.js
+++ b/FrontEnd/static/mode-select.js
@@ -55,9 +55,11 @@ document.addEventListener('DOMContentLoaded', () => {
       .then(data => {
         const color = data.secondary_color || '#ccc';
         btn.style.borderColor = color;
+        btn.style.backgroundColor = color;
       })
       .catch(() => {
         btn.style.borderColor = '#ccc';
+        btn.style.backgroundColor = '#ccc';
       });
   });
 });


### PR DESCRIPTION
## Summary
- Fill Scout Teams tiles with each team's secondary_color, matching 3px border
- Style taglines in Bebas Neue, bold white for readability

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a2adf8eb08328a44a5c58880d17a2