### PR TITLE
Add bounce and delayed hide for shot results

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -120,9 +120,36 @@ export function shootBall({
           ease: "Sine.easeIn",
           onComplete: () => {
             if (result === "MAKE") {
-              ballSprite.setVisible(false);
+              // Slight pause before hiding to trigger existing make flow
+              scene.time.delayedCall(250, () => {
+                ballSprite.setVisible(false);
+                resolve();
+              });
+            } else if (result === "MISS") {
+              // Bounce the ball off the rim
+              const bounceGridX = isHomeTeam
+                ? rimCoords.x - 6
+                : rimCoords.x + 6;
+              const bounceGridY =
+                rimCoords.y + Phaser.Math.Between(-6, 6);
+              const bounce = gridToPixels(
+                bounceGridX,
+                bounceGridY,
+                scene.game.config.width,
+                scene.game.config.height
+              );
+
+              scene.tweens.add({
+                targets: ballSprite,
+                x: bounce.x,
+                y: bounce.y,
+                duration: duration / 3,
+                ease: "Sine.easeOut",
+                onComplete: resolve
+              });
+            } else {
+              resolve();
             }
-            resolve();
           }
         });
       }


### PR DESCRIPTION
## Summary
- Branch on shot result in `shootBall`
- Delay 250ms before hiding ball on makes to trigger make flow
- Animate rim bounce for misses with randomized offset

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e617d48ac8328ab13ae06c1c081bb