### PR TITLE
Scoreboard: live per-turn updates for clock, quarter, and team fouls (same flow as score)

### DIFF
--- a/BackEnd/models/turn_manager.py
+++ b/BackEnd/models/turn_manager.py
@@ -126,6 +126,16 @@ class TurnManager:
 
         result["score"] = dict(self.game.score)
 
+        # Sync and expose fouls/clock/quarter for live scoreboard updates
+        self.game.game_state["team_fouls"] = {
+            self.game.home_team.name: self.game.home_team.team_fouls,
+            self.game.away_team.name: self.game.away_team.team_fouls,
+        }
+        result["homeFouls"] = self.game.home_team.team_fouls
+        result["awayFouls"] = self.game.away_team.team_fouls
+        result["clock"] = self.game.game_state["clock"]
+        result["quarter"] = self.game.game_state["quarter"]
+
         # print(f"inside run_micro_turn result: {result}")
         # print(f"result: {result}")
         return result

--- a/tests/test_scoreboard_turn_updates.py
+++ b/tests/test_scoreboard_turn_updates.py
@@ -54,3 +54,31 @@ def test_scoring_turn_includes_metadata_and_score():
     assert result["score"][game.home_team.name] == 2
     assert result.get("points") == 2
     assert result.get("scoring_team") == game.home_team.name
+
+
+def test_turn_payload_includes_clock_quarter_fouls():
+    game = build_mock_game()
+    tm = game.turn_manager
+
+    def fake_turn_with_foul():
+        # Record a defensive foul on the away team
+        game.defense_team.record_team_foul()
+        return {
+            "result_type": "FOUL",
+            "ball_handler": game.offense_team.lineup["PG"],
+            "shooter": game.offense_team.lineup["PG"],
+            "screener": game.offense_team.lineup["SG"],
+            "passer": game.offense_team.lineup["SG"],
+            "defender": game.defense_team.lineup["PG"],
+            "text": "foul",
+            "possession_flips": False,
+            "time_elapsed": 30,
+        }
+
+    tm.resolve_half_court_offense = types.MethodType(lambda self: fake_turn_with_foul(), tm)
+    result = tm.run_micro_turn()
+
+    assert result["clock"] == "7:30"
+    assert result["quarter"] == 1
+    assert result["homeFouls"] == 0
+    assert result["awayFouls"] == 1


### PR DESCRIPTION
## Summary
- Include current clock, quarter, and team foul counts in each turn payload.
- Sync scoreboard UI with fouls and time using existing per-turn update flow.
- Add regression tests ensuring per-turn payload carries clock/quarter/fouls.

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b612a6c908328b5d3bcdedfa843d6