### PR TITLE
Prompt users to play Q4 after sim-to-quarter flow

### DIFF
--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -267,7 +267,7 @@ async function handleSimToFourth() {
     });
     const qEl = document.getElementById('quarter');
     if (qEl) qEl.textContent = 'Q:4';
-    showStatus('Simulating Q1…Q2…Q3 complete. Ready for Q4.');
+    showStatus('Simulating Q1…Q2…Q3 complete. Ready for Q4. Press Play Quarter to proceed.');
   } catch (err) {
     console.error('Error simming to 4th quarter:', err);
     showStatus('Simulation failed. Please try again.');


### PR DESCRIPTION
## Summary
- append “Press Play Quarter to proceed.” after simming to the 4th quarter so users know to play the quarter

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ded92ecc88328b70958f985ac3a68