### PR TITLE
Track season and career stats for franchise players

### DIFF
--- a/BackEnd/api/franchise_routes.py
+++ b/BackEnd/api/franchise_routes.py
@@ -463,14 +463,14 @@ def leaders():
     for cat in categories:
         sorted_players = sorted(
             players,
-            key=lambda p: p.get("season_stats", {}).get(cat, 0),
+            key=lambda p: p.get("stats", {}).get("season", {}).get(cat, 0),
             reverse=True
         )[:10]
         result[cat] = [
             {
                 "name": f"{p.get('first_name', '')} {p.get('last_name', '')}".strip(),
                 "team": p.get("team"),
-                "value": p.get("season_stats", {}).get(cat, 0)
+                "value": p.get("stats", {}).get("season", {}).get(cat, 0)
             }
             for p in sorted_players
         ]
@@ -485,7 +485,7 @@ def team_stats():
         players = list(db.players.find({"team": t["name"]}))
         totals = {}
         for p in players:
-            for stat, val in p.get("season_stats", {}).items():
+            for stat, val in p.get("stats", {}).get("season", {}).items():
                 totals[stat] = totals.get(stat, 0) + val
         output.append({"team": t["name"], "stats": totals})
     return {"teams": output}

--- a/BackEnd/models/franchise_manager.py
+++ b/BackEnd/models/franchise_manager.py
@@ -7,6 +7,8 @@ import logging
 import os
 
 from BackEnd.main import run_simulation
+from BackEnd.utils.shared import summarize_game_state
+from BackEnd.utils.stat_updater import apply_stats_from_summary
 
 
 logger = logging.getLogger(__name__)
@@ -84,10 +86,29 @@ class FranchiseManager:
 
     def reset_stats(self):
         for team in self.teams:
-            self.db.players.update_many({"team_id": team["_id"]}, {"$set": {"season_stats": {}}})
+            self.db.players.update_many(
+                {"team_id": team["_id"]},
+                {
+                    "$set": {
+                        "stats.game": {},
+                        "stats.season": {},
+                        "stats.career": {},
+                        "stats.applied_games": [],
+                    },
+                    "$unset": {"season_stats": ""},
+                },
+            )
             self.db.teams.update_one(
                 {"_id": team["_id"]},
-                {"$set": {"season_stats": {}, "record": {"W": 0, "L": 0}, "PF": 0, "PA": 0}}
+                {
+                    "$set": {
+                        "stats.season": {},
+                        "record": {"W": 0, "L": 0},
+                        "PF": 0,
+                        "PA": 0,
+                    },
+                    "$unset": {"season_stats": ""},
+                },
             )
 
     def run_week(self):
@@ -162,6 +183,9 @@ class FranchiseManager:
             gm = run_simulation(home_name, away_name)
             team1_score = gm.score.get(away_name, 0)
             team2_score = gm.score.get(home_name, 0)
+            summary = summarize_game_state(gm)
+            game_token = f"{self.week}-{team1_id}-{team2_id}"
+            apply_stats_from_summary(summary, game_token)
         except Exception:
             team1_score = random.randint(50, 90)
             team2_score = random.randint(50, 90)
@@ -199,7 +223,7 @@ class FranchiseManager:
     # /franchise/standings → use team records from self.db.teams
     # /franchise/roster → use self.db.players.find({"team_id": team_id})
     # /franchise/schedule → use self.schedule
-    # /franchise/stats → aggregate from self.db.players (season_stats)
+    # /franchise/stats → aggregate from self.db.players (stats.season)
     # /franchise/recruits → use self.db.recruits.find()
 
 class ScheduleManager:

--- a/tests/test_franchise_stats.py
+++ b/tests/test_franchise_stats.py
@@ -1,0 +1,97 @@
+from BackEnd.models.franchise_manager import FranchiseManager
+from BackEnd.db import db, players_collection
+
+
+def setup_db():
+    db.games.delete_many({})
+    db.teams.delete_many({})
+    players_collection.delete_many({})
+    teams = [
+        {"_id": f"T{i}", "name": f"Team{i}", "record": {"W": 0, "L": 0}, "PF": 0, "PA": 0}
+        for i in range(8)
+    ]
+    db.teams.insert_many(teams)
+
+
+def test_initialize_season_zeros_buckets():
+    setup_db()
+    players_collection.insert_one(
+        {
+            "_id": "p1",
+            "team_id": "T0",
+            "team": "Team0",
+            "stats": {
+                "game": {"PTS": 5},
+                "season": {"PTS": 10},
+                "career": {"PTS": 20},
+                "applied_games": ["old"]
+            },
+        }
+    )
+    manager = FranchiseManager(db)
+    manager.initialize_season()
+    p1 = players_collection.find_one({"_id": "p1"})
+    assert p1["stats"]["game"] == {}
+    assert p1["stats"]["season"] == {}
+    assert p1["stats"]["career"] == {}
+    assert p1["stats"]["applied_games"] == []
+
+
+def test_simulated_game_accumulates_stats(monkeypatch):
+    setup_db()
+    players_collection.insert_many(
+        [
+            {
+                "_id": "p1",
+                "team_id": "T0",
+                "team": "Team0",
+                "first_name": "A",
+                "last_name": "One",
+                "stats": {"game": {}, "season": {}, "career": {}, "applied_games": []},
+            },
+            {
+                "_id": "p2",
+                "team_id": "T1",
+                "team": "Team1",
+                "first_name": "B",
+                "last_name": "Two",
+                "stats": {"game": {}, "season": {}, "career": {}, "applied_games": []},
+            },
+        ]
+    )
+    manager = FranchiseManager(db)
+    manager.reset_stats()
+
+    def fake_run_simulation(home, away):
+        class GM:
+            def __init__(self, h, a):
+                self.score = {h: 80, a: 70}
+        return GM(home, away)
+
+    def fake_summary(game):
+        return {
+            "home_team": "Team1",
+            "away_team": "Team0",
+            "box_score": {
+                "Team1": {"PG": {"name": "B Two", "PTS": 12}},
+                "Team0": {"PG": {"name": "A One", "PTS": 7}},
+            },
+            "players": [
+                {"playerId": "p2", "team": "home", "pos": "PG"},
+                {"playerId": "p1", "team": "away", "pos": "PG"},
+            ],
+        }
+
+    monkeypatch.setattr("BackEnd.models.franchise_manager.run_simulation", fake_run_simulation)
+    monkeypatch.setattr("BackEnd.models.franchise_manager.summarize_game_state", fake_summary)
+
+    manager.simulate_game("T0", "T1")
+
+    p1 = players_collection.find_one({"_id": "p1"})
+    p2 = players_collection.find_one({"_id": "p2"})
+    assert p1["stats"]["season"]["PTS"] == 7
+    assert p1["stats"]["career"]["PTS"] == 7
+    assert p2["stats"]["season"]["PTS"] == 12
+    assert p2["stats"]["career"]["PTS"] == 12
+    assert p1["stats"]["game"].get("PTS") == 0
+    assert p2["stats"]["game"].get("PTS") == 0


### PR DESCRIPTION
## Summary
- Reset franchise player stats by clearing game, season, career buckets and applied tokens
- Swap season_stats usage for stats.season in franchise APIs
- Accumulate franchise game stats into season and career totals
- Add tests for franchise stat resets and game accumulation

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c71c0e2708328afc5f8bd843ee473