### PR TITLE
feat: add shot attempt animation

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -1,4 +1,11 @@
 import { generateBallTween } from "./generateBallTween.js";
+import { gridToPixels } from "../utils/gridToPixels.js";
+
+// Debug flag for logging shot details
+const SHOT_DEBUG = false;
+
+// Half-court rim location in grid coordinates
+const RIM_COORDS = { x: 94, y: 25 };
 
 export function lockBallToPlayer(scene, ballSprite, playerSprite) {
   if (!ballSprite || !playerSprite) {
@@ -48,6 +55,78 @@ export function passBall({
  */
 export function hideBall(ballSprite) {
   if (ballSprite) ballSprite.setVisible(false);
+}
+
+/**
+ * Launches a shot toward the rim with a simple two-part arc.
+ * Resolves after the ball reaches the rim.
+ */
+export function shootBall({
+  scene,
+  ballSprite,
+  fromCoords,
+  startTimestamp,
+  result,
+  shooterPos
+}) {
+  if (!scene || !ballSprite) return Promise.resolve();
+
+  const duration = 600; // fallback duration in ms
+  const start = gridToPixels(
+    fromCoords.x,
+    fromCoords.y,
+    scene.game.config.width,
+    scene.game.config.height
+  );
+  const rim = gridToPixels(
+    RIM_COORDS.x,
+    RIM_COORDS.y,
+    scene.game.config.width,
+    scene.game.config.height
+  );
+  const mid = {
+    x: (start.x + rim.x) / 2,
+    y: Math.min(start.y, rim.y) - 40
+  };
+
+  ballSprite.setPosition(start.x, start.y);
+  ballSprite.setVisible(true);
+
+  if (SHOT_DEBUG) {
+    const endTs = startTimestamp + duration;
+    const outcomeSource = result ? "explicit" : "inferred";
+    console.log(
+      `[shot] pos=${shooterPos} start=(${start.x},${start.y}) rim=(${rim.x},${rim.y}) ` +
+        `ts=${startTimestamp}->${endTs} outcome=${result || "UNKNOWN"} source=${outcomeSource}`
+    );
+  }
+
+  return new Promise((resolve) => {
+    scene.tweens.timeline({
+      tweens: [
+        {
+          targets: ballSprite,
+          x: mid.x,
+          y: mid.y,
+          duration: duration / 2,
+          ease: "Sine.easeOut"
+        },
+        {
+          targets: ballSprite,
+          x: rim.x,
+          y: rim.y,
+          duration: duration / 2,
+          ease: "Sine.easeIn",
+          onComplete: () => {
+            if (result === "MAKE") {
+              ballSprite.setVisible(false);
+            }
+            resolve();
+          }
+        }
+      ]
+    });
+  });
 }
 
 /**

--- a/FrontEnd/static/js/phaser/animation/playTurnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/playTurnAnimation.js
@@ -1,6 +1,6 @@
 import { animateStep } from "./animateStep.js";
 import { gridToPixels } from "../utils/gridToPixels.js";
-import { lockBallToPlayer } from "./ballManager.js";
+import { lockBallToPlayer, shootBall } from "./ballManager.js";
 
 /**
  * Centralized ball ownership logic
@@ -234,6 +234,7 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
     });
 
     const promises = [];
+    let shotInfo = null;
 
     for (const anim of turnData.animations) {
       if (scene.skipToEnd) break;
@@ -245,6 +246,10 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
       const prev = movement[stepIndex - 1];
       const curr = movement[stepIndex];
       const duration = (curr.timestamp - prev.timestamp) * 3;
+
+      if (curr.action === "shoot") {
+        shotInfo = { step: curr, playerId: anim.playerId };
+      }
 
       const promise = animateStep({
         scene,
@@ -259,5 +264,19 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
     }
 
     await Promise.all(promises);
+
+    if (shotInfo) {
+      currentBallOwnerRef.value = null;
+      const shooterPos = scene.playerInfo?.[shotInfo.playerId]?.pos;
+      await shootBall({
+        scene,
+        ballSprite,
+        fromCoords: shotInfo.step.coords,
+        startTimestamp: shotInfo.step.timestamp,
+        result: turnData.result_type,
+        shooterPos
+      });
+      break;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add rim shot tween with arc and make/miss handling
- detect shoot steps and launch ball flight during turn animation

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e359bad50832888e77ce38b42282b