### PR TITLE
Track tournament player stats and finalize games

### DIFF
--- a/BackEnd/api/tournament_routes.py
+++ b/BackEnd/api/tournament_routes.py
@@ -11,7 +11,7 @@ from BackEnd.tournament.tournament_manager import TournamentManager
 from BackEnd.tournament.bracket_logic import update_bracket_from_results
 from BackEnd.main import run_simulation
 from BackEnd.utils.shared import summarize_game_state
-from BackEnd.utils.stat_updater import apply_stats_from_summary
+from BackEnd.utils import stat_updater
 from bson import ObjectId
 
 router = APIRouter()
@@ -60,7 +60,7 @@ def get_tournament_leaders(tournament_id: str):
                 "first_name": pdata.get("first_name", ""),
                 "last_name": pdata.get("last_name", ""),
                 "team_name": pdata.get("team", ""),
-                "stats": pdata.get("stats", {}),
+                "stats": pdata.get("season", {}),
             }
         )
 
@@ -203,7 +203,9 @@ def simulate_round(request: SimulateRequest):
                 else matchup["away_team"]
             )
             manager.save_game_result(round_name, i, str(game_id), winner)
-            apply_stats_from_summary(summary, str(game_id), request.tournament_id)
+            stat_updater.finalize_game(
+                str(game_id), mode="tournament", tournament_id=request.tournament_id
+            )
 
         # Reload tournament to check if round is complete
         updated_doc = tournaments_collection.find_one({"_id": tournament_id})
@@ -293,7 +295,7 @@ def save_result(request: TournamentResultRequest):
             if ObjectId.is_valid(request.game_id):
                 summary = games_collection.find_one({"_id": ObjectId(request.game_id)}) or {}
             manager.save_game_result(round_key, i, request.game_id, request.winner, summary.get("score"))
