### PR TITLE
Add live player stat sidebar with controls

### DIFF
--- a/FrontEnd/static/court.html
+++ b/FrontEnd/static/court.html
@@ -99,11 +99,65 @@
       line-height: 1;
     }
 
-    #phaser-container {
+    #main-container {
+      display: flex;
       width: 100%;
       height: calc(100vh - var(--scoreboard-height));
       margin-top: var(--scoreboard-height);
+    }
+
+    #phaser-container {
+      flex: 1;
       position: relative;
+    }
+
+    #stats-sidebar {
+      width: 260px;
+      background: #222;
+      color: #fff;
+      box-sizing: border-box;
+      padding: 10px;
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .stats-box {
+      width: 100%;
+    }
+
+    .stats-box table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 16px;
+    }
+
+    .stats-box th,
+    .stats-box td {
+      text-align: center;
+      padding: 2px;
+    }
+
+    .controls {
+      margin-top: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    #pause-btn,
+    #skip-btn {
+      background-color: #ff6200;
+      color: #fff;
+      border: none;
+      padding: 10px 20px;
+      border-radius: 4px;
+      cursor: pointer;
+      font-family: 'Bebas Neue', sans-serif;
+    }
+
+    #skip-btn {
+      background-color: #007bff;
     }
 
     .play-button,
@@ -177,9 +231,35 @@
       </div>
     </div>
   </div>
-  <div id="phaser-container">
-    <button class="play-button">Play Game</button>
-    <button class="results-button">See Results</button>
+  <div id="main-container">
+    <div id="phaser-container">
+      <button class="play-button">Play Game</button>
+      <button class="results-button">See Results</button>
+    </div>
+    <div id="stats-sidebar">
+      <div class="stats-box" id="home-stats-box">
+        <table>
+          <thead>
+            <tr><th colspan="4">Home Team</th></tr>
+            <tr><th>Name</th><th>PTS</th><th>REB</th><th>AST</th></tr>
+          </thead>
+          <tbody id="home-stats-body"></tbody>
+        </table>
+      </div>
+      <div class="stats-box" id="away-stats-box">
+        <table>
+          <thead>
+            <tr><th colspan="4">Away Team</th></tr>
+            <tr><th>Name</th><th>PTS</th><th>REB</th><th>AST</th></tr>
+          </thead>
+          <tbody id="away-stats-body"></tbody>
+        </table>
+      </div>
+      <div class="controls">
+        <button id="pause-btn">Pause</button>
+        <button id="skip-btn">Skip To End</button>
+      </div>
+    </div>
   </div>
 
   <!-- <script type="module" src="./js/phaser/bootGame.js"></script> -->

