### PR TITLE
Replace shot timeline with sequential tweens

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -102,16 +102,14 @@ export function shootBall({
   }
 
   return new Promise((resolve) => {
-    scene.tweens.timeline({
-      tweens: [
-        {
-          targets: ballSprite,
-          x: mid.x,
-          y: mid.y,
-          duration: duration / 2,
-          ease: "Sine.easeOut"
-        },
-        {
+    scene.tweens.add({
+      targets: ballSprite,
+      x: mid.x,
+      y: mid.y,
+      duration: duration / 2,
+      ease: "Sine.easeOut",
+      onComplete: () => {
+        scene.tweens.add({
           targets: ballSprite,
           x: rim.x,
           y: rim.y,
@@ -123,8 +121,8 @@ export function shootBall({
             }
             resolve();
           }
-        }
-      ]
+        });
+      }
     });
   });
 }


### PR DESCRIPTION
## Summary
- refactor shootBall to use sequential tweens instead of a timeline

## Testing
- `PYTHONPATH=. pytest`
- `node --experimental-modules -e "import('./FrontEnd/static/js/phaser/animation/ballManager.js').then(async ({shootBall}) => {const scene={game:{config:{width:800,height:600}},tweens:{add(c){setTimeout(()=>c.onComplete&&c.onComplete(),0);},killTweensOf(){}}}; const ballSprite={visible:false,setPosition(){},setVisible(v){this.visible=v;}}; await shootBall({scene, ballSprite, fromCoords:{x:10,y:20}, startTimestamp:0, result:'MAKE', shooterPos:'SG'}); console.log('resolved', ballSprite.visible);}); setTimeout(()=>{},100);"`

------
https://chatgpt.com/codex/tasks/task_e_689e41f202448328934541f75d6fa22e