### PR TITLE
Add position column to lineup screen

### DIFF
--- a/FrontEnd/static/set-lineup.css
+++ b/FrontEnd/static/set-lineup.css
@@ -73,6 +73,12 @@ body {
   overflow-x: auto;
 }
 
+.pos-note {
+  font-style: italic;
+  font-size: 0.9em;
+  margin-top: 4px;
+}
+
 .roster-table td.ht,
 .roster-table td.wt {
   font-size: 0.75em;

--- a/FrontEnd/static/set-lineup.html
+++ b/FrontEnd/static/set-lineup.html
@@ -28,6 +28,7 @@
       <thead>
         <tr>
           <th>Player Name</th>
+          <th>Pos</th>
           <th>HT</th>
           <th>WT</th>
           <th>SC</th>
@@ -48,6 +49,7 @@
       </thead>
       <tbody id="roster-body"></tbody>
     </table>
+    <p class="pos-note"><em>*Pos represents the player's highest rated position. Players can play any position.</em></p>
   </div>
 
   <div id="toast" hidden></div>

--- a/FrontEnd/static/set-lineup.js
+++ b/FrontEnd/static/set-lineup.js
@@ -44,9 +44,18 @@ function renderRoster() {
       e.dataTransfer.setData('text/plain', p._id);
     });
 
-    const rt = Math.max(...Object.values(p.position_ratings || {}));
+    const posRatings = p.position_ratings || {};
+    let bestPos = '--';
+    let rt = '--';
+    const entries = Object.entries(posRatings);
+    if (entries.length) {
+      const [pos, rating] = entries.reduce((a, b) => b[1] > a[1] ? b : a);
+      bestPos = pos;
+      rt = rating;
+    }
     const cells = [
       p.name,
+      bestPos,
       formatHeight(p.height),
       p.weight ?? '--',
       p.attributes.SC, p.attributes.SH, p.attributes.ID, p.attributes.OD,
@@ -54,7 +63,7 @@ function renderRoster() {
       p.attributes.AG, p.attributes.ND, p.attributes.IQ, p.attributes.FT,
       p.attributes.NG, rt
     ];
-    const classes = ['','ht','wt','','','','','','','','','','','','','', 'rt'];
+    const classes = ['', '', 'ht', 'wt', '', '', '', '', '', '', '', '', '', '', '', '', '', 'rt'];
     cells.forEach((val, idx) => {
       const td = document.createElement('td');
       td.textContent = val ?? '--';


### PR DESCRIPTION
## Summary
- show each player's top-rated position in the lineup table
- style and document the new Pos column with explanatory note

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ddd9df3288328927cf4bc4cec37cf