### PR TITLE
Tournament: dynamic Leaders tab from season stats (top 10 by stat)

### DIFF
--- a/BackEnd/api/tournament_routes.py
+++ b/BackEnd/api/tournament_routes.py
@@ -1,6 +1,11 @@
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
-from BackEnd.db import tournaments_collection, teams_collection, games_collection
+from BackEnd.db import (
+    tournaments_collection,
+    teams_collection,
+    games_collection,
+    players_collection,
+)
 from BackEnd.tournament.tournament_manager import TournamentManager
 from BackEnd.tournament.bracket_logic import update_bracket_from_results
 from BackEnd.main import run_simulation
@@ -22,6 +27,86 @@ class TournamentResultRequest(BaseModel):
 
 class SimulateRequest(BaseModel):
     tournament_id: str
+
+
+@router.get("/tournament/leaders")
+def get_tournament_leaders(tournament_id: str):
+    """Return top 10 leaders for key stats within a tournament."""
+    try:
+        tid = ObjectId(tournament_id)
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid tournament_id")
+
+    tourney = tournaments_collection.find_one({"_id": tid})
+    if not tourney:
+        raise HTTPException(status_code=404, detail="Tournament not found")
+
+    teams: set[str] = set()
+    for round_matches in tourney.get("bracket", {}).values():
+        for match in round_matches:
+            teams.add(match.get("home_team"))
+            teams.add(match.get("away_team"))
+    teams.discard(None)
+
+    players = list(players_collection.find({"team": {"$in": list(teams)}}))
+
+    categories = [
+        ("PTS", "MIN"),
+        ("TPM", "TPA"),
+        ("REB", "MIN"),
+        ("AST", "MIN"),
+        ("STL", "MIN"),
+        ("BLK", "MIN"),
+    ]
+
+    def stat_val(stats: dict, key: str) -> float:
+        if key in stats:
+            return stats.get(key, 0)
+        if key == "TPM":
+            return stats.get("3PTM", 0)
+        if key == "TPA":
+            return stats.get("3PTA", 0)
+        return stats.get(key, 0)
+
+    result: dict[str, list] = {}
+    for stat, tie_key in categories:
+        entries = []
+        for p in players:
+            season = p.get("stats", {}).get("season", {})
+            value = stat_val(season, stat)
+            tie_val = stat_val(season, tie_key) if tie_key else 0
+            entries.append(
+                {
+                    "player_id": str(p.get("_id")),
+                    "first_name": p.get("first_name", ""),
+                    "last_name": p.get("last_name", ""),
+                    "team_name": p.get("team", ""),
+                    "value": value,
+                    "_tie": tie_val,
+                }
+            )
+        entries.sort(
+            key=lambda x: (
+                -x["value"],
+                -x["_tie"],
+                f"{x['first_name']} {x['last_name']}",
+            )
+        )
+        top = []
+        for idx, e in enumerate(entries[:10], start=1):
+            top.append(
+                {
+                    "rank": idx,
+                    "player_id": e["player_id"],
+                    "first_name": e["first_name"],
+                    "last_name": e["last_name"],
+                    "team_name": e["team_name"],
+                    "value": e["value"],
+                }
+            )
+        result[stat] = top
+
+    return result
 
 @router.post("/start-tournament")
 def start_tournament(request: StartTournamentRequest):

--- a/FrontEnd/static/tournament.js
+++ b/FrontEnd/static/tournament.js
@@ -43,6 +43,8 @@ const leaderBoards = [
   { title: "Blocks", key: "BLK" }
 ];
 
