### PR TITLE
ModeSelect: triple tagline font size in Scout Teams tiles (responsive, spacing preserved)

### DIFF
--- a/FrontEnd/static/mode-select.css
+++ b/FrontEnd/static/mode-select.css
@@ -90,12 +90,14 @@ body {
 }
 
 .team-tagline {
-  margin-top: 8px;
-  font-size: clamp(12px, 1.1vw, 66px);
+  margin-top: 0.25em;
+  font-size: clamp(12px, 3.3vw, 198px);
+  line-height: 0.9;
   text-align: center;
   font-family: 'Bebas Neue', sans-serif;
   font-weight: 700;
   color: #fff;
+  overflow-wrap: anywhere;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- triple Scout Teams tagline font size using responsive `clamp` and fluid vw scaling
- adjust margins/line-height to keep spacing and prevent overlap; allow text wrap

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b713aa2508328899a92e9103220a5