### PR TITLE
Track and persist per-turn stat changes

### DIFF
--- a/BackEnd/main.py
+++ b/BackEnd/main.py
@@ -92,6 +92,9 @@ def simulate_quarter(
     and advances ``gm.quarter`` when finished.
     """
 
+    if game_id is not None:
+        gm.game_id = game_id
+
     # Apply lineups if provided or build them if not already set
     if home_lineup_ids:
         gm.home_team.lineup = assign_lineup_from_ids(gm.home_team, home_lineup_ids)

--- a/BackEnd/models/game_manager.py
+++ b/BackEnd/models/game_manager.py
@@ -7,6 +7,8 @@ from BackEnd.constants import POSITION_LIST, PLAYCALLS, BOX_SCORE_KEYS
 from copy import deepcopy
 import random
 
+from BackEnd.utils.stat_updater import update_game_stats
+
 class GameManager:
     def __init__(self, home_team_name, away_team_name):
         self.home_team = TeamManager(home_team_name)
@@ -24,10 +26,13 @@ class GameManager:
 
         self.turn_manager = TurnManager(self)
         self.shot_manager = ShotManager(self)
-        
+
         # Add counters for function calls
         self.macro_turn_count = 0
         self.micro_turn_count = 0
+
+        # optional database identifier for live games
+        self.game_id: str | None = None
 
     
     def _init_game_state(self):
@@ -79,13 +84,18 @@ class GameManager:
         result = self.turn_manager.run_micro_turn()
         self.turns.append(result)
         self.text_log.append(result["text"])
-        
+
         # Update team stats after each turn
         self.update_team_stats()
-        
+
+        # Persist incremental stats for active games
+        deltas = result.get("deltas")
+        if self.game_id and deltas:
+            update_game_stats(self.game_id, deltas, dict(self.score))
+
         # print("End of simulate_macro_turn")
         # print(f"result: {result}")
-        
+
         return result
 
     def switch_possession(self):

--- a/BackEnd/models/turn_manager.py
+++ b/BackEnd/models/turn_manager.py
@@ -56,7 +56,13 @@ class TurnManager:
     def run_micro_turn(self):
         # Increment micro turn counter
         self.game.micro_turn_count += 1
-        
+
+        # Snapshot player stats to compute deltas after the turn
+        pre_stats = {}
+        for team in (self.game.home_team, self.game.away_team):
+            for player in team.get_all_players():
+                pre_stats[player.player_id] = player.stats["game"].copy()
+
         # STEP 1: Set strategy calls (tempo + aggression)
         self.set_strategy_calls()
 
@@ -125,6 +131,20 @@ class TurnManager:
         result["away_lineup"] = serialize_lineup(self.game.away_team.lineup)
 
         result["score"] = dict(self.game.score)
+
+        # Compute stat deltas for each player
+        deltas = {}
+        for team in (self.game.home_team, self.game.away_team):
+            for player in team.get_all_players():
+                prev = pre_stats.get(player.player_id, {})
+                diff = {
+                    stat: player.stats["game"].get(stat, 0) - prev.get(stat, 0)
+                    for stat in player.stats["game"]
+                    if player.stats["game"].get(stat, 0) - prev.get(stat, 0)
+                }
+                if diff:
+                    deltas[player.player_id] = {"team": team.name, "stats": diff}
+        result["deltas"] = deltas
 
         # Sync and expose fouls/clock/quarter for live scoreboard updates
         self.game.game_state["team_fouls"] = {

--- a/BackEnd/utils/stat_updater.py
+++ b/BackEnd/utils/stat_updater.py
@@ -2,7 +2,7 @@ from typing import Any, Dict
 
 from bson import ObjectId
 
-from BackEnd.db import players_collection, tournaments_collection
+from BackEnd.db import players_collection, tournaments_collection, games_collection
 
 
 def apply_stats_from_summary(summary: Dict[str, Any], game_id: str, tournament_id: str | None = None) -> None:
@@ -76,3 +76,25 @@ def apply_stats_from_summary(summary: Dict[str, Any], game_id: str, tournament_i
                     {"_id": tid},
                     {"$set": {f"player_stats.{pid}": player_entry}},
                 )
+
+
+def update_game_stats(game_id: str | None, deltas: Dict[str, Any], score: Dict[str, Any]) -> None:
+    """Apply per-turn stat deltas to the ongoing game's document."""
+    if not game_id or not deltas:
+        return
+    for pid, pdata in deltas.items():
+        stats = pdata.get("stats", {})
+        if not stats:
+            continue
+        inc_doc = {f"players.$.stats.{stat}": amt for stat, amt in stats.items()}
+        set_doc: Dict[str, Any] = {}
+        team_name = pdata.get("team")
+        if team_name and team_name in score:
+            set_doc[f"score.{team_name}"] = score[team_name]
+        update_doc: Dict[str, Any] = {"$inc": inc_doc}
+        if set_doc:
+            update_doc["$set"] = set_doc
+        games_collection.update_one(
+            {"_id": game_id, "players.playerId": pid},
+            update_doc,
+        )


### PR DESCRIPTION
## Summary
- Track per-player stat deltas in `TurnManager.run_micro_turn` and expose them on each turn
- Persist incremental player stats and score via `update_game_stats` during `GameManager.simulate_macro_turn`
- Store provided `game_id` on the `GameManager` so live games can update the database

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cdae9709c8328bd6eb6d653333ba3