### PR TITLE
feat: deliver turn-by-turn scoreboard updates

### DIFF
--- a/BackEnd/engine/phase_resolution.py
+++ b/BackEnd/engine/phase_resolution.py
@@ -307,14 +307,19 @@ def resolve_free_throw_logic(game):
             possession_flips = True
 
     shooter_pos = get_player_position(off_lineup, shooter)
-
-    return {
+    result = {
         "result_type": "FREE_THROW",
         "ball_handler": shooter,
         "text": text,
         "time_elapsed": 0,  # clock does not run
         "possession_flips": possession_flips,
     }
+
+    if makes_shot:
+        result["points"] = 1
+        result["scoring_team"] = off_team.name
+
+    return result
 
 
 def resolve_turnover_logic(roles, game, turnover_type="DEAD BALL"):

--- a/BackEnd/models/shot_manager.py
+++ b/BackEnd/models/shot_manager.py
@@ -176,7 +176,7 @@ class ShotManager:
         shooter_pos = get_player_position(off_lineup, shooter)
         print(f"end of resolve_shot, possession_flips: {possession_flips}")
 
-        return {
+        result = {
             "result_type": "MAKE" if made else "MISS",
             "ball_handler": shooter,
             "shooter": shooter,
@@ -187,6 +187,12 @@ class ShotManager:
             "possession_flips": possession_flips,
             "time_elapsed": time_elapsed
         }
+
+        if made:
+            result["points"] = points
+            result["scoring_team"] = off_team.name
+
+        return result
 
     
     def calculate_shot_score(self, shooter, passer, screener, defender, playcall, defense_call, is_three):

--- a/BackEnd/models/turn_manager.py
+++ b/BackEnd/models/turn_manager.py
@@ -124,6 +124,8 @@ class TurnManager:
         result["home_lineup"] = serialize_lineup(self.game.home_team.lineup)
         result["away_lineup"] = serialize_lineup(self.game.away_team.lineup)
 
+        result["score"] = dict(self.game.score)
+
         # print(f"inside run_micro_turn result: {result}")
         # print(f"result: {result}")
         return result

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -94,15 +94,9 @@ export function createGameScene(Phaser) {
         const prevHome = liveScore[homeTeam];
         const prevAway = liveScore[awayTeam];
 
-        // Update score from authoritative state or incrementally from event
         if (turn.score) {
           if (typeof turn.score[homeTeam] === 'number') liveScore[homeTeam] = turn.score[homeTeam];
           if (typeof turn.score[awayTeam] === 'number') liveScore[awayTeam] = turn.score[awayTeam];
-        } else {
-          const scoringTeam = turn.scoring_team || turn.team || turn.offense_team;
-          if (turn.result === 'made_3') liveScore[scoringTeam] = (liveScore[scoringTeam] || 0) + 3;
-          else if (turn.result === 'made_2') liveScore[scoringTeam] = (liveScore[scoringTeam] || 0) + 2;
-          else if (turn.result === 'made_ft') liveScore[scoringTeam] = (liveScore[scoringTeam] || 0) + 1;
         }
 
         const homeF = turn.homeFouls ?? turn.home_team_fouls ?? turn.fouls?.home;

--- a/tests/test_scoreboard_turn_updates.py
+++ b/tests/test_scoreboard_turn_updates.py
@@ -1,0 +1,56 @@
+import types
+from tests.test_utils import build_mock_game
+from BackEnd.utils.shared import record_team_points
+
+
+def test_turn_result_includes_score_without_scoring():
+    game = build_mock_game()
+    tm = game.turn_manager
+
+    def fake_no_score():
+        return {
+            "result_type": "MISS",
+            "ball_handler": game.offense_team.lineup["PG"],
+            "shooter": game.offense_team.lineup["PG"],
+            "screener": game.offense_team.lineup["SG"],
+            "passer": game.offense_team.lineup["SG"],
+            "defender": game.defense_team.lineup["PG"],
+            "text": "miss",
+            "possession_flips": True,
+            "time_elapsed": 24,
+        }
+
+    tm.resolve_half_court_offense = types.MethodType(lambda self: fake_no_score(), tm)
+    result = tm.run_micro_turn()
+
+    assert "score" in result
+    assert result["score"][game.home_team.name] == 0
+    assert result["score"][game.away_team.name] == 0
+
+
+def test_scoring_turn_includes_metadata_and_score():
+    game = build_mock_game()
+    tm = game.turn_manager
+
+    def fake_score():
+        record_team_points(game, game.offense_team, 2)
+        return {
+            "result_type": "MAKE",
+            "ball_handler": game.offense_team.lineup["PG"],
+            "shooter": game.offense_team.lineup["PG"],
+            "screener": game.offense_team.lineup["SG"],
+            "passer": game.offense_team.lineup["SG"],
+            "defender": game.defense_team.lineup["PG"],
+            "text": "scores",
+            "possession_flips": True,
+            "time_elapsed": 24,
+            "points": 2,
+            "scoring_team": game.offense_team.name,
+        }
+
+    tm.resolve_half_court_offense = types.MethodType(lambda self: fake_score(), tm)
+    result = tm.run_micro_turn()
+
+    assert result["score"][game.home_team.name] == 2
+    assert result.get("points") == 2
+    assert result.get("scoring_team") == game.home_team.name


### PR DESCRIPTION
## Summary
- include cumulative score in every turn payload
- add points and scoring_team metadata for made shots and free throws
- drive frontend scoreboard directly from turn.score
- test scoring and non-scoring turns for score metadata

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b463204d883288bcb8c51a5f8f2e8