### PR TITLE
Add overtime periods to game simulation

### DIFF
--- a/BackEnd/main.py
+++ b/BackEnd/main.py
@@ -248,22 +248,28 @@ def run_simulation(home_team_name, away_team_name, home_lineup_ids=None, away_li
         gm.away_team.lineup = build_lineup_from_mongo(away_team_name)
 
     gm.turn_manager = TurnManager(gm)  # Rebuild now that lineups are present
-    for q in range(1, 5):
+
+    q = 1
+    while True:
         gm.quarter = q
         gm.game_state["quarter"] = q
 
+        # Label current period
+        period_label = f"Q{q}" if q <= 4 else f"OT{q - 4}"
+        gm.game_state["period_label"] = period_label
+
         # Reset clock and fouls
-        gm.game_state["time_remaining"] = 480
-        gm.game_state["clock"] = "8:00"
+        gm.game_state["time_remaining"] = 480 if q <= 4 else 240
+        gm.game_state["clock"] = "8:00" if q <= 4 else "4:00"
         gm.home_team.team_fouls = 0
         gm.away_team.team_fouls = 0
         gm.game_state["team_fouls"] = {gm.home_team.name: 0, gm.away_team.name: 0}
 
-        # Recharge energy at quarter start
+        # Recharge energy at period start
         recharge_amount = 0.3 if q == 3 else 0.2
         recharge_lineups(gm, recharge_amount)
 
-        print(f"=== Start of Q{q} ===")
+        print(f"=== Start of {period_label} ===")
         while gm.game_state["time_remaining"] > 0:
             gm.simulate_macro_turn()
             gm.game_state["team_fouls"] = {
@@ -274,10 +280,25 @@ def run_simulation(home_team_name, away_team_name, home_lineup_ids=None, away_li
             h, a = gm.home_team.name, gm.away_team.name
             h_pts = gm.game_state["score"][h]
             a_pts = gm.game_state["score"][a]
-            print(f"Clock: {clock} // Q{q}")
+            print(f"Clock: {clock} // {period_label}")
             print(f"🏀 {h}: {h_pts} | {a}: {a_pts}")
             print(f"Team Fouls: {gm.game_state['team_fouls']}")
-        print(f"=== End of Q{q} ===")
+        print(f"=== End of {period_label} ===")
+
+        # Check for game end after regulation or OT
+        if q >= 4:
+            h_pts = gm.game_state["score"][gm.home_team.name]
+            a_pts = gm.game_state["score"][gm.away_team.name]
+            if h_pts != a_pts:
+                break  # Game over
+            # Prepare for another overtime
+            gm.home_team.points_by_quarter.append(0)
+            gm.away_team.points_by_quarter.append(0)
+        elif q < 4:
+            # Continue to next regulation quarter
+            pass
+
+        q += 1
 
     # Print all game statistics including defense score stats
     # gm.print_game_statistics()

--- a/BackEnd/models/turn_manager.py
+++ b/BackEnd/models/turn_manager.py
@@ -135,6 +135,7 @@ class TurnManager:
         result["awayFouls"] = self.game.away_team.team_fouls
         result["clock"] = self.game.game_state["clock"]
         result["quarter"] = self.game.game_state["quarter"]
+        result["period_label"] = self.game.game_state.get("period_label")
 
         # print(f"inside run_micro_turn result: {result}")
         # print(f"result: {result}")

--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -50,6 +50,7 @@ if (weekParam && !Number.isNaN(weekParam) && typeof localStorage !== 'undefined'
   localStorage.setItem('franchise_week', weekParam);
 }
 const mode = urlParams.get('mode') || getMode({ tournamentId, franchiseId });
+const periodLabel = urlParams.get('period');
 
 const homeLineup = {};
 const awayLineup = {};
@@ -65,7 +66,8 @@ console.log("🏀 Tournament launch params:", {
   franchiseId,
   homeTeam,
   awayTeam,
-  mode
+  mode,
+  periodLabel,
 });
 
 const GameScene = createGameScene(Phaser);
@@ -120,6 +122,7 @@ async function startGame({ homeRoster, awayRoster, animate = true }) {
     animate,
     homeLineup,
     awayLineup,
+    periodLabel,
   };
 
   if (game.scene.isActive('GameScene')) {

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -20,6 +20,7 @@ export function createGameScene(Phaser) {
         this.mode = data.mode;
         this.homeLineup = data.homeLineup || {};
         this.awayLineup = data.awayLineup || {};
+        this.periodLabel = data.periodLabel;
 
         console.log("🧠 Game initialized with:", {
           rosters: this.rosters,
@@ -28,6 +29,7 @@ export function createGameScene(Phaser) {
           homeTeam: this.homeTeam,
           awayTeam: this.awayTeam,
           mode: this.mode,
+          periodLabel: this.periodLabel,
         });
       }
       
@@ -202,6 +204,7 @@ export function createGameScene(Phaser) {
       let liveAwayFouls = 0;
       let liveClock = '8:00';
       let liveQuarter = 1;
+      let livePeriodLabel = this.periodLabel || 'Q1';
 
       const updateScoreboard = (turn = {}) => {
         const prevHome = liveScore[homeTeam];
@@ -219,11 +222,16 @@ export function createGameScene(Phaser) {
 
         if (turn.clock || turn.game_clock) liveClock = turn.clock || turn.game_clock;
         if (turn.quarter != null) liveQuarter = turn.quarter;
+        if (turn.period_label) {
+          livePeriodLabel = turn.period_label;
+        } else if (turn.quarter != null) {
+          livePeriodLabel = turn.quarter > 4 ? `OT${turn.quarter - 4}` : `Q${turn.quarter}`;
+        }
 
         if (homeFoulsEl) homeFoulsEl.textContent = `F: ${liveHomeFouls}`;
         if (awayFoulsEl) awayFoulsEl.textContent = `F: ${liveAwayFouls}`;
         if (clockEl) clockEl.textContent = liveClock;
-        if (quarterEl) quarterEl.textContent = `Q:${liveQuarter}`;
+        if (quarterEl) quarterEl.textContent = livePeriodLabel;
 
         applyPlayerStats(turn);
 

--- a/FrontEnd/static/set-lineup.js
+++ b/FrontEnd/static/set-lineup.js
@@ -5,6 +5,7 @@ const homeId = urlParams.get('home_id');
 const awayId = urlParams.get('away_id');
 let myTeamSide = urlParams.get('my_team');
 const userTeamIdParam = urlParams.get('user_team_id');
+const periodLabel = urlParams.get('period');
 let teamName = '';
 
 let roster = [];
@@ -142,7 +143,10 @@ function resolveTeam() {
 
 function setHeader() {
   const title = document.getElementById('team-title');
-  if (title) title.textContent = `Set Your Lineup — ${teamName}`;
+  if (title) {
+    const periodText = periodLabel ? ` — ${periodLabel}` : '';
+    title.textContent = `Set Your Lineup — ${teamName}${periodText}`;
+  }
   const logo = document.getElementById('team-logo');
   if (logo) {
     logo.src = `/static/images/homepage-logos/${teamName}.png`;

--- a/tests/test_overtime.py
+++ b/tests/test_overtime.py
@@ -1,0 +1,41 @@
+import BackEnd.main as main
+from BackEnd.models.game_manager import GameManager
+from BackEnd.models.player import Player
+from BackEnd.utils.roster_loader import load_roster
+
+
+def test_run_simulation_handles_overtime(monkeypatch):
+    def fake_simulate_macro_turn(self):
+        # end period immediately
+        self.game_state["time_remaining"] = 0
+        q = self.game_state["quarter"]
+        home = self.home_team.name
+        away = self.away_team.name
+        if q == 4 and self.score[home] == 0:
+            # force a tie at end of regulation
+            self.score[home] = 90
+            self.score[away] = 90
+            self.home_team.points_by_quarter[3] = 90
+            self.away_team.points_by_quarter[3] = 90
+        elif q == 5 and self.score[home] == 90:
+            # give home team the win in OT1
+            self.score[home] = 92
+            self.home_team.points_by_quarter[4] = 2
+
+    def fake_build_lineup(team_name):
+        _, players = load_roster(team_name)
+        positions = ["PG", "SG", "SF", "PF", "C"]
+        return {pos: Player(p) for pos, p in zip(positions, players[:5])}
+
+    monkeypatch.setattr(GameManager, "simulate_macro_turn", fake_simulate_macro_turn)
+    monkeypatch.setattr(main, "build_lineup_from_mongo", fake_build_lineup)
+
+    gm = main.run_simulation("Lancaster", "Bentley-Truman")
+
+    assert gm.quarter == 5
+    home = gm.home_team.name
+    away = gm.away_team.name
+    assert gm.score[home] == 92
+    assert gm.score[away] == 90
+    assert len(gm.home_team.points_by_quarter) == 5
+    assert gm.home_team.points_by_quarter[4] == 2


### PR DESCRIPTION
## Summary
- allow simulation to loop through 4-minute overtime periods until a winner is found
- surface `period_label` to each turn for UI and adjust front-end to show `OT1`, `OT2`, etc.
- support overtime labeling on lineup screen and when launching the game
- add regression test ensuring a tied game advances into overtime

## Testing
- `PYTHONPATH=/workspace/gob-simplified pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c64d06ccc83289357107cef4ba987