### PR TITLE
Update scoreboard live on score turns

### DIFF
--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -1,6 +1,21 @@
 import * as Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.60.0/dist/phaser.esm.js';
 import { createGameScene } from './gameScene.js';
 import { setCourtOffsets } from './utils/gridToPixels.js';
+import { on, emit } from './utils/eventBus.js';
+
+function updateScoreboardScores({ home, away }) {
+  const homeScoreEl = document.getElementById('home-score');
+  const awayScoreEl = document.getElementById('away-score');
+  if (homeScoreEl) homeScoreEl.textContent = home;
+  if (awayScoreEl) awayScoreEl.textContent = away;
+}
+
+if (typeof on === 'function' && typeof emit === 'function') {
+  on('score:update', updateScoreboardScores);
+  emit('score:update', { home: 0, away: 0 });
+} else {
+  updateScoreboardScores({ home: 0, away: 0 });
+}
 
 function getMode({ tournamentId, franchiseId }) {
   if (tournamentId) return 'tournament';

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -2,6 +2,7 @@ import { animateGameTurns } from './animation/animateGameTurns.js';
 import { loadPhaserPlayers } from './setup/loadPhaserPlayers.js';
 import { gridToPixels } from './utils/gridToPixels.js';
 import { finalizeGame } from './finalizeGame.js';
+import { emit } from './utils/eventBus.js';
 
 export function createGameScene(Phaser) {
   return class GameScene extends Phaser.Scene {
@@ -77,8 +78,6 @@ export function createGameScene(Phaser) {
       if (homeLogoEl) homeLogoEl.src = `/static/images/homepage-logos/${encodeURIComponent(homeTeam)}.png`;
       if (awayLogoEl) awayLogoEl.src = `/static/images/homepage-logos/${encodeURIComponent(awayTeam)}.png`;
 
-      const homeScoreEl = document.getElementById('home-score');
-      const awayScoreEl = document.getElementById('away-score');
       const homeFoulsEl = document.getElementById('home-fouls');
       const awayFoulsEl = document.getElementById('away-fouls');
       const clockEl = document.getElementById('game-clock');
@@ -92,6 +91,9 @@ export function createGameScene(Phaser) {
       let liveQuarter = 1;
 
       const updateScoreboard = (turn = {}) => {
+        const prevHome = liveScore[homeTeam];
+        const prevAway = liveScore[awayTeam];
+
         // Update score from authoritative state or incrementally from event
         if (turn.score) {
           if (typeof turn.score[homeTeam] === 'number') liveScore[homeTeam] = turn.score[homeTeam];
@@ -111,12 +113,17 @@ export function createGameScene(Phaser) {
         if (turn.clock || turn.game_clock) liveClock = turn.clock || turn.game_clock;
         if (turn.quarter != null) liveQuarter = turn.quarter;
 
-        if (homeScoreEl) homeScoreEl.textContent = liveScore[homeTeam];
-        if (awayScoreEl) awayScoreEl.textContent = liveScore[awayTeam];
         if (homeFoulsEl) homeFoulsEl.textContent = `F: ${liveHomeFouls}`;
         if (awayFoulsEl) awayFoulsEl.textContent = `F: ${liveAwayFouls}`;
         if (clockEl) clockEl.textContent = liveClock;
         if (quarterEl) quarterEl.textContent = `Q:${liveQuarter}`;
+
+        if (liveScore[homeTeam] !== prevHome || liveScore[awayTeam] !== prevAway) {
+          emit('score:update', {
+            home: liveScore[homeTeam],
+            away: liveScore[awayTeam],
+          });
+        }
       };
 
       // Initialize scoreboard at tip-off

--- a/FrontEnd/static/js/phaser/utils/eventBus.js
+++ b/FrontEnd/static/js/phaser/utils/eventBus.js
@@ -1,0 +1,9 @@
+const bus = new EventTarget();
+
+export function on(event, handler) {
+  bus.addEventListener(event, (e) => handler(e.detail));
+}
+
+export function emit(event, detail) {
+  bus.dispatchEvent(new CustomEvent(event, { detail }));
+}


### PR DESCRIPTION
## Summary
- Add a tiny event bus for simple `on`/`emit` helpers
- Emit `score:update` from the game scene whenever scores change
- Subscribe in `bootGame` to update the scoreboard DOM and initialize at 0-0

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a846faec883289b23bb18a432770e