### PR TITLE
Refresh cached tournament after matches

### DIFF
--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -120,6 +120,14 @@ export function createGameScene(Phaser) {
             console.error("❌ Failed to save tournament result:", await res.text());
             } else {
             console.log("✅ Tournament result saved.");
+            try {
+                const activeRes = await fetch(`/tournament/active?user_team_id=${encodeURIComponent(localStorage.getItem("userTeamId") || "")}`);
+                const updatedTournament = await activeRes.json();
+                localStorage.setItem("activeTournament", JSON.stringify(updatedTournament));
+                console.log("🔄 Tournament cache refreshed");
+            } catch (err) {
+                console.error("Failed to refresh tournament", err);
+            }
             }
         } catch (err) {
             console.error("🚨 Error during tournament result save:", err);

--- a/FrontEnd/static/tournament.js
+++ b/FrontEnd/static/tournament.js
@@ -259,10 +259,10 @@ function initTopAssets() {
 }
 
 async function loadTournament() {
-  if (tournament) return;
   try {
     const res = await fetch(`/tournament/active?user_team_id=${encodeURIComponent(userTeamId)}`);
     tournament = await res.json();
+    localStorage.setItem("activeTournament", JSON.stringify(tournament));
     console.log("Bracket data arrives", tournament);
   } catch (err) {
     console.error("Failed to load tournament", err);


### PR DESCRIPTION
## Summary
- Always fetch the active tournament and update localStorage
- Refresh cached tournament after saving a game result

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cd17fb768832881d409927795f0ab