### PR TITLE
Handle skip flow and stop tweens safely

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animateStep.js
+++ b/FrontEnd/static/js/phaser/animation/animateStep.js
@@ -11,6 +11,7 @@ import { gridToPixels } from "../utils/gridToPixels.js";
  * @returns {Promise} resolves when tween completes
  */
 export function animateStep({ scene, sprite, step, duration, ballSprite, currentBallOwnerRef }) {
+  if (scene.skipToEnd) return Promise.resolve();
   return new Promise((resolve) => {
     const { x: targetX, y: targetY } = gridToPixels(
       step.coords.x,

--- a/FrontEnd/static/js/phaser/animation/playTurnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/playTurnAnimation.js
@@ -6,9 +6,11 @@ import { lockBallToPlayer } from "./ballManager.js";
  * Centralized ball ownership logic
  * Assigns the ball to the correct player for the current stepIndex
  */
-function updateBallOwnership({ ballSprite, animations, playerSprites, stepIndex, offenseTeamId, currentBallOwnerRef }) {
+function updateBallOwnership({ scene, ballSprite, animations, playerSprites, stepIndex, offenseTeamId, currentBallOwnerRef }) {
+  if (scene?.skipToEnd) return;
   console.log("🟡 inside updateBallOwnership → stepIndex:", stepIndex);
   for (const anim of animations) {
+    if (scene.skipToEnd) break;
     const sprite = playerSprites[anim.playerId];
     const hasBall = anim.hasBallAtStep?.[stepIndex];
     const team = sprite?.team_id;
@@ -47,10 +49,12 @@ function updateBallOwnership({ ballSprite, animations, playerSprites, stepIndex,
  */
 
 async function runSetupTween({ scene, ballSprite, animations, playerSprites, currentBallOwnerRef }) {
+  if (scene.skipToEnd) return;
   const stepIndex = 0;
   const promises = [];
 
   for (const anim of animations) {
+    if (scene.skipToEnd) break;
     const sprite = playerSprites[anim.playerId];
     const firstStep = anim.movement?.[stepIndex];
     if (!sprite || !firstStep) continue;
@@ -172,6 +176,7 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
   // Determine which player owns the ball at step 0
   let step0OwnerSprite = null;
   for (const anim of turnData.animations) {
+    if (scene.skipToEnd) break;
     if (anim.hasBallAtStep?.[0]) {
       step0OwnerSprite = playerSprites[anim.playerId];
       break;
@@ -206,6 +211,7 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
   // console.log("turnData.animations[0].playerId", turnData.animations[0].playerId);
   // console.log("turnData.animations[0].movement", turnData.animations[0].movement);
   updateBallOwnership({
+    scene,
     ballSprite,
     animations: turnData.animations,
     playerSprites,
@@ -218,6 +224,7 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
     if (scene.skipToEnd) break;
 
     updateBallOwnership({
+      scene,
       ballSprite,
       animations: turnData.animations,
       playerSprites,
@@ -229,6 +236,7 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
     const promises = [];
 
     for (const anim of turnData.animations) {
+      if (scene.skipToEnd) break;
       const sprite = playerSprites[anim.playerId];
       const movement = anim.movement;
 

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -242,6 +242,8 @@ export function createGameScene(Phaser) {
       const skipBtn = document.getElementById('skip-btn');
       this.isPaused = false;
       this.skipToEnd = false;
+      this.isSkipping = false;
+      this.finalized = false;
       if (pauseBtn) {
         pauseBtn.addEventListener('click', () => {
           this.isPaused = !this.isPaused;
@@ -255,16 +257,21 @@ export function createGameScene(Phaser) {
         });
       }
       if (skipBtn) {
-        skipBtn.addEventListener('click', () => {
+        skipBtn.addEventListener('click', async () => {
+          if (this.isSkipping) return;
           this.skipToEnd = true;
+          this.isSkipping = true;
           this.isPaused = false;
+          skipBtn.disabled = true;
           if (pauseBtn) pauseBtn.textContent = 'Pause';
           this.tweens.resumeAll();
-          this.tweens.killAll();
+          this.tweens.getAllTweens().forEach(t => t.stop());
+          await finalize();
         });
       }
 
       const finalize = async () => {
+        if (this.finalized) return this.finalScore;
         const finalScore = await finalizeGame({
           simData,
           tournamentId: this.tournamentId,
@@ -272,6 +279,8 @@ export function createGameScene(Phaser) {
           game: this.game,
         });
         this.finalScore = finalScore;
+        this.finalized = true;
+        return finalScore;
       };
 
       if (this.animate) {


### PR DESCRIPTION
## Summary
- Disable Skip button and stop active tweens on skip while ensuring finalize runs once
- Guard animation loops with `skipToEnd` and resolve promises when tweens stop
- Short-circuit animation steps when skipping

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_689be43af33483289ba6dd1b381412bf