### PR TITLE
Separate final box score from live state

### DIFF
--- a/BackEnd/utils/shared.py
+++ b/BackEnd/utils/shared.py
@@ -391,10 +391,23 @@ def summarize_game_state(game):
         },
     }
 
+    final_box = game.get_box_score()
+    zero_box = {
+        team: {
+            pos: {
+                stat: (0 if isinstance(val, (int, float)) else val)
+                for stat, val in stats.items()
+            }
+            for pos, stats in team_stats.items()
+        }
+        for team, team_stats in final_box.items()
+    }
+
     return {
         "final_score": game.score,
         "points_by_quarter": game.game_state["points_by_quarter"],
-        "box_score": game.get_box_score(),
+        "box_score": zero_box,
+        "final_box_score": final_box,
         "scouting": {
             game.home_team.name: game.home_team.scouting_data,
             game.away_team.name: game.away_team.scouting_data,

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -165,6 +165,9 @@ export function createGameScene(Phaser) {
 
       const hydrateBoxScore = () => {
         const box = simData.box_score || {};
+        // Preserve the final box score separately for any consumers that
+        // need the completed stats (e.g. post-game summaries).
+        this.finalBoxScore = simData.final_box_score || {};
         ['home', 'away'].forEach(teamKey => {
           const teamName = teamKey === 'home' ? homeTeam : awayTeam;
           const teamBox = box[teamName] || {};


### PR DESCRIPTION
## Summary
- Zero out box score stats in `summarize_game_state` while preserving a `final_box_score`
- Store final box score on the client and hydrate lineups from zeroed stats

## Testing
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d239c69808328bb828eac63f81060