### PR TITLE
ModeSelect: align Scout Teams width to mode cards; keep gaps; scale tiles/logos/taglines proportionally

### DIFF
--- a/FrontEnd/static/mode-select.css
+++ b/FrontEnd/static/mode-select.css
@@ -68,7 +68,7 @@ body {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 15px;
-  width: 100%;
+  margin: 0 auto;
 }
 
 .team-button {
@@ -85,6 +85,7 @@ body {
 .team-button img {
   flex: 1;
   width: 100%;
+  height: 100%;
   object-fit: contain;
 }
 

--- a/FrontEnd/static/mode-select.js
+++ b/FrontEnd/static/mode-select.js
@@ -26,6 +26,15 @@ if (franchiseBtn) {
 
 document.addEventListener('DOMContentLoaded', () => {
   const teamButtons = document.querySelectorAll('.team-button');
+  const modeContainer = document.querySelector('.mode-container');
+  const teamGrid = document.getElementById('team-grid');
+  const syncTeamGridWidth = () => {
+    if (modeContainer && teamGrid) {
+      teamGrid.style.width = `${modeContainer.offsetWidth}px`;
+    }
+  };
+  window.addEventListener('resize', syncTeamGridWidth);
+  syncTeamGridWidth();
   const taglines = {
     'Bentley-Truman': 'Top-Shelf Talent',
     'Lancaster': 'Muscle & Defense',


### PR DESCRIPTION
## Summary
- constrain Scout Teams grid width to match mode cards via dynamic sync
- center grid and let tiles/logos scale within fixed bounds
- ensure logos maintain aspect with explicit height for consistent scaling

## Testing
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a42a2173083289fa902f3e3d907fe