--- a/FrontEnd/static/js/phaser/animation/animateGameTurns.js
+++ b/FrontEnd/static/js/phaser/animation/animateGameTurns.js
@@ -16,7 +16,9 @@ export async function animateGameTurns({ //hasBallAtStep
   const allPlayers = simData.players || [];
 
   for (let i = 0; i < turns.length; i++) {
+    scene.currentTurn = i;
     const turn = turns[i];
+    if (scene.skipToEnd) break;
     console.log(`🔁 Turn ${i + 1}`, turn);
 
     const shooterName = turn.shooter || "";
@@ -92,6 +94,16 @@ export async function animateGameTurns({ //hasBallAtStep
       } catch (err) {
         console.error('Scoreboard update failed:', err);
       }
+    }
+    if (scene.skipToEnd) {
+      for (let j = i + 1; j < turns.length; j++) {
+        try {
+          if (onUpdate) onUpdate(turns[j]);
+        } catch (err) {
+          console.error('Scoreboard update failed:', err);
+        }
+      }
+      break;
     }
   }
 }

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -88,6 +88,107 @@ export function createGameScene(Phaser) {
       const clockEl = document.getElementById('game-clock');
       const quarterEl = document.getElementById('quarter');
 
+      const positions = ["PG","SG","SF","PF","C"];
+      this.nameToId = Object.fromEntries(simData.players.map(p => [p.name, p.playerId]));
+      this.playerInfo = Object.fromEntries(simData.players.map(p => [p.playerId, { name: p.name, team: p.team, pos: p.pos }]));
+      this.playerStats = {};
+      simData.players.forEach(p => {
+        this.playerStats[p.playerId] = { PTS: 0, REB: 0, AST: 0 };
+      });
+      this.rowRefs = { home: {}, away: {} };
+      this.currentLineup = { home: {}, away: {} };
+
+      const homeBody = document.getElementById('home-stats-body');
+      const awayBody = document.getElementById('away-stats-body');
+
+      const initTeamTable = (teamKey, bodyEl) => {
+        positions.forEach(pos => {
+          const player = simData.players.find(p => p.team === teamKey && p.pos === pos);
+          const playerId = player?.playerId;
+          const tr = document.createElement('tr');
+          const nameTd = document.createElement('td');
+          const ptsTd = document.createElement('td');
+          const rebTd = document.createElement('td');
+          const astTd = document.createElement('td');
+          nameTd.textContent = player?.name || '';
+          ptsTd.textContent = '0';
+          rebTd.textContent = '0';
+          astTd.textContent = '0';
+          tr.append(nameTd, ptsTd, rebTd, astTd);
+          bodyEl.appendChild(tr);
+          this.rowRefs[teamKey][pos] = { nameCell: nameTd, ptsCell: ptsTd, rebCell: rebTd, astCell: astTd };
+          if (playerId) {
+            this.playerStats[playerId].cells = { pts: ptsTd, reb: rebTd, ast: astTd };
+            this.currentLineup[teamKey][pos] = playerId;
+          }
+        });
+      };
+
+      initTeamTable('home', homeBody);
+      initTeamTable('away', awayBody);
+
+      const updateLineup = (teamKey, lineup) => {
+        if (!lineup) return;
+        positions.forEach(pos => {
+          const playerId = lineup[pos];
+          if (!playerId) return;
+          this.currentLineup[teamKey][pos] = playerId;
+          const info = this.playerInfo[playerId];
+          const row = this.rowRefs[teamKey][pos];
+          if (info && row) {
+            row.nameCell.textContent = info.name;
+            const stats = this.playerStats[playerId] || { PTS: 0, REB: 0, AST: 0 };
+            this.playerStats[playerId] = stats;
+            row.ptsCell.textContent = stats.PTS;
+            row.rebCell.textContent = stats.REB;
+            row.astCell.textContent = stats.AST;
+            stats.cells = { pts: row.ptsCell, reb: row.rebCell, ast: row.astCell };
+          }
+        });
+      };
+
+      const applyPlayerStats = (turn = {}) => {
+        if (turn.home_lineup) updateLineup('home', turn.home_lineup);
+        if (turn.away_lineup) updateLineup('away', turn.away_lineup);
+
+        if (turn.points && turn.shooter) {
+          const shooterId = this.nameToId[turn.shooter];
+          if (shooterId) {
+            const ps = this.playerStats[shooterId];
+            ps.PTS += turn.points;
+            if (ps.cells?.pts) ps.cells.pts.textContent = ps.PTS;
+          }
+          if (turn.passer) {
+            const passerId = this.nameToId[turn.passer];
+            if (passerId) {
+              const ps = this.playerStats[passerId];
+              ps.AST += 1;
+              if (ps.cells?.ast) ps.cells.ast.textContent = ps.AST;
+            }
+          }
+        }
+
+        if ((turn.result_type === 'DREB' || turn.result_type === 'OREB') && turn.ball_handler) {
+          const rebId = this.nameToId[turn.ball_handler];
+          if (rebId) {
+            const ps = this.playerStats[rebId];
+            ps.REB += 1;
+            if (ps.cells?.reb) ps.cells.reb.textContent = ps.REB;
+          }
+        } else if (turn.text) {
+          const m = turn.text.match(/([A-Za-z\-\'\.\s]+) grabs the rebound/);
+          if (m) {
+            const name = m[1].trim();
+            const rebId = this.nameToId[name];
+            if (rebId) {
+              const ps = this.playerStats[rebId];
+              ps.REB += 1;
+              if (ps.cells?.reb) ps.cells.reb.textContent = ps.REB;
+            }
+          }
+        }
+      };
+
       // Live scoreboard state
       const liveScore = { [homeTeam]: 0, [awayTeam]: 0 };
       let liveHomeFouls = 0;
@@ -117,6 +218,8 @@ export function createGameScene(Phaser) {
         if (clockEl) clockEl.textContent = liveClock;
         if (quarterEl) quarterEl.textContent = `Q:${liveQuarter}`;
 
+        applyPlayerStats(turn);
+
         if (liveScore[homeTeam] !== prevHome || liveScore[awayTeam] !== prevAway) {
           emit('score:update', {
             home: liveScore[homeTeam],
@@ -127,6 +230,29 @@ export function createGameScene(Phaser) {
 
       // Initialize scoreboard at tip-off
       updateScoreboard();
+
+      const pauseBtn = document.getElementById('pause-btn');
+      const skipBtn = document.getElementById('skip-btn');
+      this.isPaused = false;
+      this.skipToEnd = false;
+      if (pauseBtn) {
+        pauseBtn.addEventListener('click', () => {
+          this.isPaused = !this.isPaused;
+          if (this.isPaused) {
+            this.tweens.pauseAll();
+            pauseBtn.textContent = 'Resume';
+          } else {
+            this.tweens.resumeAll();
+            pauseBtn.textContent = 'Pause';
+          }
+        });
+      }
+      if (skipBtn) {
+        skipBtn.addEventListener('click', () => {
+          this.skipToEnd = true;
+          this.tweens.killAll();
+        });
+      }
 
       const finalize = async () => {
         const finalScore = await finalizeGame({


### PR DESCRIPTION
## Summary
- Add right-side sidebar with live player stats and Pause/Skip controls on court page
- Track player PTS/REB/AST during animation using turn results and lineup updates
- Support skipping animation while processing remaining turns instantly

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'BackEnd')*

------
https://chatgpt.com/codex/tasks/task_e_689bcbdd28ec8328acfafbd2f12bdf7e