### PR TITLE
Avoid aggregates for scrimmage simulations

### DIFF
--- a/BackEnd/api/api.py
+++ b/BackEnd/api/api.py
@@ -17,6 +17,7 @@ from BackEnd.db import (
 from BackEnd.utils.roster_loader import load_roster
 from BackEnd.utils.game_summary_builder import build_game_summary
 from BackEnd.utils.shared import clean_mongo_ids, summarize_game_state, format_height
+from BackEnd.utils import stat_updater
 from pydantic import BaseModel
 from fastapi import HTTPException
 import pprint
@@ -213,6 +214,11 @@ def simulate_quarter_endpoint(request: QuarterSimulationRequest):
             "next_lineup_needed": not is_final,
         }
     )
+
+    if is_final and game_id:
+        # Scrimmage simulations should not generate aggregate stats.
+        # Finalizing with ``mode="scrimmage"`` is a no-op but documents intent.
+        stat_updater.finalize_game(game_id, mode="scrimmage")
 
     return summary
 

--- a/BackEnd/utils/stat_updater.py
+++ b/BackEnd/utils/stat_updater.py
@@ -85,7 +85,16 @@ def finalize_game(
     tournament_id: str | None = None,
     franchise_id: str | None = None,
 ) -> None:
-    """Persist finished game stats into tournament or franchise documents."""
+    """Persist finished game stats into aggregate documents for supported modes.
+
+    Scrimmage games (or calls with ``mode`` omitted) should not write any
+    aggregate data.  They rely solely on :func:`update_game_stats` for per-turn
+    box score updates.  Passing ``mode="scrimmage"`` therefore causes an early
+    return so future modes don't unintentionally create aggregates.
+    """
+    if mode in (None, "scrimmage"):
+        # Explicitly skip aggregation for scrimmages and unspecified modes.
+        return
     if mode == "tournament" and tournament_id:
         try:
             tid = ObjectId(tournament_id)


### PR DESCRIPTION
## Summary
- Skip aggregate stat updates for scrimmage games by early-returning in `finalize_game`
- Explicitly finalize scrimmage games with a no-op to document behavior

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ce29f93588328b165a9b772bb78c2