### PR TITLE
Ensure free throw results include shooter and points

### DIFF
--- a/BackEnd/engine/phase_resolution.py
+++ b/BackEnd/engine/phase_resolution.py
@@ -250,9 +250,12 @@ def resolve_free_throw_logic(game):
                 return {
                     "result_type": "FREE_THROW",
                     "ball_handler": shooter,
+                    "shooter": shooter,
                     "text": text,
                     "time_elapsed": 0,
-                    "possession_flips": False
+                    "possession_flips": False,
+                    "points": 1,
+                    "scoring_team": off_team.name
                 }
             else:
                 # Missed front end → dead ball, rebound
@@ -302,7 +305,9 @@ def resolve_free_throw_logic(game):
                     game_state["offensive_state"] = "FAST_BREAK"
             else:
                 # 🟡 Offensive rebound → putback loop
-                return resolve_offensive_rebound_loop(game, rebounder)
+                result = resolve_offensive_rebound_loop(game, rebounder)
+                result["shooter"] = shooter
+                return result
         else:
             possession_flips = True
 
@@ -310,6 +315,7 @@ def resolve_free_throw_logic(game):
     result = {
         "result_type": "FREE_THROW",
         "ball_handler": shooter,
+        "shooter": shooter,
         "text": text,
         "time_elapsed": 0,  # clock does not run
         "possession_flips": possession_flips,

--- a/tests/test_free_throw_logic.py
+++ b/tests/test_free_throw_logic.py
@@ -1,0 +1,45 @@
+from tests.test_utils import build_mock_game
+from BackEnd.engine.phase_resolution import resolve_free_throw_logic
+
+
+def _setup_game(one_and_one: bool):
+    game = build_mock_game()
+    shooter = game.offense_team.lineup["PG"]
+    game.game_state.update({
+        "offensive_state": "FREE_THROW",
+        "shooter": shooter,
+        "last_ball_handler": shooter,
+        "free_throws_remaining": 1,
+        "one_and_one": one_and_one,
+    })
+    # ensure every FT is made
+    game.offense_team.team_attributes["ft_shot_threshold"] = 0
+    return game, shooter
+
+
+def test_standard_free_throw_records_points_and_totals():
+    game, shooter = _setup_game(one_and_one=False)
+    result = resolve_free_throw_logic(game)
+
+    assert result["shooter"] is shooter
+    assert result["points"] == 1
+    assert result["scoring_team"] == game.offense_team.name
+    assert game.score[game.offense_team.name] == 1
+    assert shooter.stats["game"]["FTM"] == 1
+    assert shooter.stats["game"]["FTA"] == 1
+    assert shooter.stats["game"]["PTS"] == 1
+
+
+def test_one_and_one_front_end_records_points_and_totals():
+    game, shooter = _setup_game(one_and_one=True)
+    result = resolve_free_throw_logic(game)
+
+    assert result["shooter"] is shooter
+    assert result["points"] == 1
+    assert result["scoring_team"] == game.offense_team.name
+    assert game.score[game.offense_team.name] == 1
+    assert shooter.stats["game"]["FTM"] == 1
+    assert shooter.stats["game"]["FTA"] == 1
+    assert shooter.stats["game"]["PTS"] == 1
+    assert game.game_state["free_throws_remaining"] == 1
+    assert game.game_state["one_and_one"] is False


### PR DESCRIPTION
## Summary
- attach the shooting player to all free throw results
- always report one point on made free throws, including 1-and-1 situations
- cover standard and 1-and-1 free throws with dedicated tests

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689df4c37de88328a15403e45e5a64a7