### PR TITLE
Add drag-and-drop lineup selection before game animation

### DIFF
--- a/BackEnd/api/api.py
+++ b/BackEnd/api/api.py
@@ -55,6 +55,8 @@ app.add_middleware(
 class SimulationRequest(BaseModel):
     home_team: str
     away_team: str
+    home_lineup: dict[str, str] | None = None
+    away_lineup: dict[str, str] | None = None
 
 # 4. Routes
 @app.get("/")
@@ -99,7 +101,7 @@ def simulate_game(request: SimulationRequest):
     # print("🔍 Full request body:", request)
 
 
-    game = run_simulation(home_team, away_team)
+    game = run_simulation(home_team, away_team, request.home_lineup, request.away_lineup)
     # print("Right before summarize_game_state")
     # print("🧪 Turns sample:", game.turns[:3])
     summary = summarize_game_state(game)

--- a/BackEnd/main.py
+++ b/BackEnd/main.py
@@ -1,7 +1,7 @@
 import random
 import json
 from BackEnd.db import players_collection, teams_collection
-from BackEnd.utils.db_utils import build_lineup_from_mongo
+from BackEnd.utils.db_utils import build_lineup_from_mongo, build_lineup_from_ids
 from BackEnd.models.player import Player
 from BackEnd.models.game_manager import GameManager
 from BackEnd.models.turn_manager import TurnManager
@@ -231,14 +231,21 @@ def print_scouting_report(data):
         for def_type, val in data[team]["defense"].items():
             print(f"{def_type.ljust(14)} — Used: {val['used']}, Success: {val['success']}")
 
-def run_simulation(home_team_name, away_team_name):
+def run_simulation(home_team_name, away_team_name, home_lineup_ids=None, away_lineup_ids=None):
     gm = GameManager(home_team_name, away_team_name)
 
     print("Inside run_simulation")
     print(f"Home team: {home_team_name}, Away team: {away_team_name}")
 
-    gm.home_team.lineup = build_lineup_from_mongo(home_team_name)
-    gm.away_team.lineup = build_lineup_from_mongo(away_team_name)
+    if home_lineup_ids:
+        gm.home_team.lineup = build_lineup_from_ids(home_lineup_ids)
+    else:
+        gm.home_team.lineup = build_lineup_from_mongo(home_team_name)
+
+    if away_lineup_ids:
+        gm.away_team.lineup = build_lineup_from_ids(away_lineup_ids)
+    else:
+        gm.away_team.lineup = build_lineup_from_mongo(away_team_name)
 
     gm.turn_manager = TurnManager(gm)  # Rebuild now that lineups are present
     for q in range(1, 5):

--- a/BackEnd/utils/db_utils.py
+++ b/BackEnd/utils/db_utils.py
@@ -1,6 +1,7 @@
 
 import random
 from typing import List, Dict
+from bson import ObjectId
 from BackEnd.db import players_collection
 from BackEnd.models.player import Player
 
@@ -44,5 +45,17 @@ def build_lineup_from_mongo(team_name: str) -> dict:
         print(f"Chose {chosen_player.first_name} {chosen_player.last_name} for {pos}")
         available_players.remove(chosen_player)
 
+    return lineup
+
+
+def build_lineup_from_ids(lineup_ids: Dict[str, str]) -> Dict[str, Player]:
+    lineup: Dict[str, Player] = {}
+    for pos, pid in lineup_ids.items():
+        try:
+            doc = players_collection.find_one({"_id": ObjectId(pid)})
+        except Exception:
+            doc = players_collection.find_one({"_id": pid})
+        if doc:
+            lineup[pos] = Player(doc)
     return lineup
 

--- a/FrontEnd/static/franchise-command-center.js
+++ b/FrontEnd/static/franchise-command-center.js
@@ -228,7 +228,7 @@ playNowBtn.addEventListener('click', async () => {
     try {
       localStorage.setItem('franchise_week', week);
     } catch {}
-    const url = `/court.html?franchise_id=${encodeURIComponent(franchiseId)}&week=${week}&home=${encodeURIComponent(home)}&away=${encodeURIComponent(away)}&home_id=${encodeURIComponent(home_id)}&away_id=${encodeURIComponent(away_id)}`;
+    const url = `/static/set-lineup.html?franchise_id=${encodeURIComponent(franchiseId)}&week=${week}&home=${encodeURIComponent(home)}&away=${encodeURIComponent(away)}&home_id=${encodeURIComponent(home_id)}&away_id=${encodeURIComponent(away_id)}`;
     console.log('Navigating to', url);
     window.location.href = url;
   } catch (err) {

--- a/FrontEnd/static/homepage.js
+++ b/FrontEnd/static/homepage.js
@@ -139,7 +139,7 @@ playBtn.addEventListener('click', () => {
     params.set('my_team', homeCheck.checked ? 'home' : 'away');
   }
 
-  window.location.href = `court.html?${params.toString()}`;
+  window.location.href = `/static/set-lineup.html?${params.toString()}`;
 });
 
 createLogoButtons();

--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -51,6 +51,15 @@ if (weekParam && !Number.isNaN(weekParam) && typeof localStorage !== 'undefined'
 }
 const mode = urlParams.get('mode') || getMode({ tournamentId, franchiseId });
 
+const homeLineup = {};
+const awayLineup = {};
+['pg', 'sg', 'sf', 'pf', 'c'].forEach(pos => {
+  const h = urlParams.get(`home_${pos}`);
+  const a = urlParams.get(`away_${pos}`);
+  if (h) homeLineup[pos.toUpperCase()] = h;
+  if (a) awayLineup[pos.toUpperCase()] = a;
+});
+
 console.log("🏀 Tournament launch params:", {
   tournamentId,
   franchiseId,
@@ -109,6 +118,8 @@ async function startGame({ homeRoster, awayRoster, animate = true }) {
     homeTeam,
     awayTeam,
     animate,
+    homeLineup,
+    awayLineup,
   };
 
   if (game.scene.isActive('GameScene')) {

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -18,6 +18,8 @@ export function createGameScene(Phaser) {
         this.awayTeam = data.awayTeam;
         this.animate = data.animate;
         this.mode = data.mode;
+        this.homeLineup = data.homeLineup || {};
+        this.awayLineup = data.awayLineup || {};
 
         console.log("🧠 Game initialized with:", {
           rosters: this.rosters,
@@ -52,10 +54,13 @@ export function createGameScene(Phaser) {
 
     console.log("📨 Sending /api/simulate request for:", homeTeam, "vs", awayTeam);
 
+      const payload = { home_team: homeTeam, away_team: awayTeam };
+      if (Object.keys(this.homeLineup).length) payload.home_lineup = this.homeLineup;
+      if (Object.keys(this.awayLineup).length) payload.away_lineup = this.awayLineup;
       const res = await fetch('/api/simulate', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ home_team: homeTeam, away_team: awayTeam })
+      body: JSON.stringify(payload)
       });
 
 

--- a/FrontEnd/static/set-lineup.css
+++ b/FrontEnd/static/set-lineup.css
@@ -1,0 +1,84 @@
+body {
+  font-family: 'Inter', sans-serif;
+  margin: 20px;
+}
+
+#lineup-container {
+  display: flex;
+  gap: 20px;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+#slots {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.slot {
+  border: 2px dashed #ccc;
+  padding: 8px 12px;
+  width: 200px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #f9f9f9;
+}
+
+.slot.filled {
+  border-style: solid;
+}
+
+.slot .remove {
+  background: none;
+  border: none;
+  color: #c00;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.play-button {
+  background: #ff9800;
+  color: #fff;
+  border: none;
+  padding: 10px 20px;
+  font-weight: bold;
+  border-radius: 4px;
+  cursor: pointer;
+  height: fit-content;
+}
+
+.play-button.disabled {
+  background: #777;
+  cursor: default;
+  pointer-events: none;
+}
+
+#roster-table-container {
+  margin-top: 20px;
+  overflow-x: auto;
+}
+
+.roster-table td.ht,
+.roster-table td.wt {
+  font-size: 0.75em;
+}
+
+.roster-table th.rt,
+.roster-table td.rt {
+  font-weight: bold;
+}
+
+#toast {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  background: rgba(0,0,0,0.8);
+  color: #fff;
+  padding: 8px 12px;
+  border-radius: 4px;
+}

--- a/FrontEnd/static/set-lineup.html
+++ b/FrontEnd/static/set-lineup.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Set Lineup</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="/static/tournament.css" />
+  <link rel="stylesheet" href="/static/set-lineup.css" />
+</head>
+<body>
+  <h1 style="font-family: 'Bebas Neue', sans-serif;">SET LINEUP</h1>
+  <div id="lineup-container">
+    <ul id="slots">
+      <li class="slot" data-pos="PG">PG<button class="remove" hidden>✕</button></li>
+      <li class="slot" data-pos="SG">SG<button class="remove" hidden>✕</button></li>
+      <li class="slot" data-pos="SF">SF<button class="remove" hidden>✕</button></li>
+      <li class="slot" data-pos="PF">PF<button class="remove" hidden>✕</button></li>
+      <li class="slot" data-pos="C">C<button class="remove" hidden>✕</button></li>
+    </ul>
+    <button id="play-now" class="play-button disabled">PLAY NOW</button>
+  </div>
+
+  <div id="roster-table-container">
+    <table class="roster-table">
+      <thead>
+        <tr>
+          <th>Player Name</th>
+          <th>HT</th>
+          <th>WT</th>
+          <th>SC</th>
+          <th>SH</th>
+          <th>ID</th>
+          <th>OD</th>
+          <th>PS</th>
+          <th>BH</th>
+          <th>RB</th>
+          <th>ST</th>
+          <th>AG</th>
+          <th>ND</th>
+          <th>IQ</th>
+          <th>FT</th>
+          <th>NG</th>
+          <th class="rt">RT</th>
+        </tr>
+      </thead>
+      <tbody id="roster-body"></tbody>
+    </table>
+  </div>
+
+  <div id="toast" hidden></div>
+  <script src="/static/common.js"></script>
+  <script src="/static/set-lineup.js"></script>
+</body>
+</html>

--- a/FrontEnd/static/set-lineup.js
+++ b/FrontEnd/static/set-lineup.js
@@ -1,0 +1,136 @@
+const urlParams = new URLSearchParams(window.location.search);
+const homeTeam = urlParams.get('home');
+const awayTeam = urlParams.get('away');
+const myTeamSide = urlParams.get('my_team') || 'home';
+const teamName = myTeamSide === 'away' ? awayTeam : homeTeam;
+
+let roster = [];
+const lineup = {};
+const playerMap = {};
+
+function showToast(msg) {
+  const toast = document.getElementById('toast');
+  if (!toast) return;
+  toast.textContent = msg;
+  toast.hidden = false;
+  setTimeout(() => { toast.hidden = true; }, 2000);
+}
+
+async function loadRoster() {
+  if (!teamName) return;
+  const res = await fetch(`/roster/${encodeURIComponent(teamName)}`);
+  if (!res.ok) return;
+  const data = await res.json();
+  roster = data.players || [];
+  roster.forEach(p => playerMap[p._id] = p);
+  renderRoster();
+}
+
+function renderRoster() {
+  const tbody = document.getElementById('roster-body');
+  if (!tbody) return;
+  tbody.innerHTML = '';
+  roster.forEach(p => {
+    const tr = document.createElement('tr');
+    tr.draggable = true;
+    tr.dataset.playerId = p._id;
+    tr.addEventListener('dragstart', e => {
+      e.dataTransfer.setData('text/plain', p._id);
+    });
+
+    const rt = Math.max(...Object.values(p.position_ratings || {}));
+    const cells = [
+      p.name,
+      formatHeight(p.height),
+      p.weight ?? '--',
+      p.attributes.SC, p.attributes.SH, p.attributes.ID, p.attributes.OD,
+      p.attributes.PS, p.attributes.BH, p.attributes.RB, p.attributes.ST,
+      p.attributes.AG, p.attributes.ND, p.attributes.IQ, p.attributes.FT,
+      p.attributes.NG, rt
+    ];
+    const classes = ['','ht','wt','','','','','','','','','','','','','', 'rt'];
+    cells.forEach((val, idx) => {
+      const td = document.createElement('td');
+      td.textContent = val ?? '--';
+      if (classes[idx]) td.classList.add(classes[idx]);
+      tr.appendChild(td);
+    });
+    tbody.appendChild(tr);
+  });
+}
+
+function updatePlayButton() {
+  const btn = document.getElementById('play-now');
+  if (!btn) return;
+  const filled = ['PG','SG','SF','PF','C'].every(pos => lineup[pos]);
+  if (filled) {
+    btn.classList.remove('disabled');
+  } else {
+    btn.classList.add('disabled');
+  }
+}
+
+function clearSlot(slot) {
+  const pos = slot.dataset.pos;
+  delete lineup[pos];
+  slot.textContent = pos;
+  const remove = document.createElement('button');
+  remove.className = 'remove';
+  remove.textContent = '✕';
+  remove.hidden = true;
+  slot.appendChild(remove);
+  slot.classList.remove('filled');
+  remove.addEventListener('click', () => clearSlot(slot));
+  updatePlayButton();
+}
+
+function setupSlots() {
+  document.querySelectorAll('.slot').forEach(slot => {
+    clearSlot(slot);
+    slot.addEventListener('dragover', e => e.preventDefault());
+    slot.addEventListener('drop', e => {
+      e.preventDefault();
+      const playerId = e.dataTransfer.getData('text/plain');
+      const pos = slot.dataset.pos;
+      if (lineup[pos]) {
+        showToast('Slot already filled');
+        return;
+      }
+      if (Object.values(lineup).includes(playerId)) {
+        showToast('Player already used');
+        return;
+      }
+      const player = playerMap[playerId];
+      if (!player) return;
+      const rating = player.position_ratings?.[pos] ?? '--';
+      slot.textContent = `${player.name} — ${rating}`;
+      const remove = document.createElement('button');
+      remove.className = 'remove';
+      remove.textContent = '✕';
+      remove.addEventListener('click', () => clearSlot(slot));
+      slot.appendChild(remove);
+      slot.classList.add('filled');
+      lineup[pos] = playerId;
+      updatePlayButton();
+    });
+  });
+}
+
+async function init() {
+  await loadRoster();
+  setupSlots();
+  const btn = document.getElementById('play-now');
+  if (btn) {
+    btn.addEventListener('click', () => {
+      if (btn.classList.contains('disabled')) return;
+      const params = new URLSearchParams(window.location.search);
+      ['PG','SG','SF','PF','C'].forEach(pos => {
+        const id = lineup[pos];
+        if (id) params.set(`${myTeamSide}_${pos.toLowerCase()}`, id);
+      });
+      window.location.href = `/court.html?${params.toString()}`;
+    });
+  }
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/FrontEnd/static/tournament.js
+++ b/FrontEnd/static/tournament.js
@@ -399,7 +399,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         await refreshLeaders();
         const { home, away } = data;
         if (!home || !away) throw new Error('Matchup not found');
-        window.location.href = `/court.html?tournament_id=${encodeURIComponent(tournament._id)}&home=${encodeURIComponent(home)}&away=${encodeURIComponent(away)}`;
+        window.location.href = `/static/set-lineup.html?tournament_id=${encodeURIComponent(tournament._id)}&home=${encodeURIComponent(home)}&away=${encodeURIComponent(away)}`;
       } catch (err) {
         console.error('Failed to start game', err);
         alert('Unable to start game');


### PR DESCRIPTION
## Summary
- Add Set Lineup page to choose a five-man starting lineup from the roster
- Wire lineup data into simulation flow and frontend navigation
- Allow backend simulation to accept explicit home/away lineups

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_689bc1ca2ac48328b0174dc919a52cfa