### PR TITLE
Preserve per-game stats when resuming games

### DIFF
--- a/BackEnd/main.py
+++ b/BackEnd/main.py
@@ -47,6 +47,20 @@ def _initialize_game_stats(gm: GameManager, game_id: str | None = None) -> None:
     if gm.game_state.get("game_stats_initialized"):
         return
 
+    if game_id:
+        doc = games_collection.find_one({"_id": game_id})
+        if doc and doc.get("game_stats_initialized"):
+            stats_map = {
+                p.get("playerId"): p.get("stats", {}) for p in doc.get("players", [])
+            }
+            for team in (gm.home_team, gm.away_team):
+                for player in team.get_all_players():
+                    stats = stats_map.get(player.player_id)
+                    if stats:
+                        player.stats["game"].update(stats)
+            gm.game_state["game_stats_initialized"] = True
+            return
+
     affected: list[str] = []
     for team in (gm.home_team, gm.away_team):
         for player in team.get_all_players():

--- a/tests/test_resume_game_stats.py
+++ b/tests/test_resume_game_stats.py
@@ -1,0 +1,58 @@
+import BackEnd.main as main
+from BackEnd.models.game_manager import GameManager
+from BackEnd.models.team_manager import TeamManager
+from BackEnd.db import games_collection
+from BackEnd.constants import BOX_SCORE_KEYS
+
+
+def fake_load_roster(team_name):
+    players = []
+    for i, pos in enumerate(["PG", "SG", "SF", "PF", "C"]):
+        players.append({
+            "_id": f"{team_name}_{i}",
+            "first_name": team_name,
+            "last_name": pos,
+            "team": team_name,
+            "attributes": {"SC": 50, "SH": 50, "ID": 50, "OD": 50, "PS": 50, "BH": 50, "RB": 50, "AG": 50, "ST": 50, "ND": 50, "IQ": 50, "FT": 50, "NG": 1.0},
+        })
+    team_doc = {"name": team_name}
+    return team_doc, players
+
+
+def fake_build_lineup(team):
+    roster = list(team.players.values())
+    positions = ["PG", "SG", "SF", "PF", "C"]
+    return {pos: roster[i] for i, pos in enumerate(positions)}
+
+
+def no_turn(self):
+    self.game_state["time_remaining"] = 0
+
+
+def test_resume_game_skips_stat_reset(monkeypatch):
+    monkeypatch.setattr("BackEnd.models.team_manager.load_roster", fake_load_roster)
+    monkeypatch.setattr(main, "build_lineup_from_mongo", fake_build_lineup)
+    monkeypatch.setattr(GameManager, "simulate_macro_turn", no_turn)
+
+    game_id = "existing"
+    games_collection.insert_one({
+        "_id": game_id,
+        "game_stats_initialized": True,
+        "players": [
+            {
+                "playerId": "Lancaster_0",
+                "team": "home",
+                "team_id": None,
+                "pos": "PG",
+                "stats": {**{k: 0 for k in BOX_SCORE_KEYS}, "PTS": 5},
+            }
+        ],
+    })
+
+    gm = GameManager("Lancaster", "Bentley-Truman")
+
+    main.simulate_quarter(gm, game_id=game_id)
+
+    pg = gm.home_team.players["Lancaster_0"]
+    assert pg.stats["game"]["PTS"] == 5
+    assert gm.game_state.get("game_stats_initialized") is True


### PR DESCRIPTION
## Summary
- Avoid resetting player stats if a game document already marks stats initialized.
- Load existing per-game stats from the game document into active player objects.
- Test resuming a game to ensure stats persist across quarters.

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ddab67b5c8328b9535267e25b1330