### PR TITLE
Improve lineup assignment using roster lookup

### DIFF
--- a/BackEnd/main.py
+++ b/BackEnd/main.py
@@ -1,7 +1,7 @@
 import random
 import json
 from BackEnd.db import players_collection, teams_collection
-from BackEnd.utils.db_utils import build_lineup_from_mongo, build_lineup_from_ids
+from BackEnd.utils.db_utils import build_lineup_from_mongo, assign_lineup_from_ids
 from BackEnd.models.player import Player
 from BackEnd.models.game_manager import GameManager
 from BackEnd.models.turn_manager import TurnManager
@@ -45,12 +45,12 @@ def simulate_quarter(gm: GameManager, home_lineup_ids=None, away_lineup_ids=None
 
     # Apply lineups if provided or build them if not already set
     if home_lineup_ids:
-        gm.home_team.lineup = build_lineup_from_ids(home_lineup_ids)
+        gm.home_team.lineup = assign_lineup_from_ids(gm.home_team, home_lineup_ids)
     elif not gm.home_team.lineup:
         gm.home_team.lineup = build_lineup_from_mongo(gm.home_team.name)
 
     if away_lineup_ids:
-        gm.away_team.lineup = build_lineup_from_ids(away_lineup_ids)
+        gm.away_team.lineup = assign_lineup_from_ids(gm.away_team, away_lineup_ids)
     elif not gm.away_team.lineup:
         gm.away_team.lineup = build_lineup_from_mongo(gm.away_team.name)
 

--- a/BackEnd/models/team_manager.py
+++ b/BackEnd/models/team_manager.py
@@ -1,5 +1,5 @@
 import random
-from BackEnd.db import players_collection, teams_collection
+from BackEnd.db import teams_collection
 from BackEnd.utils.roster_loader import load_roster
 from BackEnd.models.player import Player
 from BackEnd.constants import PLAYCALLS
@@ -35,15 +35,18 @@ class TeamManager:
 
     def _load_roster(self):
         _, players = load_roster(self.name)
-        return [Player(p) for p in players]
+        roster = {}
+        for pdata in players:
+            player = Player(pdata)
+            roster[player.player_id] = player
+        return roster
 
     def _load_lineup(self):
         # If you’re still defining self.players before this
         return {}  # default to empty dict — lineup will be set later
 
-
-    def get_player(self, position):
-        return self.players.get(position)
+    def get_player_by_id(self, player_id):
+        return self.players.get(player_id)
 
     def get_all_players(self):
         return self.players.values()

--- a/BackEnd/utils/db_utils.py
+++ b/BackEnd/utils/db_utils.py
@@ -1,9 +1,9 @@
 
 import random
 from typing import List, Dict
-from bson import ObjectId
 from BackEnd.db import players_collection
 from BackEnd.models.player import Player
+from BackEnd.models.team_manager import TeamManager
 
 # Trait groups per position
 POSITION_TRAITS = {
@@ -48,14 +48,10 @@ def build_lineup_from_mongo(team_name: str) -> dict:
     return lineup
 
 
-def build_lineup_from_ids(lineup_ids: Dict[str, str]) -> Dict[str, Player]:
-    lineup: Dict[str, Player] = {}
+def assign_lineup_from_ids(team: TeamManager, lineup_ids: Dict[str, str]) -> Dict[str, Player]:
     for pos, pid in lineup_ids.items():
-        try:
-            doc = players_collection.find_one({"_id": ObjectId(pid)})
-        except Exception:
-            doc = players_collection.find_one({"_id": pid})
-        if doc:
-            lineup[pos] = Player(doc)
-    return lineup
+        player = team.get_player_by_id(pid)
+        if player and team.lineup.get(pos) is not player:
+            team.lineup[pos] = player
+    return team.lineup
 


### PR DESCRIPTION
## Summary
- Store team rosters as dicts keyed by `player_id` for constant-time lookups and expose `get_player_by_id`
- Add `assign_lineup_from_ids` helper that reuses existing `Player` objects when setting lineups
- Update `simulate_quarter` to use the new helper, only changing lineup positions that differ

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c74a9b9f48328b6a467276543cf13