### PR TITLE
Implement quarter-by-quarter lineup flow

### DIFF
--- a/BackEnd/api/api.py
+++ b/BackEnd/api/api.py
@@ -6,7 +6,8 @@ from fastapi.templating import Jinja2Templates
 from fastapi import Request
 from BackEnd.constants import POSITION_LIST
 import uuid
-from BackEnd.main import run_simulation
+from BackEnd.main import run_simulation, simulate_quarter
+from BackEnd.models.game_manager import GameManager
 from BackEnd.db import (
     players_collection,
     teams_collection,
@@ -57,6 +58,18 @@ class SimulationRequest(BaseModel):
     away_team: str
     home_lineup: dict[str, str] | None = None
     away_lineup: dict[str, str] | None = None
+
+
+class QuarterSimulationRequest(BaseModel):
+    game_id: str | None = None
+    home_team: str
+    away_team: str
+    quarter: int = 1
+    home_lineup: dict[str, str] | None = None
+    away_lineup: dict[str, str] | None = None
+
+
+ongoing_games: dict[str, GameManager] = {}
 
 # 4. Routes
 @app.get("/")
@@ -142,7 +155,40 @@ def simulate_game(request: SimulationRequest):
         traceback.print_exc()
     
     print("Inside simulate_game()\nReturning summary keys:", summary.keys())
-    
+
+    return summary
+
+
+@app.post("/api/simulate-quarter")
+def simulate_quarter_endpoint(request: QuarterSimulationRequest):
+    game_id = request.game_id
+    if game_id and game_id in ongoing_games:
+        gm = ongoing_games[game_id]
+    else:
+        gm = GameManager(request.home_team, request.away_team)
+        game_id = str(uuid.uuid4())
+        ongoing_games[game_id] = gm
+
+    gm.quarter = request.quarter
+
+    simulate_quarter(
+        gm,
+        request.home_lineup,
+        request.away_lineup,
+    )
+
+    summary = summarize_game_state(gm)
+    is_final = (
+        gm.quarter > 4
+        and summary["score"][gm.home_team.name] != summary["score"][gm.away_team.name]
+    )
+    summary.update({
+        "game_id": game_id,
+        "quarter": request.quarter,
+        "is_final": is_final,
+        "next_lineup_needed": not is_final,
+    })
+
     return summary
 
 

--- a/BackEnd/main.py
+++ b/BackEnd/main.py
@@ -33,6 +33,58 @@ from BackEnd.utils.shared import (
 )
 from BackEnd.utils.energy_system import recharge_lineups
 
+
+def simulate_quarter(gm: GameManager, home_lineup_ids=None, away_lineup_ids=None):
+    """Simulate a single quarter on an existing ``GameManager``.
+
+    Lineups may be optionally supplied as dictionaries mapping positions to
+    player ids. When omitted the current lineup on the ``GameManager`` is used
+    (or auto-generated if still empty). This function mutates ``gm`` in place
+    and advances ``gm.quarter`` when finished.
+    """
+
+    # Apply lineups if provided or build them if not already set
+    if home_lineup_ids:
+        gm.home_team.lineup = build_lineup_from_ids(home_lineup_ids)
+    elif not gm.home_team.lineup:
+        gm.home_team.lineup = build_lineup_from_mongo(gm.home_team.name)
+
+    if away_lineup_ids:
+        gm.away_team.lineup = build_lineup_from_ids(away_lineup_ids)
+    elif not gm.away_team.lineup:
+        gm.away_team.lineup = build_lineup_from_mongo(gm.away_team.name)
+
+    # Ensure the turn manager is aware of any lineup changes
+    gm.turn_manager = TurnManager(gm)
+
+    q = gm.quarter
+    gm.game_state["quarter"] = q
+
+    period_label = f"Q{q}" if q <= 4 else f"OT{q - 4}"
+    gm.game_state["period_label"] = period_label
+
+    # Reset clock and fouls for the upcoming quarter
+    gm.game_state["time_remaining"] = 480 if q <= 4 else 240
+    gm.game_state["clock"] = "8:00" if q <= 4 else "4:00"
+    gm.home_team.team_fouls = 0
+    gm.away_team.team_fouls = 0
+    gm.game_state["team_fouls"] = {gm.home_team.name: 0, gm.away_team.name: 0}
+
+    # Recharge energy slightly between quarters
+    recharge_amount = 0.3 if q == 3 else 0.2
+    recharge_lineups(gm, recharge_amount)
+
+    while gm.game_state["time_remaining"] > 0:
+        gm.simulate_macro_turn()
+        gm.game_state["team_fouls"] = {
+            gm.home_team.name: gm.home_team.team_fouls,
+            gm.away_team.name: gm.away_team.team_fouls,
+        }
+
+    gm.quarter += 1
+
+    return gm
+
 def initialize_team_attributes():
     settings = {}
     for team in ["Lancaster", "Bentley-Truman"]:
@@ -232,76 +284,34 @@ def print_scouting_report(data):
             print(f"{def_type.ljust(14)} — Used: {val['used']}, Success: {val['success']}")
 
 def run_simulation(home_team_name, away_team_name, home_lineup_ids=None, away_lineup_ids=None):
+    """Run a full game simulation.
+
+    This now acts as a thin wrapper around :func:`simulate_quarter`, looping
+    until the game is complete. Existing callers therefore continue to work
+    without modification while enabling quarter-by-quarter control elsewhere.
+    """
+
     gm = GameManager(home_team_name, away_team_name)
 
     print("Inside run_simulation")
     print(f"Home team: {home_team_name}, Away team: {away_team_name}")
 
-    if home_lineup_ids:
-        gm.home_team.lineup = build_lineup_from_ids(home_lineup_ids)
-    else:
-        gm.home_team.lineup = build_lineup_from_mongo(home_team_name)
-
-    if away_lineup_ids:
-        gm.away_team.lineup = build_lineup_from_ids(away_lineup_ids)
-    else:
-        gm.away_team.lineup = build_lineup_from_mongo(away_team_name)
-
-    gm.turn_manager = TurnManager(gm)  # Rebuild now that lineups are present
-
-    q = 1
+    gm.quarter = 1
     while True:
-        gm.quarter = q
-        gm.game_state["quarter"] = q
+        simulate_quarter(gm, home_lineup_ids if gm.quarter == 1 else None,
+                         away_lineup_ids if gm.quarter == 1 else None)
 
-        # Label current period
-        period_label = f"Q{q}" if q <= 4 else f"OT{q - 4}"
-        gm.game_state["period_label"] = period_label
+        current_q = gm.quarter - 1  # simulate_quarter increments after play
 
-        # Reset clock and fouls
-        gm.game_state["time_remaining"] = 480 if q <= 4 else 240
-        gm.game_state["clock"] = "8:00" if q <= 4 else "4:00"
-        gm.home_team.team_fouls = 0
-        gm.away_team.team_fouls = 0
-        gm.game_state["team_fouls"] = {gm.home_team.name: 0, gm.away_team.name: 0}
-
-        # Recharge energy at period start
-        recharge_amount = 0.3 if q == 3 else 0.2
-        recharge_lineups(gm, recharge_amount)
-
-        print(f"=== Start of {period_label} ===")
-        while gm.game_state["time_remaining"] > 0:
-            gm.simulate_macro_turn()
-            gm.game_state["team_fouls"] = {
-                gm.home_team.name: gm.home_team.team_fouls,
-                gm.away_team.name: gm.away_team.team_fouls,
-            }
-            clock = gm.game_state["clock"]
-            h, a = gm.home_team.name, gm.away_team.name
-            h_pts = gm.game_state["score"][h]
-            a_pts = gm.game_state["score"][a]
-            print(f"Clock: {clock} // {period_label}")
-            print(f"🏀 {h}: {h_pts} | {a}: {a_pts}")
-            print(f"Team Fouls: {gm.game_state['team_fouls']}")
-        print(f"=== End of {period_label} ===")
-
-        # Check for game end after regulation or OT
-        if q >= 4:
+        if current_q >= 4:
             h_pts = gm.game_state["score"][gm.home_team.name]
             a_pts = gm.game_state["score"][gm.away_team.name]
             if h_pts != a_pts:
-                break  # Game over
-            # Prepare for another overtime
+                gm.quarter = current_q
+                gm.game_state["quarter"] = current_q
+                break
             gm.home_team.points_by_quarter.append(0)
             gm.away_team.points_by_quarter.append(0)
-        elif q < 4:
-            # Continue to next regulation quarter
-            pass
-
-        q += 1
-
-    # Print all game statistics including defense score stats
-    # gm.print_game_statistics()
 
     print(f"*********gm:\n{gm}")
     return gm

--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -50,7 +50,9 @@ if (weekParam && !Number.isNaN(weekParam) && typeof localStorage !== 'undefined'
   localStorage.setItem('franchise_week', weekParam);
 }
 const mode = urlParams.get('mode') || getMode({ tournamentId, franchiseId });
-const periodLabel = urlParams.get('period');
+const gameId = urlParams.get('game_id');
+const quarter = parseInt(urlParams.get('quarter'), 10) || 1;
+const periodLabel = urlParams.get('period') || `Q${quarter}`;
 
 const homeLineup = {};
 const awayLineup = {};
@@ -123,6 +125,8 @@ async function startGame({ homeRoster, awayRoster, animate = true }) {
     homeLineup,
     awayLineup,
     periodLabel,
+    gameId,
+    quarter,
   };
 
   if (game.scene.isActive('GameScene')) {

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -21,6 +21,8 @@ export function createGameScene(Phaser) {
         this.homeLineup = data.homeLineup || {};
         this.awayLineup = data.awayLineup || {};
         this.periodLabel = data.periodLabel;
+        this.gameId = data.gameId;
+        this.quarter = data.quarter || 1;
 
         console.log("🧠 Game initialized with:", {
           rosters: this.rosters,
@@ -57,9 +59,12 @@ export function createGameScene(Phaser) {
     console.log("📨 Sending /api/simulate request for:", homeTeam, "vs", awayTeam);
 
       const payload = { home_team: homeTeam, away_team: awayTeam };
+      if (this.gameId) payload.game_id = this.gameId;
+      payload.quarter = this.quarter;
       if (Object.keys(this.homeLineup).length) payload.home_lineup = this.homeLineup;
       if (Object.keys(this.awayLineup).length) payload.away_lineup = this.awayLineup;
-      const res = await fetch('/api/simulate', {
+      const url = this.gameId || this.quarter > 1 ? '/api/simulate-quarter' : '/api/simulate-quarter';
+      const res = await fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload)
@@ -75,6 +80,8 @@ export function createGameScene(Phaser) {
       console.log("📦 simData received:", simData);
       const logHome = simData.homeTeam?.name || simData.home_team;
       const logAway = simData.awayTeam?.name || simData.away_team;
+      this.gameId = simData.game_id || this.gameId;
+      this.isFinal = simData.is_final;
       console.log(
         `✅ Simulated matchup: ${logHome} vs ${logAway}`
       );
@@ -328,7 +335,17 @@ export function createGameScene(Phaser) {
           });
 
           console.log("✅ GameScene animation complete");
-          await finalize();
+          if (this.isFinal) {
+            await finalize();
+          } else {
+            const nextQ = this.quarter + 1;
+            const params = new URLSearchParams(window.location.search);
+            params.set('game_id', this.gameId);
+            params.set('quarter', nextQ);
+            params.set('period', `Q${nextQ}`);
+            window.location.href = `/static/set-lineup.html?${params.toString()}`;
+            return;
+          }
         };
 
         if (this.textures.exists(courtKey)) {
@@ -348,7 +365,16 @@ export function createGameScene(Phaser) {
           this.load.start();
         }
       } else {
-        await finalize();
+        if (this.isFinal) {
+          await finalize();
+        } else {
+          const nextQ = this.quarter + 1;
+          const params = new URLSearchParams(window.location.search);
+          params.set('game_id', this.gameId);
+          params.set('quarter', nextQ);
+          params.set('period', `Q${nextQ}`);
+          window.location.href = `/static/set-lineup.html?${params.toString()}`;
+        }
       }
     }
   };

--- a/FrontEnd/static/set-lineup.js
+++ b/FrontEnd/static/set-lineup.js
@@ -5,7 +5,9 @@ const homeId = urlParams.get('home_id');
 const awayId = urlParams.get('away_id');
 let myTeamSide = urlParams.get('my_team');
 const userTeamIdParam = urlParams.get('user_team_id');
-const periodLabel = urlParams.get('period');
+const gameId = urlParams.get('game_id');
+const quarter = parseInt(urlParams.get('quarter'), 10) || 1;
+const periodLabel = urlParams.get('period') || `Q${quarter}`;
 let teamName = '';
 
 let roster = [];

--- a/tests/test_simulate_quarter.py
+++ b/tests/test_simulate_quarter.py
@@ -1,0 +1,36 @@
+import BackEnd.main as main
+from BackEnd.models.game_manager import GameManager
+from BackEnd.models.player import Player
+from BackEnd.utils.roster_loader import load_roster
+
+
+def fake_simulate_macro_turn(self):
+    # End the quarter immediately
+    self.game_state["time_remaining"] = 0
+
+
+def fake_build_lineup(team_name):
+    _, players = load_roster(team_name)
+    positions = ["PG", "SG", "SF", "PF", "C"]
+    return {pos: Player(p) for pos, p in zip(positions, players[:5])}
+
+
+def test_simulate_quarter_advances_game(monkeypatch):
+    monkeypatch.setattr(GameManager, "simulate_macro_turn", fake_simulate_macro_turn)
+    monkeypatch.setattr(main, "build_lineup_from_mongo", fake_build_lineup)
+
+    gm = GameManager("Lancaster", "Bentley-Truman")
+
+    main.simulate_quarter(gm)
+    assert gm.quarter == 2
+    assert gm.game_state["time_remaining"] == 0
+
+    # add fouls to ensure reset
+    gm.home_team.team_fouls = 3
+    gm.away_team.team_fouls = 4
+
+    main.simulate_quarter(gm)
+    assert gm.quarter == 3
+    assert gm.game_state["team_fouls"][gm.home_team.name] == 0
+    assert gm.game_state["team_fouls"][gm.away_team.name] == 0
+


### PR DESCRIPTION
## Summary
- add `simulate_quarter` helper and refactor `run_simulation` to use it
- provide `/api/simulate-quarter` endpoint with persistent game state
- plumb quarter parameters through frontend so users set new lineups between quarters
- add unit test for quarter simulation helper

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c6471a3e08328a7477eb262689381