### PR TITLE
Hydrate player stats from prior quarters

### DIFF
--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -163,6 +163,33 @@ export function createGameScene(Phaser) {
         });
       };
 
+      const hydrateBoxScore = () => {
+        const box = simData.box_score || {};
+        ['home', 'away'].forEach(teamKey => {
+          const teamName = teamKey === 'home' ? homeTeam : awayTeam;
+          const teamBox = box[teamName] || {};
+          const lineup = {};
+          positions.forEach(pos => {
+            const statBlock = teamBox[pos];
+            if (!statBlock) return;
+            const playerId = this.nameToId[statBlock.name];
+            if (!playerId) return;
+            const pts = statBlock.PTS ?? 0;
+            const reb = statBlock.REB ?? ((statBlock.OREB || 0) + (statBlock.DREB || 0));
+            const ast = statBlock.AST ?? 0;
+            const ps = this.playerStats[playerId] || { PTS: 0, REB: 0, AST: 0 };
+            ps.PTS = pts;
+            ps.REB = reb;
+            ps.AST = ast;
+            this.playerStats[playerId] = ps;
+            lineup[pos] = playerId;
+          });
+          updateLineup(teamKey, lineup);
+        });
+      };
+
+      hydrateBoxScore();
+
       const applyPlayerStats = (turn = {}) => {
         if (turn.home_lineup) updateLineup('home', turn.home_lineup);
         if (turn.away_lineup) updateLineup('away', turn.away_lineup);


### PR DESCRIPTION
## Summary
- Hydrate sidebar player stats from the cumulative box score before each quarter
- Map existing PTS/REB/AST totals to playerStats and DOM cells for both teams

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cae0e683c8328861265fcec124c6d