### PR TITLE
Track franchise player stats and unify finalizer

### DIFF
--- a/BackEnd/api/franchise_routes.py
+++ b/BackEnd/api/franchise_routes.py
@@ -8,6 +8,8 @@ import random
 from BackEnd.main import run_simulation
 
 from BackEnd.db import db, franchise_state_collection
+from BackEnd.utils.shared import summarize_game_state
+from BackEnd.utils import stat_updater
 from BackEnd.models.franchise_manager import FranchiseManager
 
 router = APIRouter()
@@ -244,6 +246,9 @@ def save_result(req: FranchiseResultRequest):
         },
         upsert=True,
     )
+    stat_updater.finalize_game(
+        req.game_id, mode="franchise", franchise_id=req.franchise_id
+    )
 
     return {"status": "success"}
 
@@ -304,6 +309,13 @@ def complete_week(req: CompleteWeekRequest):
             gm = run_simulation(home_name, away_name)
             away_score = gm.score.get(away_name, 0)
             home_score = gm.score.get(home_name, 0)
+            summary = summarize_game_state(gm)
+            token = f"{req.week}-{away_id}-{home_id}"
+            summary["_id"] = token
+            db.games.update_one({"_id": token}, {"$set": summary}, upsert=True)
+            stat_updater.finalize_game(
+                token, mode="franchise", franchise_id=req.franchise_id
+            )
         except Exception:
             away_score = random.randint(50, 90)
             home_score = random.randint(50, 90)

--- a/BackEnd/models/franchise_manager.py
+++ b/BackEnd/models/franchise_manager.py
@@ -8,7 +8,8 @@ import os
 
 from BackEnd.main import run_simulation
 from BackEnd.utils.shared import summarize_game_state
-from BackEnd.utils.stat_updater import apply_stats_from_summary
+from BackEnd.utils import stat_updater
+from BackEnd.constants import BOX_SCORE_KEYS
 
 
 logger = logging.getLogger(__name__)
@@ -82,7 +83,35 @@ class FranchiseManager:
         self.schedule = self.schedule_manager.generate_schedule()
         self.week = 1
         self.reset_stats()
-        self.save_season_state()
+
+        zero_stats = {k: 0 for k in BOX_SCORE_KEYS}
+        existing = {}
+        if self.franchise_id:
+            existing = (
+                self.db.franchises.find_one(
+                    {"_id": self.franchise_id}, {"player_stats": 1}
+                )
+                or {}
+            )
+        prev_stats = existing.get("player_stats", {})
+        player_stats: dict[str, dict] = {}
+        players = self.db.players.find(
+            {}, {"first_name": 1, "last_name": 1, "team": 1}
+        )
+        for p in players:
+            pid = str(p.get("_id"))
+            career = prev_stats.get(pid, {}).get("career", zero_stats.copy())
+            player_stats[pid] = {
+                "first_name": p.get("first_name", ""),
+                "last_name": p.get("last_name", ""),
+                "team": p.get("team", ""),
+                "season": zero_stats.copy(),
+                "career": career,
+            }
+
+        self.save_season_state(
+            extra_state={"player_stats": player_stats, "applied_games": []}
+        )
 
     def reset_stats(self):
         for team in self.teams:
@@ -118,6 +147,7 @@ class FranchiseManager:
         for team1_id, team2_id in games:
             self.simulate_game(team1_id, team2_id)
         self.week += 1
+
         self.save_season_state()
 
     def _apply_team_result(self, team1_id, team2_id, team1_score, team2_score, sign=1):
@@ -185,7 +215,18 @@ class FranchiseManager:
             team2_score = gm.score.get(home_name, 0)
             summary = summarize_game_state(gm)
             game_token = f"{self.week}-{team1_id}-{team2_id}"
-            apply_stats_from_summary(summary, game_token)
+            summary["_id"] = game_token
+            self.db.games.update_one(
+                {"_id": game_token}, {"$set": summary}, upsert=True
+            )
+            if self.franchise_id:
+                stat_updater.finalize_game(
+                    game_token,
+                    mode="franchise",
+                    franchise_id=str(self.franchise_id),
+                )
+            else:
+                stat_updater.apply_stats_from_summary(summary, game_token)
         except Exception:
             team1_score = random.randint(50, 90)
             team2_score = random.randint(50, 90)
@@ -208,13 +249,12 @@ class FranchiseManager:
     def generate_recruits(self):
         self.recruit_manager.generate_recruits()
 
-    def save_season_state(self):
+    def save_season_state(self, extra_state: dict | None = None):
         state = {"week": self.week, "schedule": self.schedule}
+        if extra_state:
+            state.update(extra_state)
         if self.franchise_id:
-            self.db.franchises.update_one(
-                {"_id": self.franchise_id},
-                {"$set": state}
-            )
+            self.db.franchises.update_one({"_id": self.franchise_id}, {"$set": state})
         else:
             result = self.db.franchises.insert_one(state)
             self.franchise_id = result.inserted_id

--- a/BackEnd/utils/stat_updater.py
+++ b/BackEnd/utils/stat_updater.py
@@ -2,7 +2,7 @@ from typing import Any, Dict
 
 from bson import ObjectId
 
-from BackEnd.db import players_collection, tournaments_collection, games_collection
+from BackEnd.db import db, players_collection, tournaments_collection, games_collection
 
 
 def apply_stats_from_summary(summary: Dict[str, Any], game_id: str, tournament_id: str | None = None) -> None:
@@ -78,56 +78,108 @@ def apply_stats_from_summary(summary: Dict[str, Any], game_id: str, tournament_i
                 )
 
 