+let leaderData = {};
+
 console.log("✅ tournament.js loaded");
 
 function getLogo(teamName) {
@@ -229,9 +231,15 @@ function renderLeaderboards() {
     table.className = "leaders-table";
     table.innerHTML = `<thead><tr><th>Rank</th><th>Player</th><th>Team</th><th>Value</th></tr></thead>`;
     const body = document.createElement("tbody");
-    for (let i=1;i<=10;i++) {
+    const rows = (leaderData[board.key] || []);
+    for (let i = 0; i < 10; i++) {
+      const entry = rows[i];
       const tr = document.createElement("tr");
-      tr.innerHTML = `<td>${i}</td><td>Player ${i}</td><td>Team ${String.fromCharCode(64+i)}</td><td>${(20-i).toFixed(1)}</td>`;
+      if (entry) {
+        tr.innerHTML = `<td>${entry.rank}</td><td>${entry.first_name} ${entry.last_name}</td><td>${entry.team_name}</td><td>${entry.value}</td>`;
+      } else {
+        tr.innerHTML = `<td>${i + 1}</td><td>—</td><td>—</td><td>—</td>`;
+      }
       body.appendChild(tr);
     }
     table.appendChild(body);
@@ -240,6 +248,20 @@ function renderLeaderboards() {
     container.appendChild(section);
   });
 }
+
+async function refreshLeaders() {
+  if (!tournament || !tournament._id) return;
+  try {
+    const res = await fetch(`/tournament/leaders?tournament_id=${encodeURIComponent(tournament._id)}`);
+    leaderData = await res.json();
+  } catch (err) {
+    console.error("Failed to load leaders", err);
+    leaderData = {};
+  }
+  renderLeaderboards();
+}
+
+window.refreshLeaders = refreshLeaders;
 
 function updateCTA() {
   const playBtn = document.getElementById('play-now');
@@ -351,7 +373,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   renderBracket();
   renderRoster();
   renderStats();
-  renderLeaderboards();
+  await refreshLeaders();
   updateCTA();
 
   const playBtn = document.getElementById('play-now');
@@ -374,6 +396,7 @@ document.addEventListener("DOMContentLoaded", async () => {
           alert('This round has already been played.');
           return;
         }
+        await refreshLeaders();
         const { home, away } = data;
         if (!home || !away) throw new Error('Matchup not found');
         window.location.href = `/court.html?tournament_id=${encodeURIComponent(tournament._id)}&home=${encodeURIComponent(home)}&away=${encodeURIComponent(away)}`;
@@ -404,6 +427,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         tournament = data;
         localStorage.setItem('activeTournament', JSON.stringify(tournament));
         renderBracket();
+        await refreshLeaders();
         updateCTA();
       } catch (err) {
         console.error('Failed to simulate remaining games', err);

--- a/tests/test_tournament_leaders_endpoint.py
+++ b/tests/test_tournament_leaders_endpoint.py
@@ -1,0 +1,84 @@
+from BackEnd.tournament.tournament_manager import TournamentManager
+from BackEnd.api.tournament_routes import get_tournament_leaders
+from BackEnd.db import players_collection, tournaments_collection
+
+
+def setup_function(fn):
+    players_collection.delete_many({})
+    tournaments_collection.delete_many({})
+
+
+def test_leaders_return_top_players_and_exclude_others():
+    players_collection.insert_many(
+        [
+            {
+                "_id": "p1",
+                "team": "A",
+                "first_name": "Ann",
+                "last_name": "Alpha",
+                "stats": {
+                    "season": {
+                        "PTS": 20,
+                        "TPM": 5,
+                        "TPA": 10,
+                        "REB": 8,
+                        "AST": 4,
+                        "STL": 2,
+                        "BLK": 1,
+                        "MIN": 30,
+                    }
+                },
+            },
+            {
+                "_id": "p2",
+                "team": "B",
+                "first_name": "Bob",
+                "last_name": "Beta",
+                "stats": {
+                    "season": {
+                        "PTS": 15,
+                        "TPM": 5,
+                        "TPA": 8,
+                        "REB": 7,
+                        "AST": 5,
+                        "STL": 1,
+                        "BLK": 0,
+                        "MIN": 28,
+                    }
+                },
+            },
+            {
+                "_id": "p3",
+                "team": "X",
+                "first_name": "X",  # should be excluded
+                "last_name": "Excluded",
+                "stats": {
+                    "season": {
+                        "PTS": 100,
+                        "TPM": 20,
+                        "TPA": 30,
+                        "REB": 10,
+                        "AST": 10,
+                        "STL": 10,
+                        "BLK": 10,
+                        "MIN": 40,
+                    }
+                },
+            },
+        ]
+    )
+
+    manager = TournamentManager(
+        user_team_id="A",
+        tournaments_collection=tournaments_collection,
+        team_ids=["A", "B", "C", "D", "E", "F", "G", "H"],
+    )
+    tourney = manager.create_tournament()
+
+    leaders = get_tournament_leaders(tourney["_id"])
+
+    assert leaders["PTS"][0]["player_id"] == "p1"
+    assert leaders["PTS"][1]["player_id"] == "p2"
+    assert all(entry["player_id"] != "p3" for entry in leaders["PTS"])
+    assert leaders["TPM"][0]["player_id"] == "p1"
+    assert leaders["TPM"][1]["player_id"] == "p2"


### PR DESCRIPTION
## Summary
- add `/tournament/leaders` endpoint to compute top 10 players for key stats from season totals
- fetch tournament leader data on the Leaders tab and refresh after simulations
- test leaderboard computation and filtering for tournament teams

## Testing
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a39a8d8b88328a8651a85953df109