### PR TITLE
Ensure shooter step includes shoot action

### DIFF
--- a/BackEnd/models/turn_manager.py
+++ b/BackEnd/models/turn_manager.py
@@ -232,11 +232,13 @@ class TurnManager:
         # --- Step 1: Pick scene and step count
         scene = random.choice(INSIDE_SCENES)
         tempo_to_steps = {"slow": 7, "normal": 5, "fast": 4}
-        max_steps = min(
-            len(scene["steps"]),
-            tempo_to_steps.get(tempo_call.lower(), len(scene["steps"]))
-        )
-        steps = scene["steps"][:max_steps]
+        requested = tempo_to_steps.get(tempo_call.lower(), len(scene["steps"]))
+
+        # Always include the final shot step
+        if requested >= len(scene["steps"]):
+            steps = scene["steps"]
+        else:
+            steps = scene["steps"][:requested - 1] + [scene["steps"][-1]]
 
         # --- Step 2: Initialize outputs
         action_timeline = defaultdict(list)


### PR DESCRIPTION
## Summary
- Always append the final shot step during role assignment so the shooter's action is "shoot"

## Testing
- `PYTHONPATH=$PWD pytest`
- `node - <<'NODE'...>` (verify shootBall executes)


------
https://chatgpt.com/codex/tasks/task_e_689e662fd3bc8328841181e35de6cfce