### PR TITLE
Add test to ensure franchise names data packaged

### DIFF
--- a/tests/test_package_data.py
+++ b/tests/test_package_data.py
@@ -1,0 +1,33 @@
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+import shutil
+
+
+def test_package_includes_data(tmp_path):
+    project_root = Path(__file__).resolve().parent.parent
+    package_src = tmp_path / "pkg"
+    shutil.copytree(project_root / "BackEnd", package_src / "BackEnd")
+    shutil.copy2(project_root / "setup.cfg", package_src / "setup.cfg")
+    shutil.copy2(project_root / "MANIFEST.in", package_src / "MANIFEST.in")
+    (package_src / "pyproject.toml").write_text(
+        "[build-system]\nrequires=['setuptools','wheel']\nbuild-backend='setuptools.build_meta'\n"
+    )
+    venv_dir = tmp_path / "venv"
+    subprocess.run([sys.executable, "-m", "venv", str(venv_dir)], check=True)
+    python = venv_dir / ("Scripts" if os.name == "nt" else "bin") / "python"
+    pip = venv_dir / ("Scripts" if os.name == "nt" else "bin") / "pip"
+    subprocess.run([str(pip), "install", "--no-deps", str(package_src)], check=True)
+    check_code = textwrap.dedent(
+        """
+        import json
+        import importlib.resources as res
+
+        path = res.files('BackEnd') / 'data' / 'names' / 'franchise_names.json'
+        assert path.is_file(), f"Missing resource: {path}"
+        json.loads(path.read_text())
+        """
+    )
+    subprocess.run([str(python), "-c", check_code], check=True)


### PR DESCRIPTION
## Summary
- add test installing package in temp venv and verifying `BackEnd/data/names/franchise_names.json` is present and parseable

## Testing
- `PYTHONPATH=. pytest tests/test_package_data.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689c6639ef408328b6aedc3ef0e08bdb