-            apply_stats_from_summary(summary, request.game_id, request.tournament_id)
+            stat_updater.apply_stats_from_summary(summary, request.game_id, request.tournament_id)
             user_result = {
                 "home_team": home_team,
                 "away_team": away_team,
@@ -317,7 +319,7 @@ def save_result(request: TournamentResultRequest):
             if ObjectId.is_valid(match["game_id"]):
                 summary = games_collection.find_one({"_id": ObjectId(match["game_id"])} ) or {}
             manager.save_game_result(round_key, i, match["game_id"], match["winner"], summary.get("score"))
-            apply_stats_from_summary(summary, match["game_id"], request.tournament_id)
+            stat_updater.apply_stats_from_summary(summary, match["game_id"], request.tournament_id)
             result_doc = {
                 "home_team": match["home_team"],
                 "away_team": match["away_team"],
@@ -334,7 +336,7 @@ def save_result(request: TournamentResultRequest):
             summary = summarize_game_state(game)
             insert_result = games_collection.insert_one(summary)
             game_id = insert_result.inserted_id
-            apply_stats_from_summary(summary, str(game_id), request.tournament_id)
+            stat_updater.apply_stats_from_summary(summary, str(game_id), request.tournament_id)
             print(f"✅ Game document inserted for round {round_num} match {i}")
         except Exception as e:
             print(
@@ -436,7 +438,7 @@ def sim_remaining(request: SimulateRequest):
                 )
                 if not exists:
                     summary = games_collection.find_one({"_id": ObjectId(match["game_id"])}) or {}
-                    apply_stats_from_summary(summary, match["game_id"], request.tournament_id)
+                    stat_updater.apply_stats_from_summary(summary, match["game_id"], request.tournament_id)
                     result_doc = {
                         "home_team": match["home_team"],
                         "away_team": match["away_team"],
@@ -451,7 +453,7 @@ def sim_remaining(request: SimulateRequest):
             game = run_simulation(match["home_team"], match["away_team"])
             summary = summarize_game_state(game)
             game_id = games_collection.insert_one(summary).inserted_id
-            apply_stats_from_summary(summary, str(game_id), request.tournament_id)
+            stat_updater.apply_stats_from_summary(summary, str(game_id), request.tournament_id)
             home = match["home_team"]
             away = match["away_team"]
             winner = home if summary["score"][home] > summary["score"][away] else away

--- a/BackEnd/tournament/tournament_manager.py
+++ b/BackEnd/tournament/tournament_manager.py
@@ -2,7 +2,11 @@ from datetime import datetime
 import random
 from bson import ObjectId
 
-from BackEnd.db import tournaments_collection as default_tournaments_collection
+from BackEnd.db import (
+    tournaments_collection as default_tournaments_collection,
+    players_collection,
+)
+from BackEnd.constants import BOX_SCORE_KEYS
 
 class TournamentManager:
     """Manage tournament creation and progression."""
@@ -31,6 +35,21 @@ class TournamentManager:
         seeds = {team_id: i + 1 for i, team_id in enumerate(teams)}
         round1 = self._generate_first_round(seeds)
 
+        zero_stats = {key: 0 for key in BOX_SCORE_KEYS}
+        player_stats: dict[str, dict] = {}
+        players = players_collection.find(
+            {"team": {"$in": teams}},
+            {"first_name": 1, "last_name": 1, "team": 1},
+        )
+        for p in players:
+            pid = str(p.get("_id"))
+            player_stats[pid] = {
+                "first_name": p.get("first_name", ""),
+                "last_name": p.get("last_name", ""),
+                "team": p.get("team", ""),
+                "season": zero_stats.copy(),
+            }
+
         tournament_doc = {
             "user_team_id": self.user_team_id,
             "created_at": datetime.utcnow(),
@@ -47,6 +66,8 @@ class TournamentManager:
                 "top_10_blocks": [],
                 "top_10_steals": []
             },
+            "player_stats": player_stats,
+            "applied_games": [],
             "completed": False
         }
         self.tournament_id = self.tournaments_collection.insert_one(tournament_doc).inserted_id

--- a/BackEnd/utils/stat_updater.py
+++ b/BackEnd/utils/stat_updater.py
@@ -70,13 +70,64 @@ def apply_stats_from_summary(summary: Dict[str, Any], game_id: str, tournament_i
                     "first_name": player_doc.get("first_name", ""),
                     "last_name": player_doc.get("last_name", ""),
                     "team": player_doc.get("team", ""),
-                    "stats": season_stats,
+                    "season": season_stats,
                 }
                 tournaments_collection.update_one(
                     {"_id": tid},
                     {"$set": {f"player_stats.{pid}": player_entry}},
                 )
 
+
+def finalize_game(game_id: str, *, mode: str | None = None, tournament_id: str | None = None) -> None:
+    """Persist finished game stats into a tournament document.
+
+    When ``mode`` is "tournament" and ``tournament_id`` is provided, the
+    function reads the stored game summary and increments each player's season
+    totals within the tournament document.  To ensure idempotency, a game is
+    applied only once per tournament via the ``applied_games`` array.
+    """
+    if mode != "tournament" or not tournament_id:
+        return
+
+    try:
+        tid = ObjectId(tournament_id)
+    except Exception:
+        return
+
+    tourney = tournaments_collection.find_one({"_id": tid}, {"applied_games": 1})
+    if not tourney or game_id in tourney.get("applied_games", []):
+        return
+
+    try:
+        gid = ObjectId(game_id)
+    except Exception:
+        return
+
+    game = games_collection.find_one({"_id": gid}) or {}
+    players = game.get("players", [])
+    box_score = game.get("box_score", {})
+    team_map = {"home": game.get("home_team"), "away": game.get("away_team")}
+
+    inc_doc: Dict[str, Any] = {}
+    for p in players:
+        pid = p.get("playerId")
+        team_side = p.get("team")
+        pos = p.get("pos")
+        team_name = team_map.get(team_side)
+        if not pid or not team_name:
+            continue
+        stat_block = box_score.get(team_name, {}).get(pos, p.get("stats", {}))
+        for stat, val in stat_block.items():
+            if stat == "name" or not isinstance(val, (int, float)):
+                continue
+            key = f"player_stats.{pid}.season.{stat}"
+            inc_doc[key] = inc_doc.get(key, 0) + val
+
+    update: Dict[str, Any] = {"$addToSet": {"applied_games": game_id}}
+    if inc_doc:
+        update["$inc"] = inc_doc
+
+    tournaments_collection.update_one({"_id": tid}, update)
 
 def update_game_stats(game_id: str | None, deltas: Dict[str, Any], score: Dict[str, Any]) -> None:
     """Apply per-turn stat deltas to the ongoing game's document."""

--- a/tests/test_tournament_leaders_endpoint.py
+++ b/tests/test_tournament_leaders_endpoint.py
@@ -28,7 +28,7 @@ def test_leaders_return_top_players_and_exclude_others():
                         "team": "A",
                         "first_name": "Ann",
                         "last_name": "Alpha",
-                        "stats": {
+                        "season": {
                             "PTS": 20,
                             "TPM": 5,
                             "TPA": 10,
@@ -43,7 +43,7 @@ def test_leaders_return_top_players_and_exclude_others():
                         "team": "B",
                         "first_name": "Bob",
                         "last_name": "Beta",
-                        "stats": {
+                        "season": {
                             "PTS": 15,
                             "TPM": 5,
                             "TPA": 8,
@@ -58,7 +58,7 @@ def test_leaders_return_top_players_and_exclude_others():
                         "team": "X",  # should be excluded
                         "first_name": "X",
                         "last_name": "Excluded",
-                        "stats": {
+                        "season": {
                             "PTS": 100,
                             "TPM": 20,
                             "TPA": 30,

--- a/tests/test_tournament_player_stats.py
+++ b/tests/test_tournament_player_stats.py
@@ -78,5 +78,5 @@ def test_apply_stats_saved_to_tournament():
     tourney = tournaments_collection.find_one({"_id": tid})
     assert tourney is not None
     pstats = tourney.get("player_stats", {})
-    assert pstats["p1"]["stats"]["PTS"] == 7
-    assert pstats["p2"]["stats"]["AST"] == 5
+    assert pstats["p1"]["season"]["PTS"] == 7
+    assert pstats["p2"]["season"]["AST"] == 5


### PR DESCRIPTION
## Summary
- Initialize tournament documents with zeroed player stats and applied-game tracking
- Move tournament leader lookups to use per-player season stats
- Add `finalize_game` to accumulate game results into tournament stats and integrate into simulation route

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cdd0bd55483288fb7a5a7b8a24e74