### PR TITLE
Tournament: accumulate player game stats into season (and career), reset game stats, show

### DIFF
--- a/BackEnd/api/api.py
+++ b/BackEnd/api/api.py
@@ -234,6 +234,7 @@ def get_team_players(team_id: str):
             "weight": p.get("weight"),
             "position_ratings": p.get("position_ratings", {}),
             "attributes": {attr: attributes.get(attr, "--") for attr in display_attributes},
+            "stats": p.get("stats", {}).get("season", {}),
         })
 
     return {

--- a/BackEnd/api/tournament_routes.py
+++ b/BackEnd/api/tournament_routes.py
@@ -5,6 +5,7 @@ from BackEnd.tournament.tournament_manager import TournamentManager
 from BackEnd.tournament.bracket_logic import update_bracket_from_results
 from BackEnd.main import run_simulation
 from BackEnd.utils.shared import summarize_game_state
+from BackEnd.utils.stat_updater import apply_stats_from_summary
 from bson import ObjectId
 
 router = APIRouter()
@@ -87,6 +88,7 @@ def simulate_round(request: SimulateRequest):
                 else matchup["away_team"]
             )
             manager.save_game_result(round_name, i, str(game_id), winner)
+            apply_stats_from_summary(summary, str(game_id), request.tournament_id)
 
         # Reload tournament to check if round is complete
         updated_doc = tournaments_collection.find_one({"_id": tournament_id})
@@ -174,6 +176,7 @@ def save_result(request: TournamentResultRequest):
             away_team = match["away_team"]
             summary = games_collection.find_one({"_id": ObjectId(request.game_id)}) or {}
             manager.save_game_result(round_key, i, request.game_id, request.winner, summary.get("score"))
+            apply_stats_from_summary(summary, request.game_id, request.tournament_id)
             user_result = {
                 "home_team": home_team,
                 "away_team": away_team,
@@ -195,6 +198,7 @@ def save_result(request: TournamentResultRequest):
         if match.get("game_id"):
             summary = games_collection.find_one({"_id": ObjectId(match["game_id"])} ) or {}
             manager.save_game_result(round_key, i, match["game_id"], match["winner"], summary.get("score"))
+            apply_stats_from_summary(summary, match["game_id"], request.tournament_id)
             result_doc = {
                 "home_team": match["home_team"],
                 "away_team": match["away_team"],
@@ -211,6 +215,7 @@ def save_result(request: TournamentResultRequest):
             summary = summarize_game_state(game)
             insert_result = games_collection.insert_one(summary)
             game_id = insert_result.inserted_id
+            apply_stats_from_summary(summary, str(game_id), request.tournament_id)
             print(f"✅ Game document inserted for round {round_num} match {i}")
         except Exception as e:
             print(
@@ -312,6 +317,7 @@ def sim_remaining(request: SimulateRequest):
                 )
                 if not exists:
                     summary = games_collection.find_one({"_id": ObjectId(match["game_id"])}) or {}
+                    apply_stats_from_summary(summary, match["game_id"], request.tournament_id)
                     result_doc = {
                         "home_team": match["home_team"],
                         "away_team": match["away_team"],
@@ -326,6 +332,7 @@ def sim_remaining(request: SimulateRequest):
             game = run_simulation(match["home_team"], match["away_team"])
             summary = summarize_game_state(game)
             game_id = games_collection.insert_one(summary).inserted_id
+            apply_stats_from_summary(summary, str(game_id), request.tournament_id)
             home = match["home_team"]
             away = match["away_team"]
             winner = home if summary["score"][home] > summary["score"][away] else away

--- a/BackEnd/utils/stat_updater.py
+++ b/BackEnd/utils/stat_updater.py
@@ -1,0 +1,49 @@
+from typing import Any, Dict
+
+from BackEnd.db import players_collection
+
+
+def apply_stats_from_summary(summary: Dict[str, Any], game_id: str, tournament_id: str | None = None) -> None:
+    """Accumulate each player's game stats into season and career totals.
+
+    This function is idempotent per (tournament_id, game_id) pair.  If the
+    combination has already been applied for a player, no changes will occur.
+    After applying, the player's game stats are reset to zero.
+    """
+    token = f"{tournament_id}:{game_id}" if tournament_id else str(game_id)
+
+    box_score = summary.get("box_score", {})
+    players = summary.get("players", [])
+    team_map = {
+        "home": summary.get("home_team"),
+        "away": summary.get("away_team"),
+    }
+
+    for p in players:
+        pid = p.get("playerId")
+        team_side = p.get("team")
+        pos = p.get("pos")
+        team_name = team_map.get(team_side)
+        if not pid or not team_name:
+            continue
+        stat_block = box_score.get(team_name, {}).get(pos, {})
+        inc_fields: Dict[str, Any] = {}
+        set_fields: Dict[str, Any] = {}
+        for stat, val in stat_block.items():
+            if stat == "name":
+                continue
+            if isinstance(val, (int, float)):
+                inc_fields[f"stats.season.{stat}"] = val
+                inc_fields[f"stats.career.{stat}"] = val
+                set_fields[f"stats.game.{stat}"] = 0
+        if not inc_fields and not set_fields:
+            continue
+        update_doc: Dict[str, Any] = {"$addToSet": {"stats.applied_games": token}}
+        if inc_fields:
+            update_doc["$inc"] = inc_fields
+        if set_fields:
+            update_doc["$set"] = set_fields
+        players_collection.update_one(
+            {"_id": pid, "stats.applied_games": {"$ne": token}},
+            update_doc,
+        )

--- a/FrontEnd/static/tournament.js
+++ b/FrontEnd/static/tournament.js
@@ -325,15 +325,16 @@ async function loadRoster() {
         weight: p.weight ?? '--',
         attributes: p.attributes || {},
         rt: best.rating,
+        rawStats: p.stats || {},
       };
     });
     roster.sort((a, b) => (b.rt ?? -1) - (a.rt ?? -1));
-    stats = roster.map(p => ({
-      name: p.name,
-      PTS: 0, FGM: 0, FGA: 0, TPM: 0, TPA: 0,
-      FTM: 0, FTA: 0, REB: 0, AST: 0,
-      STL: 0, BLK: 0, F: 0, MIN: 0, TO: 0,
-    }));
+    const statKeys = ["PTS","FGM","FGA","TPM","TPA","FTM","FTA","REB","AST","STL","BLK","F","MIN","TO"];
+    stats = roster.map(p => {
+      const row = { name: p.name };
+      statKeys.forEach(k => row[k] = p.rawStats[k] || 0);
+      return row;
+    });
   } catch (err) {
     console.error("Failed to load roster", err);
   }

