### PR TITLE
Capture baseline box score before each quarter

### DIFF
--- a/BackEnd/api/api.py
+++ b/BackEnd/api/api.py
@@ -173,6 +173,7 @@ def simulate_quarter_endpoint(request: QuarterSimulationRequest):
     # If the requested quarter has already been simulated, return the existing state
     if request.quarter < gm.quarter:
         summary = summarize_game_state(gm)
+        summary["start_box_score"] = gm.game_state.get("start_box_score")
         is_final = (
             gm.quarter > 4
             and summary["score"][gm.home_team.name] != summary["score"][gm.away_team.name]
@@ -202,6 +203,7 @@ def simulate_quarter_endpoint(request: QuarterSimulationRequest):
     )
 
     summary = summarize_game_state(gm)
+    summary["start_box_score"] = gm.game_state.get("start_box_score")
     is_final = (
         gm.quarter > 4
         and summary["score"][gm.home_team.name] != summary["score"][gm.away_team.name]

--- a/BackEnd/main.py
+++ b/BackEnd/main.py
@@ -123,6 +123,7 @@ def simulate_quarter(
 
     # Zero per-game stats exactly once per game before the opening tip.
     _initialize_game_stats(gm, game_id)
+    gm.game_state["start_box_score"] = gm.get_box_score()
 
     # Ensure the turn manager is aware of any lineup changes
     gm.turn_manager = TurnManager(gm)

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -164,11 +164,12 @@ export function createGameScene(Phaser) {
       };
 
       const hydrateBoxScore = () => {
-        // Use the cumulative stats block so numbers persist between quarters.
-        const box = simData.final_box_score || simData.box_score || {};
+        // Use the baseline stats captured at the start of the quarter so the
+        // table initially reflects pre-tip totals.
+        const box = simData.start_box_score || {};
         // Preserve the final (cumulative) box score separately for any
         // consumers that need the completed stats (e.g. post-game summaries).
-        this.finalBoxScore = box;
+        this.finalBoxScore = simData.final_box_score || simData.box_score || {};
         ['home', 'away'].forEach(teamKey => {
           const teamName = teamKey === 'home' ? homeTeam : awayTeam;
           const teamBox = box[teamName] || {};


### PR DESCRIPTION
## Summary
- snapshot box score at quarter start and attach to game state
- expose baseline box score in simulate-quarter API responses
- hydrate frontend box score from starting snapshot while preserving final totals

## Testing
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_689de77756548328a0b7bf958da304a4