### PR TITLE
refactor: centralize franchise name loading

### DIFF
--- a/BackEnd/models/franchise_manager.py
+++ b/BackEnd/models/franchise_manager.py
@@ -1,17 +1,64 @@
 import random
 from datetime import datetime
 from itertools import combinations, permutations
-from importlib import resources
 from pathlib import Path
 import json
 import logging
 import os
-import sys
 
 from BackEnd.main import run_simulation
 
 
 logger = logging.getLogger(__name__)
+
+
+# Helper ---------------------------------------------------------------------
+def load_franchise_names() -> tuple[list[str], list[str]]:
+    """Load recruit name lists from ``franchise_names.json``.
+
+    The path is resolved from the ``FRANCHISE_NAMES_FILE`` environment
+    variable, falling back to ``BackEnd/data/names/franchise_names.json``
+    relative to this file. ``BackEnd.data.names`` must be importable so the
+    JSON resource is packaged and available at runtime.
+
+    Logs the absolute path checked (and whether it exists) along with counts of
+    loaded first and last names.
+
+    Returns:
+        Tuple of ``(first_names, last_names)``.
+
+    Raises:
+        FileNotFoundError: if the file does not exist.
+        ValueError: if the JSON is malformed or missing required keys.
+    """
+
+    env_path = os.environ.get("FRANCHISE_NAMES_FILE")
+    default_path = Path(__file__).resolve().parents[1] / "data" / "names" / "franchise_names.json"
+    path = Path(env_path).expanduser() if env_path else default_path
+    abs_path = path.resolve()
+    exists = abs_path.is_file()
+    logger.info("Loading franchise names from %s (exists=%s)", abs_path, exists)
+    if not exists:
+        msg = f"franchise names file not found: {abs_path}"
+        logger.warning(msg)
+        raise FileNotFoundError(msg)
+
+    try:
+        with abs_path.open("r", encoding="utf-8") as f:
+            payload = json.load(f)
+    except Exception as exc:  # pragma: no cover - json errors
+        logger.warning("Failed to parse franchise names JSON %s: %s", abs_path, exc)
+        raise ValueError(f"invalid franchise names JSON: {exc}") from exc
+
+    fn = payload.get("first_names")
+    ln = payload.get("last_names")
+    if not isinstance(fn, list) or not isinstance(ln, list) or not fn or not ln:
+        msg = "Names JSON malformed: expected non-empty 'first_names' and 'last_names' lists"
+        logger.warning(msg)
+        raise ValueError(msg)
+
+    logger.info("Loaded %d first names and %d last names", len(fn), len(ln))
+    return fn, ln
 
 
 class FranchiseManager:
@@ -188,87 +235,22 @@ class ScheduleManager:
 
         return schedule
 
-# --- Drop-in replacement for RecruitManager (path-robust + same JSON schema) ---
 class RecruitManager:
-    def __init__(self, db, names_file: Path | None = None):
+    """Manage recruit generation using optional external name data."""
+
+    def __init__(self, db):
         self.db = db
 
         # Defaults only if file truly missing/malformed
         self.first_names = ["Jalen", "Marcus", "Tyrese", "Zion", "Cade"]
-        self.last_names  = ["Walker", "Jackson", "Robinson", "Wright", "Anderson"]
+        self.last_names = ["Walker", "Jackson", "Robinson", "Wright", "Anderson"]
 
         self.diagnostics = None
-        diag_enabled = os.environ.get("NAMES_DIAG") == "1"
-        if diag_enabled:
-            self.diagnostics = {
-                "file": __file__,
-                "cwd": os.getcwd(),
-                "sys_path": sys.path[:5],
-            }
 
-        payload = None
-
-        # 1) Try local path relative to this file: BackEnd/data/names/franchise_names.json
-        default_path = (Path(__file__).resolve().parents[1]
-                        / "data" / "names" / "franchise_names.json")
-        path = Path(names_file).expanduser() if names_file else default_path
-        if diag_enabled and self.diagnostics is not None:
-            self.diagnostics.update({
-                "expected_path": str(path.resolve()),
-                "expected_path_exists": path.exists(),
-            })
         try:
-            with path.open("r", encoding="utf-8") as f:
-                payload = json.load(f)
-            logger.info("Recruit names loaded from %s", path)
-            if diag_enabled and self.diagnostics is not None:
-                self.diagnostics["code_path"] = "filesystem"
+            self.first_names, self.last_names = load_franchise_names()
         except Exception as exc:
