### PR TITLE
Use primary color for mode select tiles

### DIFF
--- a/BackEnd/api/api.py
+++ b/BackEnd/api/api.py
@@ -63,11 +63,20 @@ def root():
 
 @app.get("/teams")
 def get_team_names():
-    teams = teams_collection.find({}, {"name": 1, "secondary_color": 1, "_id": 0})
-    return sorted([
-        {"name": team.get("name"), "secondary_color": team.get("secondary_color")}
-        for team in teams
-    ], key=lambda t: t["name"])
+    teams = teams_collection.find(
+        {}, {"name": 1, "primary_color": 1, "secondary_color": 1, "_id": 0}
+    )
+    return sorted(
+        [
+            {
+                "name": team.get("name"),
+                "primary_color": team.get("primary_color"),
+                "secondary_color": team.get("secondary_color"),
+            }
+            for team in teams
+        ],
+        key=lambda t: t["name"],
+    )
 
 
 @app.post("/api/simulate")

--- a/FrontEnd/static/mode-select.js
+++ b/FrontEnd/static/mode-select.js
@@ -56,18 +56,23 @@ document.addEventListener('DOMContentLoaded', () => {
     .then(teamData => {
       const colorMap = {};
       teamData.forEach(t => {
-        colorMap[t.name] = t.secondary_color;
+        colorMap[t.name] = {
+          primary: t.primary_color,
+          secondary: t.secondary_color
+        };
       });
 
       teamButtons.forEach(btn => {
         const team = btn.dataset.team;
         const taglineEl = btn.querySelector('.team-tagline');
-        const color = colorMap[team] || fallbackColor;
-        const taglineColor = colorMap[team] ? '#fff' : '#000';
-        btn.style.borderColor = color;
-        btn.style.backgroundColor = color;
+        const colors = colorMap[team] || {};
+        const bgColor = colors.primary || fallbackColor;
+        const borderColor = colors.secondary || fallbackColor;
+        const taglineColor = colors.primary ? '#fff' : '#000';
+        btn.style.backgroundColor = bgColor;
+        btn.style.borderColor = borderColor;
         if (taglineEl) taglineEl.style.color = taglineColor;
-        console.log(`Tile ${team} bgColor: ${color}`);
+        console.log(`Tile ${team} bgColor: ${bgColor} borderColor: ${borderColor}`);
       });
     })
     .catch(() => {


### PR DESCRIPTION
## Summary
- Populate mode select team tiles with their `primary_color` while keeping borders in `secondary_color`
- Expose `primary_color` in `/teams` API response for the frontend
- Ensure taglines use white text unless falling back to grey, where they switch to black

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a30e125348328a6c6b585b3f233fb