### PR TITLE
Use cumulative box score for mid-game updates

### DIFF
--- a/BackEnd/utils/shared.py
+++ b/BackEnd/utils/shared.py
@@ -391,23 +391,13 @@ def summarize_game_state(game):
         },
     }
 
-    final_box = game.get_box_score()
-    zero_box = {
-        team: {
-            pos: {
-                stat: (0 if isinstance(val, (int, float)) else val)
-                for stat, val in stats.items()
-            }
-            for pos, stats in team_stats.items()
-        }
-        for team, team_stats in final_box.items()
-    }
+    cumulative_box = game.get_box_score()
 
     return {
         "final_score": game.score,
         "points_by_quarter": game.game_state["points_by_quarter"],
-        "box_score": zero_box,
-        "final_box_score": final_box,
+        "box_score": cumulative_box,
+        "final_box_score": cumulative_box,
         "scouting": {
             game.home_team.name: game.home_team.scouting_data,
             game.away_team.name: game.away_team.scouting_data,

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -164,10 +164,11 @@ export function createGameScene(Phaser) {
       };
 
       const hydrateBoxScore = () => {
-        const box = simData.box_score || {};
-        // Preserve the final box score separately for any consumers that
-        // need the completed stats (e.g. post-game summaries).
-        this.finalBoxScore = simData.final_box_score || {};
+        // Use the cumulative stats block so numbers persist between quarters.
+        const box = simData.final_box_score || simData.box_score || {};
+        // Preserve the final (cumulative) box score separately for any
+        // consumers that need the completed stats (e.g. post-game summaries).
+        this.finalBoxScore = box;
         ['home', 'away'].forEach(teamKey => {
           const teamName = teamKey === 'home' ? homeTeam : awayTeam;
           const teamBox = box[teamName] || {};


### PR DESCRIPTION
## Summary
- Return cumulative box score from `summarize_game_state` so mid-game summaries expose accumulated stats
- Hydrate game scene from the cumulative box score so stats persist between quarters

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ddcc2d6e08328b3c21cc8b8672cfd