### PR TITLE
Gameplay: run four quarters (Q1–Q4), reset clock each quarter, finalize after Q4

### DIFF
--- a/BackEnd/main.py
+++ b/BackEnd/main.py
@@ -31,6 +31,7 @@ from BackEnd.utils.shared import (
     default_rebounder_dict,
     determine_rebounder,
 )
+from BackEnd.utils.energy_system import recharge_lineups
 
 def initialize_team_attributes():
     settings = {}
@@ -240,10 +241,36 @@ def run_simulation(home_team_name, away_team_name):
     gm.away_team.lineup = build_lineup_from_mongo(away_team_name)
 
     gm.turn_manager = TurnManager(gm)  # Rebuild now that lineups are present
+    for q in range(1, 5):
+        gm.quarter = q
+        gm.game_state["quarter"] = q
 
-    while gm.game_state["time_remaining"] > 0:
-        gm.simulate_macro_turn()
-        print(f"🏀 {gm.home_team.name}: {gm.game_state['score'][gm.home_team.name]} | {gm.away_team.name}: {gm.game_state['score'][gm.away_team.name]}")
+        # Reset clock and fouls
+        gm.game_state["time_remaining"] = 480
+        gm.game_state["clock"] = "8:00"
+        gm.home_team.team_fouls = 0
+        gm.away_team.team_fouls = 0
+        gm.game_state["team_fouls"] = {gm.home_team.name: 0, gm.away_team.name: 0}
+
+        # Recharge energy at quarter start
+        recharge_amount = 0.3 if q == 3 else 0.2
+        recharge_lineups(gm, recharge_amount)
+
+        print(f"=== Start of Q{q} ===")
+        while gm.game_state["time_remaining"] > 0:
+            gm.simulate_macro_turn()
+            gm.game_state["team_fouls"] = {
+                gm.home_team.name: gm.home_team.team_fouls,
+                gm.away_team.name: gm.away_team.team_fouls,
+            }
+            clock = gm.game_state["clock"]
+            h, a = gm.home_team.name, gm.away_team.name
+            h_pts = gm.game_state["score"][h]
+            a_pts = gm.game_state["score"][a]
+            print(f"Clock: {clock} // Q{q}")
+            print(f"🏀 {h}: {h_pts} | {a}: {a_pts}")
+            print(f"Team Fouls: {gm.game_state['team_fouls']}")
+        print(f"=== End of Q{q} ===")
 
     # Print all game statistics including defense score stats
     # gm.print_game_statistics()

--- a/BackEnd/models/game_manager.py
+++ b/BackEnd/models/game_manager.py
@@ -47,6 +47,10 @@ class GameManager:
             "current_playcall": "Outside",
             "defense_playcall": "Zone",
             "offensive_state": "HCO",
+            "team_fouls": {
+                self.home_team.name: 0,
+                self.away_team.name: 0,
+            },
             "box_score": {
                 self.home_team.name: {},
                 self.away_team.name: {}

--- a/BackEnd/utils/energy_system.py
+++ b/BackEnd/utils/energy_system.py
@@ -1,0 +1,14 @@
+"""Energy system utilities for quarter breaks."""
+
+from BackEnd.models.game_manager import GameManager
+
+def recharge_lineups(game: GameManager, amount: float) -> None:
+    """Recharge energy for all players in both lineups.
+
+    Args:
+        game: GameManager instance containing home and away teams.
+        amount: Fraction of energy to restore (0.0-1.0).
+    """
+    for team in [game.home_team, game.away_team]:
+        for player in team.lineup.values():
+            player.recharge_energy(amount)


### PR DESCRIPTION
## Summary
- Simulate full four-quarter games, resetting clock and fouls each quarter and recharging player energy between quarters.
- Track team fouls in game state to keep scoreboard updated in real time.
- Provide reusable energy recharge helper for quarter breaks.

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b485234f4832897a4b32796b5ca82