### PR TITLE
Split Play Next Game button text over two lines

### DIFF
--- a/FrontEnd/static/tournament.css
+++ b/FrontEnd/static/tournament.css
@@ -114,6 +114,11 @@ h1, h2, h3, h4, h5, h6 {
   font-family: 'Bebas Neue', cursive;
   font-size: 20px;
   cursor: pointer;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
 }
 
 #eliminated-msg {

--- a/FrontEnd/static/tournament.html
+++ b/FrontEnd/static/tournament.html
@@ -42,7 +42,10 @@
           <div class="coach-bonus">+ID / +OD</div>
         </div>
         <div class="play-now-container" style="margin-left: auto;">
-          <button id="play-now" class="play-now-btn">Play Now</button>
+          <button id="play-now" class="play-now-btn">
+            <span class="play-now-main">Play Next Game</span>
+            <span id="play-now-opponent" class="play-now-opponent"></span>
+          </button>
           <button id="sim-remaining" class="play-now-btn" style="display: none;">Sim Remaining Games</button>
         </div>
         <button id="exit-tournament" class="play-now-btn" style="display: none; margin-left: auto;">Exit</button>

--- a/FrontEnd/static/tournament.js
+++ b/FrontEnd/static/tournament.js
@@ -268,13 +268,15 @@ function updateCTA() {
   const simBtn = document.getElementById('sim-remaining');
   const exitBtn = document.getElementById('exit-tournament');
   const container = document.querySelector('.play-now-container');
-  if (!container || !playBtn || !simBtn || !exitBtn || !tournament) return;
+  const opponentEl = document.getElementById('play-now-opponent');
+  if (!container || !playBtn || !simBtn || !exitBtn || !tournament || !opponentEl) return;
 
   if (tournament.completed) {
     playBtn.style.display = 'none';
     simBtn.style.display = 'none';
     container.style.display = 'none';
     exitBtn.style.display = 'inline-block';
+    opponentEl.textContent = '';
     return;
   }
 
@@ -287,11 +289,12 @@ function updateCTA() {
 
   if (userMatch) {
     const opponent = userMatch.home_team === userTeamId ? userMatch.away_team : userMatch.home_team;
-    playBtn.style.display = 'inline-block';
-    playBtn.textContent = `Play Next Game vs ${opponent}`;
+    playBtn.style.display = 'inline-flex';
+    opponentEl.textContent = `vs ${opponent}`;
     simBtn.style.display = 'none';
   } else {
     playBtn.style.display = 'none';
+    opponentEl.textContent = '';
     simBtn.style.display = 'inline-block';
   }
 }


### PR DESCRIPTION
## Summary
- Break Play Next Game button text into two lines with opponent line inserted dynamically
- Center multi-line Play Next Game button using flexbox
- Preserve existing style while keeping opponent name dynamic

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c6b6ca35083288229de0809a4e375