### PR TITLE
Allow targeting home or away hoop

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -4,8 +4,9 @@ import { gridToPixels } from "../utils/gridToPixels.js";
 // Debug flag for logging shot details
 const SHOT_DEBUG = false;
 
-// Half-court rim location in grid coordinates
-const RIM_COORDS = { x: 94, y: 25 };
+// Hoop locations in grid coordinates for each team
+const HOME_RIM_COORDS = { x: 94, y: 25 };
+const AWAY_RIM_COORDS = { x: 6, y: 25 };
 
 export function lockBallToPlayer(scene, ballSprite, playerSprite) {
   if (!ballSprite || !playerSprite) {
@@ -67,7 +68,8 @@ export function shootBall({
   fromCoords,
   startTimestamp,
   result,
-  shooterPos
+  shooterPos,
+  isHomeTeam
 }) {
   if (!scene || !ballSprite) return Promise.resolve();
 
@@ -78,9 +80,10 @@ export function shootBall({
     scene.game.config.width,
     scene.game.config.height
   );
+  const rimCoords = isHomeTeam ? HOME_RIM_COORDS : AWAY_RIM_COORDS;
   const rim = gridToPixels(
-    RIM_COORDS.x,
-    RIM_COORDS.y,
+    rimCoords.x,
+    rimCoords.y,
     scene.game.config.width,
     scene.game.config.height
   );

--- a/FrontEnd/static/js/phaser/animation/playTurnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/playTurnAnimation.js
@@ -274,7 +274,8 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
         fromCoords: shotInfo.step.coords,
         startTimestamp: shotInfo.step.timestamp,
         result: turnData.result_type,
-        shooterPos
+        shooterPos,
+        isHomeTeam: turnData.possession_team_id === simData.home_team_id
       });
       break;
     }


### PR DESCRIPTION
## Summary
- Allow `shootBall` to target home or away hoops
- Pass possession team flag from `playTurnAnimation` to select hoop

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e5f9319b483289e6ff7a761620a81