### PR TITLE
Preserve player game stats across quarters

### DIFF
--- a/BackEnd/main.py
+++ b/BackEnd/main.py
@@ -99,12 +99,13 @@ def simulate_quarter(
     if home_lineup_ids:
         gm.home_team.lineup = assign_lineup_from_ids(gm.home_team, home_lineup_ids)
     elif not gm.home_team.lineup:
-        gm.home_team.lineup = build_lineup_from_mongo(gm.home_team.name)
+        # Reuse existing player objects so per-game stats persist mid-game.
+        gm.home_team.lineup = build_lineup_from_mongo(gm.home_team)
 
     if away_lineup_ids:
         gm.away_team.lineup = assign_lineup_from_ids(gm.away_team, away_lineup_ids)
     elif not gm.away_team.lineup:
-        gm.away_team.lineup = build_lineup_from_mongo(gm.away_team.name)
+        gm.away_team.lineup = build_lineup_from_mongo(gm.away_team)
 
     # Zero per-game stats exactly once per game before the opening tip.
     _initialize_game_stats(gm, game_id)

--- a/BackEnd/utils/db_utils.py
+++ b/BackEnd/utils/db_utils.py
@@ -1,6 +1,7 @@
 
 import random
-from typing import List, Dict
+from typing import List, Dict, Union
+
 from BackEnd.db import players_collection
 from BackEnd.models.player import Player
 from BackEnd.models.team_manager import TeamManager
@@ -20,9 +21,23 @@ def get_player_rating(player, traits: List[str]) -> float:
         total += player.attributes.get(trait, 0)
     return total / len(traits)
 
-def build_lineup_from_mongo(team_name: str) -> dict:
-    players_cursor = players_collection.find({"team": team_name})
-    players = [Player(p) for p in players_cursor]
+def build_lineup_from_mongo(team: Union[str, TeamManager]) -> Dict[str, Player]:
+    """Build a starting lineup using existing player objects when available.
+
+    ``team`` may be either a team name or an actual :class:`TeamManager`
+    instance.  When a ``TeamManager`` is supplied the players from its roster
+    are reused so their in-memory ``stats['game']`` containers are preserved.
+    Passing a string falls back to the original behaviour of constructing new
+    :class:`Player` objects from the database.
+    """
+
+    if isinstance(team, TeamManager):
+        team_name = team.name
+        players = list(team.get_all_players())
+    else:
+        team_name = team
+        players_cursor = players_collection.find({"team": team_name})
+        players = [Player(p) for p in players_cursor]
 
     if len(players) < 5:
         raise ValueError(f"Team '{team_name}' has fewer than 5 players.")

--- a/tests/test_overtime.py
+++ b/tests/test_overtime.py
@@ -1,7 +1,6 @@
 import BackEnd.main as main
 from BackEnd.models.game_manager import GameManager
 from BackEnd.models.player import Player
-from BackEnd.utils.roster_loader import load_roster
 
 
 def test_run_simulation_handles_overtime(monkeypatch):
@@ -22,10 +21,20 @@ def test_run_simulation_handles_overtime(monkeypatch):
             self.score[home] = 92
             self.home_team.points_by_quarter[4] = 2
 
-    def fake_build_lineup(team_name):
-        _, players = load_roster(team_name)
+    def fake_build_lineup(team):
+        name = team.name if hasattr(team, "name") else str(team)
         positions = ["PG", "SG", "SF", "PF", "C"]
-        return {pos: Player(p) for pos, p in zip(positions, players[:5])}
+        lineup = {}
+        for i, pos in enumerate(positions):
+            pdata = {
+                "_id": f"{name}_{i}",
+                "first_name": f"{name}{i}",
+                "last_name": pos,
+                "team": name,
+                "attributes": {},
+            }
+            lineup[pos] = Player(pdata)
+        return lineup
 
     monkeypatch.setattr(GameManager, "simulate_macro_turn", fake_simulate_macro_turn)
     monkeypatch.setattr(main, "build_lineup_from_mongo", fake_build_lineup)

--- a/tests/test_player_stat_persistence.py
+++ b/tests/test_player_stat_persistence.py
@@ -1,0 +1,48 @@
+import BackEnd.main as main
+from BackEnd.models.game_manager import GameManager
+
+
+def fake_turn_add_points(self):
+    pg = self.home_team.lineup["PG"]
+    pg.stats["game"]["PTS"] += 2
+    self.game_state["time_remaining"] = 0
+
+
+def fake_load_roster(team_name):
+    players = []
+    for i, pos in enumerate(["PG", "SG", "SF", "PF", "C"]):
+        players.append({
+            "_id": f"{team_name}_{i}",
+            "first_name": f"{team_name}{i}",
+            "last_name": pos,
+            "team": team_name,
+            "attributes": {"SC": 50, "SH": 50, "ID": 50, "OD": 50, "PS": 50, "BH": 50, "RB": 50, "AG": 50, "ST": 50, "ND": 50, "IQ": 50, "FT": 50, "NG": 1.0},
+        })
+    team_doc = {"name": team_name}
+    return team_doc, players
+
+
+def fake_build_lineup(team):
+    roster = list(team.players.values())
+    positions = ["PG", "SG", "SF", "PF", "C"]
+    return {pos: roster[i] for i, pos in enumerate(positions)}
+
+
+def test_player_stats_persist_across_quarters(monkeypatch):
+    monkeypatch.setattr("BackEnd.models.team_manager.load_roster", fake_load_roster)
+    monkeypatch.setattr(main, "build_lineup_from_mongo", fake_build_lineup)
+    monkeypatch.setattr(GameManager, "simulate_macro_turn", fake_turn_add_points)
+
+    gm = GameManager("Lancaster", "Bentley-Truman")
+
+    main.simulate_quarter(gm)
+    pg = gm.home_team.lineup["PG"]
+    assert pg.stats["game"]["PTS"] == 2
+
+    gm.home_team.lineup = {}
+
+    main.simulate_quarter(gm)
+    same_player = gm.home_team.players[pg.player_id]
+    assert same_player is pg
+    assert same_player.stats["game"]["PTS"] == 4
+

--- a/tests/test_simulate_quarter.py
+++ b/tests/test_simulate_quarter.py
@@ -1,7 +1,6 @@
 import BackEnd.main as main
 from BackEnd.models.game_manager import GameManager
 from BackEnd.models.player import Player
-from BackEnd.utils.roster_loader import load_roster
 
 
 def fake_simulate_macro_turn(self):
@@ -9,10 +8,25 @@ def fake_simulate_macro_turn(self):
     self.game_state["time_remaining"] = 0
 
 
-def fake_build_lineup(team_name):
-    _, players = load_roster(team_name)
+def fake_build_lineup(team):
+    """Return a simple deterministic lineup for tests.
+
+    Constructs new :class:`Player` objects each call without relying on any
+    database state, allowing the simulation to proceed with minimal data.
+    """
+    name = team.name if hasattr(team, "name") else str(team)
     positions = ["PG", "SG", "SF", "PF", "C"]
-    return {pos: Player(p) for pos, p in zip(positions, players[:5])}
+    lineup = {}
+    for i, pos in enumerate(positions):
+        pdata = {
+            "_id": f"{name}_{i}",
+            "first_name": f"{name}{i}",
+            "last_name": pos,
+            "team": name,
+            "attributes": {},
+        }
+        lineup[pos] = Player(pdata)
+    return lineup
 
 
 def test_simulate_quarter_advances_game(monkeypatch):


### PR DESCRIPTION
## Summary
- Avoid re-zeroing player stats by reusing existing player objects when building new lineups
- Use TeamManager-aware lineup builder in `simulate_quarter`
- Add regression test verifying player stat persistence through multiple quarters

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dd29c286483288b1721296a8824a6