### PR TITLE
Import Phaser in ball manager

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -1,3 +1,4 @@
+import Phaser from "phaser";
 import { generateBallTween } from "./generateBallTween.js";
 import { gridToPixels } from "../utils/gridToPixels.js";
 


### PR DESCRIPTION
## Summary
- import Phaser in ballManager to ensure Phaser.Math methods are available

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e6b1035d88328a5cdb64eab181afb