### PR TITLE
fix: ensure set lineup page targets user team

### DIFF
--- a/FrontEnd/static/franchise-command-center.js
+++ b/FrontEnd/static/franchise-command-center.js
@@ -10,6 +10,7 @@ async function fetchJSON(url) {
 }
 
 let franchiseId = null;
+const userTeamName = localStorage.getItem('franchise_user_team') || '';
 const ATTR_HEADERS = ["SC","SH","ID","OD","PS","BH","RB","AG","ST","ND","IQ","FT"];
 
 const teamMap = {
@@ -228,7 +229,10 @@ playNowBtn.addEventListener('click', async () => {
     try {
       localStorage.setItem('franchise_week', week);
     } catch {}
-    const url = `/static/set-lineup.html?franchise_id=${encodeURIComponent(franchiseId)}&week=${week}&home=${encodeURIComponent(home)}&away=${encodeURIComponent(away)}&home_id=${encodeURIComponent(home_id)}&away_id=${encodeURIComponent(away_id)}`;
+    const mySide = userTeamName === home ? 'home' : (userTeamName === away ? 'away' : '');
+    let url = `/static/set-lineup.html?franchise_id=${encodeURIComponent(franchiseId)}&week=${week}&home=${encodeURIComponent(home)}&away=${encodeURIComponent(away)}&home_id=${encodeURIComponent(home_id)}&away_id=${encodeURIComponent(away_id)}`;
+    if (userTeamName) url += `&user_team_id=${encodeURIComponent(userTeamName)}`;
+    if (mySide) url += `&my_team=${mySide}`;
     console.log('Navigating to', url);
     window.location.href = url;
   } catch (err) {

--- a/FrontEnd/static/franchise-select-team.js
+++ b/FrontEnd/static/franchise-select-team.js
@@ -36,6 +36,7 @@ async function selectTeam(team) {
     if (!res.ok) throw new Error("Failed to start franchise");
     const data = await res.json();
     localStorage.setItem("franchiseId", data.franchise_id);
+    localStorage.setItem("franchise_user_team", team);
     window.location.href = "/franchise/command-center";
   } catch (err) {
     console.error(err);

--- a/FrontEnd/static/homepage.js
+++ b/FrontEnd/static/homepage.js
@@ -136,7 +136,10 @@ playBtn.addEventListener('click', () => {
   });
 
   if (homeCheck.checked || awayCheck.checked) {
-    params.set('my_team', homeCheck.checked ? 'home' : 'away');
+    const mySide = homeCheck.checked ? 'home' : 'away';
+    params.set('my_team', mySide);
+    const userTeam = mySide === 'home' ? homeTeam : awayTeam;
+    params.set('user_team_id', userTeam);
   }
 
   window.location.href = `/static/set-lineup.html?${params.toString()}`;

--- a/FrontEnd/static/set-lineup.css
+++ b/FrontEnd/static/set-lineup.css
@@ -3,6 +3,16 @@ body {
   margin: 20px;
 }
 
+#team-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+#team-logo {
+  height: 50px;
+}
+
 #lineup-container {
   display: flex;
   gap: 20px;

--- a/FrontEnd/static/set-lineup.html
+++ b/FrontEnd/static/set-lineup.html
@@ -8,7 +8,10 @@
   <link rel="stylesheet" href="/static/set-lineup.css" />
 </head>
 <body>
-  <h1 style="font-family: 'Bebas Neue', sans-serif;">SET LINEUP</h1>
+  <div id="team-header">
+    <img id="team-logo" alt="team logo" hidden>
+    <h1 id="team-title" style="font-family: 'Bebas Neue', sans-serif;"></h1>
+  </div>
   <div id="lineup-container">
     <ul id="slots">
       <li class="slot" data-pos="PG">PG<button class="remove" hidden>✕</button></li>

--- a/FrontEnd/static/set-lineup.js
+++ b/FrontEnd/static/set-lineup.js
@@ -1,8 +1,11 @@
 const urlParams = new URLSearchParams(window.location.search);
 const homeTeam = urlParams.get('home');
 const awayTeam = urlParams.get('away');
-const myTeamSide = urlParams.get('my_team') || 'home';
-const teamName = myTeamSide === 'away' ? awayTeam : homeTeam;
+const homeId = urlParams.get('home_id');
+const awayId = urlParams.get('away_id');
+let myTeamSide = urlParams.get('my_team');
+const userTeamIdParam = urlParams.get('user_team_id');
+let teamName = '';
 
 let roster = [];
 const lineup = {};
@@ -116,7 +119,47 @@ function setupSlots() {
   });
 }
 
+function resolveTeam() {
+  if (myTeamSide === 'home' || myTeamSide === 'away') {
+    teamName = myTeamSide === 'away' ? awayTeam : homeTeam;
+    return !!teamName;
+  }
+  const storedId = userTeamIdParam || localStorage.getItem('userTeamId') || localStorage.getItem('franchise_user_team');
+  if (storedId) {
+    if (storedId === homeId || storedId === homeTeam) {
+      myTeamSide = 'home';
+      teamName = homeTeam;
+      return true;
+    }
+    if (storedId === awayId || storedId === awayTeam) {
+      myTeamSide = 'away';
+      teamName = awayTeam;
+      return true;
+    }
+  }
+  return false;
+}
+
+function setHeader() {
+  const title = document.getElementById('team-title');
+  if (title) title.textContent = `Set Your Lineup — ${teamName}`;
+  const logo = document.getElementById('team-logo');
+  if (logo) {
+    logo.src = `/static/images/homepage-logos/${teamName}.png`;
+    logo.alt = `${teamName} logo`;
+    logo.hidden = false;
+    logo.onerror = () => { logo.hidden = true; };
+  }
+}
+
 async function init() {
+  if (!resolveTeam()) {
+    alert("Can't determine your team for this game. Please return and relaunch.");
+    const btn = document.getElementById('play-now');
+    if (btn) btn.classList.add('disabled');
+    return;
+  }
+  setHeader();
   await loadRoster();
   setupSlots();
   const btn = document.getElementById('play-now');
@@ -124,6 +167,9 @@ async function init() {
     btn.addEventListener('click', () => {
       if (btn.classList.contains('disabled')) return;
       const params = new URLSearchParams(window.location.search);
+      ['home','away'].forEach(side => {
+        ['pg','sg','sf','pf','c'].forEach(pos => params.delete(`${side}_${pos}`));
+      });
       ['PG','SG','SF','PF','C'].forEach(pos => {
         const id = lineup[pos];
         if (id) params.set(`${myTeamSide}_${pos.toLowerCase()}`, id);

--- a/FrontEnd/static/tournament.js
+++ b/FrontEnd/static/tournament.js
@@ -399,7 +399,11 @@ document.addEventListener("DOMContentLoaded", async () => {
         await refreshLeaders();
         const { home, away } = data;
         if (!home || !away) throw new Error('Matchup not found');
-        window.location.href = `/static/set-lineup.html?tournament_id=${encodeURIComponent(tournament._id)}&home=${encodeURIComponent(home)}&away=${encodeURIComponent(away)}`;
+        const mySide = home === userTeamId ? 'home' : (away === userTeamId ? 'away' : '');
+        let url = `/static/set-lineup.html?tournament_id=${encodeURIComponent(tournament._id)}&home=${encodeURIComponent(home)}&away=${encodeURIComponent(away)}`;
+        if (userTeamId) url += `&user_team_id=${encodeURIComponent(userTeamId)}`;
+        if (mySide) url += `&my_team=${mySide}`;
+        window.location.href = url;
       } catch (err) {
         console.error('Failed to start game', err);
         alert('Unable to start game');


### PR DESCRIPTION
## Summary
- detect controlled team via `user_team_id`/`my_team` and show team name & logo on Set Lineup
- pass user team info from scrimmage, tournament and franchise flows
- guard against unresolved team and only submit lineup for controlled side

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_689bc77b3f5c83289b3fc754e378c254