### PR TITLE
Persist tournament player stats

### DIFF
--- a/BackEnd/api/tournament_routes.py
+++ b/BackEnd/api/tournament_routes.py
@@ -4,7 +4,6 @@ from BackEnd.db import (
     tournaments_collection,
     teams_collection,
     games_collection,
-    players_collection,
 )
 from BackEnd.tournament.tournament_manager import TournamentManager
 from BackEnd.tournament.bracket_logic import update_bracket_from_results
@@ -48,7 +47,20 @@ def get_tournament_leaders(tournament_id: str):
             teams.add(match.get("away_team"))
     teams.discard(None)
 
-    players = list(players_collection.find({"team": {"$in": list(teams)}}))
+    # Use stats stored in the tournament document; ignore players from other teams.
+    players = []
+    for pid, pdata in tourney.get("player_stats", {}).items():
+        if pdata.get("team") not in teams:
+            continue
+        players.append(
+            {
+                "player_id": str(pid),
+                "first_name": pdata.get("first_name", ""),
+                "last_name": pdata.get("last_name", ""),
+                "team_name": pdata.get("team", ""),
+                "stats": pdata.get("stats", {}),
+            }
+        )
 
     categories = [
         ("PTS", "MIN"),
@@ -72,15 +84,15 @@ def get_tournament_leaders(tournament_id: str):
     for stat, tie_key in categories:
         entries = []
         for p in players:
-            season = p.get("stats", {}).get("season", {})
+            season = p.get("stats", {})
             value = stat_val(season, stat)
             tie_val = stat_val(season, tie_key) if tie_key else 0
             entries.append(
                 {
-                    "player_id": str(p.get("_id")),
+                    "player_id": p.get("player_id"),
                     "first_name": p.get("first_name", ""),
                     "last_name": p.get("last_name", ""),
-                    "team_name": p.get("team", ""),
+                    "team_name": p.get("team_name", ""),
                     "value": value,
                     "_tie": tie_val,
                 }

--- a/BackEnd/utils/stat_updater.py
+++ b/BackEnd/utils/stat_updater.py
@@ -1,6 +1,8 @@
 from typing import Any, Dict
 
-from BackEnd.db import players_collection
+from bson import ObjectId
+
+from BackEnd.db import players_collection, tournaments_collection
 
 
 def apply_stats_from_summary(summary: Dict[str, Any], game_id: str, tournament_id: str | None = None) -> None:
@@ -47,3 +49,30 @@ def apply_stats_from_summary(summary: Dict[str, Any], game_id: str, tournament_i
             {"_id": pid, "stats.applied_games": {"$ne": token}},
             update_doc,
         )
+
+        # Persist the latest season stats to the tournament document if applicable.
+        if tournament_id:
+            try:
+                tid = ObjectId(tournament_id)
+            except Exception:
+                tid = None
+            if tid:
+                player_doc = players_collection.find_one(
+                    {"_id": pid},
+                    {"first_name": 1, "last_name": 1, "team": 1, "stats.season": 1},
+                )
+                if not player_doc:
+                    continue
+                season_stats = (
+                    player_doc.get("stats", {}).get("season", {}) if isinstance(player_doc, dict) else {}
+                )
+                player_entry = {
+                    "first_name": player_doc.get("first_name", ""),
+                    "last_name": player_doc.get("last_name", ""),
+                    "team": player_doc.get("team", ""),
+                    "stats": season_stats,
+                }
+                tournaments_collection.update_one(
+                    {"_id": tid},
+                    {"$set": {f"player_stats.{pid}": player_entry}},
+                )

--- a/tests/test_tournament_leaders_endpoint.py
+++ b/tests/test_tournament_leaders_endpoint.py
@@ -1,79 +1,78 @@
 from BackEnd.tournament.tournament_manager import TournamentManager
+from bson import ObjectId
+
 from BackEnd.api.tournament_routes import get_tournament_leaders
-from BackEnd.db import players_collection, tournaments_collection
+from BackEnd.tournament.tournament_manager import TournamentManager
+from BackEnd.db import tournaments_collection
 
 
 def setup_function(fn):
-    players_collection.delete_many({})
     tournaments_collection.delete_many({})
 
 
 def test_leaders_return_top_players_and_exclude_others():
-    players_collection.insert_many(
-        [
-            {
-                "_id": "p1",
-                "team": "A",
-                "first_name": "Ann",
-                "last_name": "Alpha",
-                "stats": {
-                    "season": {
-                        "PTS": 20,
-                        "TPM": 5,
-                        "TPA": 10,
-                        "REB": 8,
-                        "AST": 4,
-                        "STL": 2,
-                        "BLK": 1,
-                        "MIN": 30,
-                    }
-                },
-            },
-            {
-                "_id": "p2",
-                "team": "B",
-                "first_name": "Bob",
-                "last_name": "Beta",
-                "stats": {
-                    "season": {
-                        "PTS": 15,
-                        "TPM": 5,
-                        "TPA": 8,
-                        "REB": 7,
-                        "AST": 5,
-                        "STL": 1,
-                        "BLK": 0,
-                        "MIN": 28,
-                    }
-                },
-            },
-            {
-                "_id": "p3",
-                "team": "X",
-                "first_name": "X",  # should be excluded
-                "last_name": "Excluded",
-                "stats": {
-                    "season": {
-                        "PTS": 100,
-                        "TPM": 20,
-                        "TPA": 30,
-                        "REB": 10,
-                        "AST": 10,
-                        "STL": 10,
-                        "BLK": 10,
-                        "MIN": 40,
-                    }
-                },
-            },
-        ]
-    )
-
     manager = TournamentManager(
         user_team_id="A",
         tournaments_collection=tournaments_collection,
         team_ids=["A", "B", "C", "D", "E", "F", "G", "H"],
     )
     tourney = manager.create_tournament()
+    tid = ObjectId(tourney["_id"])
+
+    tournaments_collection.update_one(
+        {"_id": tid},
+        {
+            "$set": {
+                "player_stats": {
+                    "p1": {
+                        "team": "A",
+                        "first_name": "Ann",
+                        "last_name": "Alpha",
+                        "stats": {
+                            "PTS": 20,
+                            "TPM": 5,
+                            "TPA": 10,
+                            "REB": 8,
+                            "AST": 4,
+                            "STL": 2,
+                            "BLK": 1,
+                            "MIN": 30,
+                        },
+                    },
+                    "p2": {
+                        "team": "B",
+                        "first_name": "Bob",
+                        "last_name": "Beta",
+                        "stats": {
+                            "PTS": 15,
+                            "TPM": 5,
+                            "TPA": 8,
+                            "REB": 7,
+                            "AST": 5,
+                            "STL": 1,
+                            "BLK": 0,
+                            "MIN": 28,
+                        },
+                    },
+                    "p3": {
+                        "team": "X",  # should be excluded
+                        "first_name": "X",
+                        "last_name": "Excluded",
+                        "stats": {
+                            "PTS": 100,
+                            "TPM": 20,
+                            "TPA": 30,
+                            "REB": 10,
+                            "AST": 10,
+                            "STL": 10,
+                            "BLK": 10,
+                            "MIN": 40,
+                        },
+                    },
+                }
+            }
+        },
+    )
 
     leaders = get_tournament_leaders(tourney["_id"])
 

--- a/tests/test_tournament_player_stats.py
+++ b/tests/test_tournament_player_stats.py
@@ -1,9 +1,10 @@
 from BackEnd.utils.stat_updater import apply_stats_from_summary
-from BackEnd.db import players_collection
+from BackEnd.db import players_collection, tournaments_collection
 
 
 def setup_function(fn):
     players_collection.delete_many({})
+    tournaments_collection.delete_many({})
     players_collection.insert_many([
         {
             "_id": "p1",
@@ -57,3 +58,25 @@ def test_apply_stats_idempotent():
     p1 = players_collection.find_one({"_id": "p1"})
     assert p1["stats"]["season"]["PTS"] == 10
     assert p1["stats"]["season"]["AST"] == 2
+
+
+def test_apply_stats_saved_to_tournament():
+    summary = {
+        "home_team": "Lancaster",
+        "away_team": "Bentley-Truman",
+        "box_score": {
+            "Lancaster": {"PG": {"name": "A One", "PTS": 7, "AST": 3}},
+            "Bentley-Truman": {"PG": {"name": "B Two", "PTS": 4, "AST": 5}},
+        },
+        "players": [
+            {"playerId": "p1", "team": "home", "pos": "PG"},
+            {"playerId": "p2", "team": "away", "pos": "PG"},
+        ],
+    }
+    tid = tournaments_collection.insert_one({}).inserted_id
+    apply_stats_from_summary(summary, "g1", str(tid))
+    tourney = tournaments_collection.find_one({"_id": tid})
+    assert tourney is not None
+    pstats = tourney.get("player_stats", {})
+    assert pstats["p1"]["stats"]["PTS"] == 7
+    assert pstats["p2"]["stats"]["AST"] == 5


### PR DESCRIPTION
## Summary
- snapshot each player's season stats into the tournament document after every game
- compute tournament leaderboard using stored player stats
- add tests for tournament stat persistence and leaderboard sourcing

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c63c9b6e8832889f9177b6477a650