### PR TITLE
Include scoring details in fast break shot results

### DIFF
--- a/BackEnd/models/shot_manager.py
+++ b/BackEnd/models/shot_manager.py
@@ -372,8 +372,8 @@ class ShotManager:
         time_elapsed = random.randint(5, 15)
 
         shooter_pos = get_player_position(off_lineup, shooter)
-        
-        return {
+
+        result = {
             "result_type": "MAKE" if made else "MISS",
             "ball_handler": shooter,
             "shooter": shooter,
@@ -385,6 +385,12 @@ class ShotManager:
             "possession_flips": possession_flips,
             "time_elapsed": time_elapsed
         }
+
+        if made:
+            result["points"] = points
+            result["scoring_team"] = off_team.name
+
+        return result
 
     def print_defense_score_stats(self):
         """Print defense score statistics for the game."""

--- a/tests/test_shot_manager.py
+++ b/tests/test_shot_manager.py
@@ -24,6 +24,7 @@ def test_resolve_shot_returns_make_or_miss():
 def test_resolve_fast_break_shot_works():
     game = build_mock_game()
     shot_manager = ShotManager(game)
+    game.offense_team.team_attributes["shot_threshold"] = 0
 
     fb_roles = {
         "shooter": game.offense_team.lineup["PG"],
@@ -35,6 +36,9 @@ def test_resolve_fast_break_shot_works():
     assert "result_type" in result
     VALID_RESULTS = {"MAKE", "MISS", "FOUL", "TURNOVER", "DEAD BALL"}
     assert result["result_type"] in VALID_RESULTS
+    assert result["result_type"] == "MAKE"
+    assert result["points"] == 2
+    assert result["scoring_team"] == game.offense_team.name
 
 
 def test_offensive_rebound_putback_updates_stats(monkeypatch):


### PR DESCRIPTION
## Summary
- Ensure fast break shot resolutions include `points` and `scoring_team` when the shot is made
- Test made fast break shots for correct scoring metadata

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e0f25da8883289f86293b26543f88