### PR TITLE
Guard player game stats from mid-game resets

### DIFF
--- a/BackEnd/main.py
+++ b/BackEnd/main.py
@@ -235,6 +235,9 @@ def run_simulation(home_team_name, away_team_name):
     gm.home_team.lineup = build_lineup_from_mongo(home_team_name)
     gm.away_team.lineup = build_lineup_from_mongo(away_team_name)
 
+    # Ensure player game stats are initialized only once
+    gm.initialize_player_stats()
+
     gm.turn_manager = TurnManager(gm)  # Rebuild now that lineups are present
 
     while True:

--- a/BackEnd/models/game_manager.py
+++ b/BackEnd/models/game_manager.py
@@ -16,11 +16,14 @@ class GameManager:
         self.quarter = 1
         self.turns = []
         self.text_log = []
-        
+
         self.offense_team = self.home_team #vary based on opening tip
         self.defense_team = self.away_team
 
         self.game_state = self._init_game_state()
+
+        # Flag to prevent mid-game reinitialization of player stats
+        self.game_state["game_stats_initialized"] = False
 
         self.turn_manager = TurnManager(self)
         self.shot_manager = ShotManager(self)
@@ -64,6 +67,18 @@ class GameManager:
             "last_rebound": None,
             "last_stealer": None
         }
+
+
+    def initialize_player_stats(self):
+        """Zero out player game stats once at game start."""
+        if self.game_state.get("game_stats_initialized"):
+            return
+
+        for team in [self.home_team, self.away_team]:
+            for player in team.lineup.values():
+                player.reset_stats()
+
+        self.game_state["game_stats_initialized"] = True
 
 
     def simulate_macro_turn(self): #run_simulation

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,6 +31,12 @@ class MockPlayer:
     def get_name(self):
         return self.name
 
+    def reset_stats(self):
+        self.stats["game"] = {}
+
+    def recharge_energy(self, amount):
+        pass
+
 
 def build_mock_game():
     home_team = "Lancaster"


### PR DESCRIPTION
## Summary
- prevent re-zeroing player game stats during quarter transitions by tracking `game_stats_initialized`
- initialize player stats once at game start via `initialize_player_stats`
- call initializer from `run_simulation` so play and sim paths share same logic

## Testing
- `PYTHONPATH=$PWD pytest`
- manual script verifying stats persist across quarters


------
https://chatgpt.com/codex/tasks/task_e_689dcfef29dc83289af91a8caa2008e6