-def finalize_game(game_id: str, *, mode: str | None = None, tournament_id: str | None = None) -> None:
-    """Persist finished game stats into a tournament document.
+def finalize_game(
+    game_id: str,
+    *,
+    mode: str | None = None,
+    tournament_id: str | None = None,
+    franchise_id: str | None = None,
+) -> None:
+    """Persist finished game stats into tournament or franchise documents."""
+    if mode == "tournament" and tournament_id:
+        try:
+            tid = ObjectId(tournament_id)
+        except Exception:
+            return
 
-    When ``mode`` is "tournament" and ``tournament_id`` is provided, the
-    function reads the stored game summary and increments each player's season
-    totals within the tournament document.  To ensure idempotency, a game is
-    applied only once per tournament via the ``applied_games`` array.
-    """
-    if mode != "tournament" or not tournament_id:
-        return
+        tourney = tournaments_collection.find_one({"_id": tid}, {"applied_games": 1})
+        if not tourney or game_id in tourney.get("applied_games", []):
+            return
 
-    try:
-        tid = ObjectId(tournament_id)
-    except Exception:
-        return
+        try:
+            gid = ObjectId(game_id)
+        except Exception:
+            return
 
-    tourney = tournaments_collection.find_one({"_id": tid}, {"applied_games": 1})
-    if not tourney or game_id in tourney.get("applied_games", []):
-        return
+        game = games_collection.find_one({"_id": gid}) or {}
+        players = game.get("players", [])
+        box_score = game.get("box_score", {})
+        team_map = {"home": game.get("home_team"), "away": game.get("away_team")}
 
-    try:
-        gid = ObjectId(game_id)
-    except Exception:
-        return
-
-    game = games_collection.find_one({"_id": gid}) or {}
-    players = game.get("players", [])
-    box_score = game.get("box_score", {})
-    team_map = {"home": game.get("home_team"), "away": game.get("away_team")}
-
-    inc_doc: Dict[str, Any] = {}
-    for p in players:
-        pid = p.get("playerId")
-        team_side = p.get("team")
-        pos = p.get("pos")
-        team_name = team_map.get(team_side)
-        if not pid or not team_name:
-            continue
-        stat_block = box_score.get(team_name, {}).get(pos, p.get("stats", {}))
-        for stat, val in stat_block.items():
-            if stat == "name" or not isinstance(val, (int, float)):
+        inc_doc: Dict[str, Any] = {}
+        for p in players:
+            pid = p.get("playerId")
+            team_side = p.get("team")
+            pos = p.get("pos")
+            team_name = team_map.get(team_side)
+            if not pid or not team_name:
                 continue
-            key = f"player_stats.{pid}.season.{stat}"
-            inc_doc[key] = inc_doc.get(key, 0) + val
+            stat_block = box_score.get(team_name, {}).get(pos, p.get("stats", {}))
+            for stat, val in stat_block.items():
+                if stat == "name" or not isinstance(val, (int, float)):
+                    continue
+                key = f"player_stats.{pid}.season.{stat}"
+                inc_doc[key] = inc_doc.get(key, 0) + val
 
-    update: Dict[str, Any] = {"$addToSet": {"applied_games": game_id}}
-    if inc_doc:
-        update["$inc"] = inc_doc
+        update: Dict[str, Any] = {"$addToSet": {"applied_games": game_id}}
+        if inc_doc:
+            update["$inc"] = inc_doc
 
-    tournaments_collection.update_one({"_id": tid}, update)
+        tournaments_collection.update_one({"_id": tid}, update)
+        return
+
+    if mode == "franchise" and franchise_id:
+        try:
+            fid = ObjectId(franchise_id)
+        except Exception:
+            return
+
+        franchise = db.franchises.find_one({"_id": fid}, {"applied_games": 1})
+        if not franchise or game_id in franchise.get("applied_games", []):
+            return
+
+        game = games_collection.find_one({"_id": game_id})
+        if not game and isinstance(game_id, str):
+            try:
+                game = games_collection.find_one({"_id": ObjectId(game_id)})
+            except Exception:
+                game = None
+        if not game:
+            return
+
+        apply_stats_from_summary(game, game_id)
+
+        players = game.get("players", [])
+        box_score = game.get("box_score", {})
+        team_map = {"home": game.get("home_team"), "away": game.get("away_team")}
+
+        inc_doc: Dict[str, Any] = {}
+        for p in players:
+            pid = p.get("playerId")
+            team_side = p.get("team")
+            pos = p.get("pos")
+            team_name = team_map.get(team_side)
+            if not pid or not team_name:
+                continue
+            stat_block = box_score.get(team_name, {}).get(pos, p.get("stats", {}))
+            for stat, val in stat_block.items():
+                if stat == "name" or not isinstance(val, (int, float)):
+                    continue
+                inc_doc[f"player_stats.{pid}.season.{stat}"] = inc_doc.get(
+                    f"player_stats.{pid}.season.{stat}", 0
+                ) + val
+                inc_doc[f"player_stats.{pid}.career.{stat}"] = inc_doc.get(
+                    f"player_stats.{pid}.career.{stat}", 0
+                ) + val
+
+        update: Dict[str, Any] = {"$addToSet": {"applied_games": game_id}}
+        if inc_doc:
+            update["$inc"] = inc_doc
+
+        db.franchises.update_one({"_id": fid}, update)
+        return
+
+    return
 
 def update_game_stats(game_id: str | None, deltas: Dict[str, Any], score: Dict[str, Any]) -> None:
     """Apply per-turn stat deltas to the ongoing game's document."""


### PR DESCRIPTION
## Summary
- initialize franchise seasons with per-player stat buckets and reset applied game tracking
- extend stat finalizer to update franchise player season/career totals and player docs
- call shared stat finalizer for saved results and auto-simulated games

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cdf4b0e0083288a3b85300f51c2aa