### PR TITLE
Fix missing player names and live stat updates on court animation sidebar

### DIFF
--- a/BackEnd/utils/shared.py
+++ b/BackEnd/utils/shared.py
@@ -356,6 +356,7 @@ def summarize_game_state(game):
             coords = getattr(player, "coords", None) or {"x": 0, "y": 0}
             players.append({
                 "playerId": player.player_id,
+                "name": getattr(player, "name", None) or f"{getattr(player, 'first_name', '')} {getattr(player, 'last_name', '')}".strip(),
                 "team": team_key,
                 "team_id": team_obj.team_id,
                 "pos": pos,


### PR DESCRIPTION
## Summary
- Include player names in `summarize_game_state` so front-end can render lineup names and map turn events to players.
- Stats sidebar now populates correctly and updates scorer/assist/rebound numbers per turn using existing event fields.

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689bdf6977fc83288ae8cf9c66cd6312