### PR TITLE
Unify stat aggregation paths

### DIFF
--- a/BackEnd/api/tournament_routes.py
+++ b/BackEnd/api/tournament_routes.py
@@ -295,7 +295,11 @@ def save_result(request: TournamentResultRequest):
             if ObjectId.is_valid(request.game_id):
                 summary = games_collection.find_one({"_id": ObjectId(request.game_id)}) or {}
             manager.save_game_result(round_key, i, request.game_id, request.winner, summary.get("score"))
-            stat_updater.apply_stats_from_summary(summary, request.game_id, request.tournament_id)
+            stat_updater.finalize_game(
+                request.game_id,
+                mode="tournament",
+                tournament_id=request.tournament_id,
+            )
             user_result = {
                 "home_team": home_team,
                 "away_team": away_team,
@@ -319,7 +323,11 @@ def save_result(request: TournamentResultRequest):
             if ObjectId.is_valid(match["game_id"]):
                 summary = games_collection.find_one({"_id": ObjectId(match["game_id"])} ) or {}
             manager.save_game_result(round_key, i, match["game_id"], match["winner"], summary.get("score"))
-            stat_updater.apply_stats_from_summary(summary, match["game_id"], request.tournament_id)
+            stat_updater.finalize_game(
+                match["game_id"],
+                mode="tournament",
+                tournament_id=request.tournament_id,
+            )
             result_doc = {
                 "home_team": match["home_team"],
                 "away_team": match["away_team"],
@@ -336,7 +344,11 @@ def save_result(request: TournamentResultRequest):
             summary = summarize_game_state(game)
             insert_result = games_collection.insert_one(summary)
             game_id = insert_result.inserted_id
-            stat_updater.apply_stats_from_summary(summary, str(game_id), request.tournament_id)
+            stat_updater.finalize_game(
+                str(game_id),
+                mode="tournament",
+                tournament_id=request.tournament_id,
+            )
             print(f"✅ Game document inserted for round {round_num} match {i}")
         except Exception as e:
             print(
@@ -438,7 +450,11 @@ def sim_remaining(request: SimulateRequest):
                 )
                 if not exists:
                     summary = games_collection.find_one({"_id": ObjectId(match["game_id"])}) or {}
-                    stat_updater.apply_stats_from_summary(summary, match["game_id"], request.tournament_id)
+                    stat_updater.finalize_game(
+                        match["game_id"],
+                        mode="tournament",
+                        tournament_id=request.tournament_id,
+                    )
                     result_doc = {
                         "home_team": match["home_team"],
                         "away_team": match["away_team"],
@@ -453,7 +469,11 @@ def sim_remaining(request: SimulateRequest):
             game = run_simulation(match["home_team"], match["away_team"])
             summary = summarize_game_state(game)
             game_id = games_collection.insert_one(summary).inserted_id
-            stat_updater.apply_stats_from_summary(summary, str(game_id), request.tournament_id)
+            stat_updater.finalize_game(
+                str(game_id),
+                mode="tournament",
+                tournament_id=request.tournament_id,
+            )
             home = match["home_team"]
             away = match["away_team"]
             winner = home if summary["score"][home] > summary["score"][away] else away

--- a/BackEnd/main.py
+++ b/BackEnd/main.py
@@ -107,8 +107,7 @@ def simulate_quarter(
         gm.away_team.lineup = build_lineup_from_mongo(gm.away_team.name)
 
     # Zero per-game stats exactly once per game before the opening tip.
-    if gm.quarter == 1:
-        _initialize_game_stats(gm, game_id)
+    _initialize_game_stats(gm, game_id)
 
     # Ensure the turn manager is aware of any lineup changes
     gm.turn_manager = TurnManager(gm)

--- a/BackEnd/utils/__init__.py
+++ b/BackEnd/utils/__init__.py
@@ -1,0 +1,9 @@
+"""Utility helpers for stats and other shared operations."""
+
+from .stat_updater import apply_stats_from_summary, finalize_game, update_game_stats
+
+__all__ = [
+    "apply_stats_from_summary",
+    "finalize_game",
+    "update_game_stats",
+]

--- a/BackEnd/utils/stat_updater.py
+++ b/BackEnd/utils/stat_updater.py
@@ -101,50 +101,28 @@ def finalize_game(
         except Exception:
             return
 
-        tourney = tournaments_collection.find_one({"_id": tid}, {"applied_games": 1})
-        if not tourney or game_id in tourney.get("applied_games", []):
+        result = tournaments_collection.update_one(
+            {"_id": tid, "applied_games": {"$ne": game_id}},
+            {"$addToSet": {"applied_games": game_id}},
+        )
+
+        if result.modified_count == 0:
             return
 
         try:
             gid = ObjectId(game_id)
         except Exception:
-            return
+            gid = game_id
 
         game = games_collection.find_one({"_id": gid}) or {}
-        players = game.get("players", [])
-        box_score = game.get("box_score", {})
-        team_map = {"home": game.get("home_team"), "away": game.get("away_team")}
+        apply_stats_from_summary(game, game_id, tournament_id)
 
-        inc_doc: Dict[str, Any] = {}
-        for p in players:
-            pid = p.get("playerId")
-            team_side = p.get("team")
-            pos = p.get("pos")
-            team_name = team_map.get(team_side)
-            if not pid or not team_name:
-                continue
-            stat_block = box_score.get(team_name, {}).get(pos, p.get("stats", {}))
-            for stat, val in stat_block.items():
-                if stat == "name" or not isinstance(val, (int, float)):
-                    continue
-                key = f"player_stats.{pid}.season.{stat}"
-                inc_doc[key] = inc_doc.get(key, 0) + val
-
-        update: Dict[str, Any] = {"$addToSet": {"applied_games": game_id}}
-        if inc_doc:
-            update["$inc"] = inc_doc
-
-        tournaments_collection.update_one({"_id": tid}, update)
         return
 
     if mode == "franchise" and franchise_id:
         try:
             fid = ObjectId(franchise_id)
         except Exception:
-            return
-
-        franchise = db.franchises.find_one({"_id": fid}, {"applied_games": 1})
-        if not franchise or game_id in franchise.get("applied_games", []):
             return
 
         game = games_collection.find_one({"_id": game_id})
@@ -155,8 +133,6 @@ def finalize_game(
                 game = None
         if not game:
             return
-
-        apply_stats_from_summary(game, game_id)
 
         players = game.get("players", [])
         box_score = game.get("box_score", {})
@@ -185,7 +161,15 @@ def finalize_game(
         if inc_doc:
             update["$inc"] = inc_doc
 
-        db.franchises.update_one({"_id": fid}, update)
+        result = db.franchises.update_one(
+            {"_id": fid, "applied_games": {"$ne": game_id}},
+            update,
+        )
+        if result.modified_count == 0:
+            return
+
+        apply_stats_from_summary(game, game_id)
+
         return
 
     return


### PR DESCRIPTION
## Summary
- track applied games on franchise and tournament docs and guard finalize_game updates
- initialize player stats once per game using `game_stats_initialized`
- route tournament stat updates through shared finalize_game helper

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cec06a49c83289ff5bedf7146b5b5