### PR TITLE
ModeSelect: conditional tagline color for fallback grey; fix secondary_color fill on team tiles

### DIFF
--- a/BackEnd/api/api.py
+++ b/BackEnd/api/api.py
@@ -63,8 +63,11 @@ def root():
 
 @app.get("/teams")
 def get_team_names():
-    teams = teams_collection.find({}, {"name": 1, "_id": 0})
-    return sorted([team["name"] for team in teams])
+    teams = teams_collection.find({}, {"name": 1, "secondary_color": 1, "_id": 0})
+    return sorted([
+        {"name": team.get("name"), "secondary_color": team.get("secondary_color")}
+        for team in teams
+    ], key=lambda t: t["name"])
 
 
 @app.post("/api/simulate")

--- a/FrontEnd/static/mode-select.js
+++ b/FrontEnd/static/mode-select.js
@@ -48,18 +48,35 @@ document.addEventListener('DOMContentLoaded', () => {
     btn.addEventListener('click', () => {
       window.location.href = `/team-roster/${encodeURIComponent(team)}`;
     });
+  });
 
-    const slug = team.toLowerCase().replace(/[\s-]/g, '_');
-    fetch(`/teams/${slug}.json`)
-      .then(resp => resp.json())
-      .then(data => {
-        const color = data.secondary_color || '#ccc';
+  const fallbackColor = '#ccc';
+  fetch('/teams')
+    .then(resp => resp.json())
+    .then(teamData => {
+      const colorMap = {};
+      teamData.forEach(t => {
+        colorMap[t.name] = t.secondary_color;
+      });
+
+      teamButtons.forEach(btn => {
+        const team = btn.dataset.team;
+        const taglineEl = btn.querySelector('.team-tagline');
+        const color = colorMap[team] || fallbackColor;
+        const taglineColor = colorMap[team] ? '#fff' : '#000';
         btn.style.borderColor = color;
         btn.style.backgroundColor = color;
-      })
-      .catch(() => {
-        btn.style.borderColor = '#ccc';
-        btn.style.backgroundColor = '#ccc';
+        if (taglineEl) taglineEl.style.color = taglineColor;
+        console.log(`Tile ${team} bgColor: ${color}`);
       });
-  });
+    })
+    .catch(() => {
+      teamButtons.forEach(btn => {
+        const taglineEl = btn.querySelector('.team-tagline');
+        btn.style.borderColor = fallbackColor;
+        btn.style.backgroundColor = fallbackColor;
+        if (taglineEl) taglineEl.style.color = '#000';
+        console.log(`Tile ${btn.dataset.team} bgColor: ${fallbackColor} (fallback)`);
+      });
+    });
 });


### PR DESCRIPTION
## Summary
- expose each team's secondary color via the `/teams` endpoint
- use that color on Mode Select tiles, logging resolved colors and setting tagline text to black when falling back to grey

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a2da8da1c8328aa9a1577c8fb3fc6