### PR TITLE
Reset player stats when starting tournament

### DIFF
--- a/BackEnd/api/tournament_routes.py
+++ b/BackEnd/api/tournament_routes.py
@@ -4,7 +4,9 @@ from BackEnd.db import (
     tournaments_collection,
     teams_collection,
     games_collection,
+    players_collection,
 )
+from BackEnd.constants import BOX_SCORE_KEYS
 from BackEnd.tournament.tournament_manager import TournamentManager
 from BackEnd.tournament.bracket_logic import update_bracket_from_results
 from BackEnd.main import run_simulation
@@ -123,14 +125,30 @@ def get_tournament_leaders(tournament_id: str):
 @router.post("/start-tournament")
 def start_tournament(request: StartTournamentRequest):
     team_docs = list(teams_collection.find({}, {"name": 1}))
-    all_team_ids = [team["name"] for team in team_docs]
+    team_ids = [team["name"] for team in team_docs]
 
-    if request.user_team_id not in all_team_ids:
+    if request.user_team_id not in team_ids:
         raise HTTPException(status_code=400, detail="Invalid user_team_id")
+
+    # Reset all player stats for teams in this tournament
+    zero_stats = {key: 0 for key in BOX_SCORE_KEYS}
+    for tid in team_ids:
+        players_collection.update_many(
+            {"team": tid},
+            {
+                "$set": {
+                    "stats.game": zero_stats,
+                    "stats.season": zero_stats,
+                    "stats.career": zero_stats,
+                    "stats.applied_games": [],
+                }
+            },
+        )
 
     manager = TournamentManager(
         user_team_id=request.user_team_id,
         tournaments_collection=tournaments_collection,
+        team_ids=team_ids,
     )
     tournament = manager.create_tournament()
     tournament["_id"] = str(tournament["_id"])

--- a/tests/test_start_tournament_resets_stats.py
+++ b/tests/test_start_tournament_resets_stats.py
@@ -1,0 +1,56 @@
+from fastapi.testclient import TestClient
+
+from BackEnd.api.api import app
+from BackEnd.constants import BOX_SCORE_KEYS
+from BackEnd.db import players_collection, teams_collection, tournaments_collection
+
+
+client = TestClient(app)
+
+
+def setup_function(fn):
+    players_collection.delete_many({})
+    teams_collection.delete_many({})
+    tournaments_collection.delete_many({})
+
+
+def _make_team_docs():
+    return [
+        {"name": "Bentley-Truman"},
+        {"name": "Four Corners"},
+        {"name": "Lancaster"},
+        {"name": "Little York"},
+        {"name": "Morristown"},
+        {"name": "Ocean City"},
+        {"name": "South Lancaster"},
+        {"name": "Xavien"},
+    ]
+
+
+def test_start_tournament_resets_player_stats():
+    teams_collection.insert_many(_make_team_docs())
+    players_collection.insert_one(
+        {
+            "_id": "p1",
+            "team": "Lancaster",
+            "first_name": "A",
+            "last_name": "One",
+            "stats": {
+                "game": {"PTS": 5},
+                "season": {"PTS": 5},
+                "career": {"PTS": 10},
+                "applied_games": ["old"],
+            },
+        }
+    )
+
+    resp = client.post("/start-tournament", json={"user_team_id": "Lancaster"})
+    assert resp.status_code == 200
+
+    player = players_collection.find_one({"_id": "p1"})
+    zero_stats = {k: 0 for k in BOX_SCORE_KEYS}
+    assert player["stats"]["game"] == zero_stats
+    assert player["stats"]["season"] == zero_stats
+    assert player["stats"]["career"] == zero_stats
+    assert player["stats"]["applied_games"] == []
+


### PR DESCRIPTION
## Summary
- reset all player stat buckets for participating teams before creating a tournament
- add regression test ensuring stats are cleared on tournament start

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c6fc29d7c832892d405e0a70affc3