### PR TITLE
Ensure tournament save uses game_id

### DIFF
--- a/FrontEnd/static/js/phaser/finalizeGame.js
+++ b/FrontEnd/static/js/phaser/finalizeGame.js
@@ -29,7 +29,7 @@ export async function finalizeGame({ simData, tournamentId, franchiseId, game })
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           tournament_id: tournamentId,
-          game_id: simData._id,
+          game_id: simData.game_id || simData._id,
           winner: winner,
         }),
       });


### PR DESCRIPTION
## Summary
- Prefer `game_id` when saving tournament results, falling back to legacy `_id`

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cc296526c8328bbdeb755644613d1