### PR TITLE
Ensure ball locks to initial owner in playTurnAnimation

### DIFF
--- a/FrontEnd/static/js/phaser/animation/playTurnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/playTurnAnimation.js
@@ -184,7 +184,7 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
   }
 
   if (step0OwnerSprite) {
-    lockBallToPlayer(ballSprite, step0OwnerSprite);
+    lockBallToPlayer(scene, ballSprite, step0OwnerSprite);
     currentBallOwnerRef.value = step0OwnerSprite;
   }
 


### PR DESCRIPTION
## Summary
- pass the scene to `lockBallToPlayer` so the ball snaps to the initial owner when a turn begins

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e655bde08832889275ec40c7ceb64