### PR TITLE
ModeSelect: widen Scout Teams to match mode cards width; scale tiles/logos/taglines proportionally (gaps unchanged)

### DIFF
--- a/FrontEnd/static/mode-select.css
+++ b/FrontEnd/static/mode-select.css
@@ -12,11 +12,18 @@ body {
   margin-bottom: 20px;
 }
 
+.mode-wrapper {
+  width: fit-content;
+  max-width: 100%;
+  margin: 0 auto;
+}
+
 .mode-container {
   display: flex;
   justify-content: center;
   gap: 20px;
   flex-wrap: wrap;
+  width: 100%;
 }
 
 .mode-card {
@@ -61,8 +68,7 @@ body {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 15px;
-  max-width: 800px;
-  margin: 0 auto;
+  width: 100%;
 }
 
 .team-button {
@@ -73,17 +79,18 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
+  aspect-ratio: 1;
 }
 
 .team-button img {
+  flex: 1;
   width: 100%;
-  height: auto;
   object-fit: contain;
 }
 
 .team-tagline {
   margin-top: 8px;
-  font-size: 14px;
+  font-size: clamp(12px, 1.1vw, 22px);
   text-align: center;
   font-family: 'Bebas Neue', sans-serif;
   font-weight: 700;

--- a/FrontEnd/static/mode-select.html
+++ b/FrontEnd/static/mode-select.html
@@ -9,6 +9,7 @@
 </head>
 <body>
   <h1 id="page-title">CHOOSE YOUR GAME MODE</h1>
+  <div class="mode-wrapper">
   <div class="mode-container">
     <div class="mode-card">
       <h2>Scrimmage</h2>
@@ -57,6 +58,7 @@
       <img src="/static/images/homepage-logos/South Lancaster.png" alt="South Lancaster logo">
       <div class="team-tagline">Us vs The World</div>
     </button>
+  </div>
   </div>
   <script src="./mode-select.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- Wrap mode cards and Scout Teams in a shared container so the grid aligns with the mode cards row
- Let Scout Teams grid expand to wrapper width and scale tiles and logos with `aspect-ratio` and flex layout
- Make taglines responsive with `font-size: clamp` while preserving existing gaps

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a385034b48328be09aceb6b545207