--- a/tests/test_tournament_player_stats.py
+++ b/tests/test_tournament_player_stats.py
@@ -1,0 +1,59 @@
+from BackEnd.utils.stat_updater import apply_stats_from_summary
+from BackEnd.db import players_collection
+
+
+def setup_function(fn):
+    players_collection.delete_many({})
+    players_collection.insert_many([
+        {
+            "_id": "p1",
+            "team": "Lancaster",
+            "first_name": "A",
+            "last_name": "One",
+            "stats": {
+                "game": {"PTS": 0, "AST": 0},
+                "season": {"PTS": 0, "AST": 0},
+                "career": {"PTS": 0, "AST": 0},
+                "applied_games": [],
+            },
+        },
+        {
+            "_id": "p2",
+            "team": "Bentley-Truman",
+            "first_name": "B",
+            "last_name": "Two",
+            "stats": {
+                "game": {"PTS": 0, "AST": 0},
+                "season": {"PTS": 0, "AST": 0},
+                "career": {"PTS": 0, "AST": 0},
+                "applied_games": [],
+            },
+        },
+    ])
+
+
+def test_apply_stats_idempotent():
+    summary = {
+        "home_team": "Lancaster",
+        "away_team": "Bentley-Truman",
+        "box_score": {
+            "Lancaster": {"PG": {"name": "A One", "PTS": 10, "AST": 2}},
+            "Bentley-Truman": {"PG": {"name": "B Two", "PTS": 5, "AST": 1}},
+        },
+        "players": [
+            {"playerId": "p1", "team": "home", "pos": "PG"},
+            {"playerId": "p2", "team": "away", "pos": "PG"},
+        ],
+    }
+    apply_stats_from_summary(summary, "g1", "t1")
+    p1 = players_collection.find_one({"_id": "p1"})
+    assert p1["stats"]["season"]["PTS"] == 10
+    assert p1["stats"]["season"]["AST"] == 2
+    assert p1["stats"]["game"]["PTS"] == 0
+    assert "t1:g1" in p1["stats"]["applied_games"]
+
+    # Apply again; should be idempotent
+    apply_stats_from_summary(summary, "g1", "t1")
+    p1 = players_collection.find_one({"_id": "p1"})
+    assert p1["stats"]["season"]["PTS"] == 10
+    assert p1["stats"]["season"]["AST"] == 2


### PR DESCRIPTION
## Summary
- Track tournament game stats into season and career totals with an idempotent helper.
- Apply season stat updates when simulating or saving tournament games and expose season stats via team-player API.
- Display tournament season stats in the Team tab and ensure no double-counting with tests.

## Testing
- `PYTHONPATH=/workspace/gob-simplified pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a2fd9bc6083289046902aa328e390