-            logger.warning("Failed to load recruit names from %s: %s", path, exc)
-            if diag_enabled and self.diagnostics is not None:
-                self.diagnostics["filesystem_error"] = str(exc)
-
-        # 2) Fallback: importlib.resources (works when BackEnd is on sys.path)
-        if payload is None:
-            try:
-                pkg = "BackEnd.data.names"
-                if diag_enabled and self.diagnostics is not None:
-                    try:
-                        self.diagnostics["resources_files"] = str(resources.files(pkg))
-                    except Exception as exc:  # pragma: no cover - diagnostic only
-                        self.diagnostics["resources_files"] = f"<error: {exc}>"
-                with resources.open_text(pkg,
-                                        "franchise_names.json", encoding="utf-8") as f:
-                    payload = json.load(f)
-                logger.info("Recruit names loaded from package BackEnd.data.names")
-                if diag_enabled and self.diagnostics is not None:
-                    self.diagnostics["code_path"] = "importlib.resources"
-            except Exception as exc:
-                logger.warning("Could not load recruit names via package resources: %s", exc)
-                if diag_enabled and self.diagnostics is not None:
-                    self.diagnostics["resource_error"] = str(exc)
-
-        # 3) If we got data, validate keys and apply
-        if isinstance(payload, dict):
-            fn = payload.get("first_names")
-            ln = payload.get("last_names")
-            if isinstance(fn, list) and fn and isinstance(ln, list) and ln:
-                self.first_names, self.last_names = fn, ln
-            else:
-                logger.warning("Names JSON missing non-empty 'first_names'/'last_names'; using fallback lists.")
-            if diag_enabled and self.diagnostics is not None:
-                self.diagnostics.update({
-                    "first_names_count": len(fn) if isinstance(fn, list) else 0,
-                    "last_names_count": len(ln) if isinstance(ln, list) else 0,
-                })
-        else:
-            logger.warning("Could not load franchise_names.json from disk or package; using fallback lists.")
-            if diag_enabled and self.diagnostics is not None:
-                self.diagnostics["parsed"] = False
-
-        if diag_enabled and self.diagnostics is not None and "parsed" not in self.diagnostics:
-            self.diagnostics["parsed"] = True
-            logger.info("NAMES_DIAG: %s", self.diagnostics)
+            logger.warning("Using fallback recruit names: %s", exc)
 
     def generate_recruits(self, count=40):
         recruits = []

--- a/tests/test_load_franchise_names.py
+++ b/tests/test_load_franchise_names.py
@@ -1,0 +1,38 @@
+import json
+import logging
+
+import pytest
+
+from BackEnd.models.franchise_manager import load_franchise_names
+
+
+def test_load_franchise_names_env_override(tmp_path, monkeypatch, caplog):
+    data = {"first_names": ["Alpha"], "last_names": ["Beta"]}
+    file = tmp_path / "names.json"
+    file.write_text(json.dumps(data))
+    monkeypatch.setenv("FRANCHISE_NAMES_FILE", str(file))
+    caplog.set_level(logging.INFO)
+
+    first, last = load_franchise_names()
+
+    assert first == ["Alpha"]
+    assert last == ["Beta"]
+    assert str(file.resolve()) in caplog.text
+
+
+def test_load_franchise_names_missing_file(monkeypatch, caplog):
+    monkeypatch.setenv("FRANCHISE_NAMES_FILE", "/no/such/file.json")
+    caplog.set_level(logging.WARNING)
+    with pytest.raises(FileNotFoundError):
+        load_franchise_names()
+    assert "not found" in caplog.text
+
+
+def test_load_franchise_names_invalid_json(tmp_path, monkeypatch, caplog):
+    bad_file = tmp_path / "bad.json"
+    bad_file.write_text("not json")
+    monkeypatch.setenv("FRANCHISE_NAMES_FILE", str(bad_file))
+    caplog.set_level(logging.WARNING)
+    with pytest.raises(ValueError):
+        load_franchise_names()
+    assert "Failed to parse franchise names JSON" in caplog.text

--- a/tests/test_recruit_manager.py
+++ b/tests/test_recruit_manager.py
@@ -4,7 +4,8 @@ from importlib import resources
 from BackEnd.models.franchise_manager import RecruitManager
 
 
-def test_recruit_manager_loads_default_names():
+def test_recruit_manager_loads_default_names(monkeypatch):
+    monkeypatch.delenv("FRANCHISE_NAMES_FILE", raising=False)
     rm = RecruitManager(db=None)
     resource_path = resources.files("BackEnd").joinpath("data", "names", "franchise_names.json")
     with resource_path.open("r") as f:


### PR DESCRIPTION
## Summary
- add `load_franchise_names` helper with env override, logging, and validation
- use helper in `RecruitManager` and warn when falling back to defaults
- test loader for custom path, missing file, and malformed JSON

## Testing
- `PYTHONPATH=. pytest tests/test_recruit_manager.py tests/test_load_franchise_names.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689c63f0163483289d522d03c5f40d25