### PR TITLE
Scale shot animation duration by distance

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -72,8 +72,6 @@ export function shootBall({
   isHomeTeam
 }) {
   if (!scene || !ballSprite) return Promise.resolve();
-
-  const duration = 600; // fallback duration in ms
   const start = gridToPixels(
     fromCoords.x,
     fromCoords.y,
@@ -91,6 +89,11 @@ export function shootBall({
     x: (start.x + rim.x) / 2,
     y: Math.min(start.y, rim.y) - 40
   };
+
+  // Scale the flight duration based on shot distance for more natural pacing
+  const baseDuration = 1000; // minimum duration in ms
+  const shotDistance = Phaser.Math.Distance.Between(start.x, start.y, rim.x, rim.y);
+  const duration = Math.max(baseDuration, shotDistance * 5); // 5ms per pixel
 
   ballSprite.setPosition(start.x, start.y);
   ballSprite.setVisible(true);


### PR DESCRIPTION
## Summary
- Ensure shot animations last at least 1000ms
- Scale shot travel time with distance for more natural pacing

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e68144db08328a8a907c92d09585d