### PR TITLE
Fix rim direction for possession animation

### DIFF
--- a/FrontEnd/static/js/phaser/animation/playTurnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/playTurnAnimation.js
@@ -275,7 +275,7 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
         startTimestamp: shotInfo.step.timestamp,
         result: turnData.result_type,
         shooterPos,
-        isHomeTeam: turnData.possession_team_id === simData.home_team_id
+        isHomeTeam: turnData.starting_possession_team_id === simData.home_team_id
       });
       break;
     }

--- a/tests/js/ballManagerStub.mjs
+++ b/tests/js/ballManagerStub.mjs
@@ -1,0 +1,3 @@
+export function lockBallToPlayer() {}
+export const calls = [];
+export function shootBall(opts) { calls.push(opts); return Promise.resolve(); }

--- a/tests/js/httpsLoader.mjs
+++ b/tests/js/httpsLoader.mjs
@@ -1,0 +1,23 @@
+import { pathToFileURL } from 'url';
+const stubBallManagerURL = pathToFileURL('./tests/js/ballManagerStub.mjs').href;
+
+export async function resolve(specifier, context, defaultResolve) {
+  if (specifier.startsWith('https://')) {
+    return { url: specifier, format: 'module', shortCircuit: true };
+  }
+  if (specifier.endsWith('ballManager.js')) {
+    return { url: stubBallManagerURL, format: 'module', shortCircuit: true };
+  }
+  return defaultResolve(specifier, context, defaultResolve);
+}
+
+export async function load(url, context, defaultLoad) {
+  if (url.startsWith('https://')) {
+    return {
+      format: 'module',
+      source: 'export const Math = { Distance: { Between: (x1,y1,x2,y2) => globalThis.Math.hypot(x2 - x1, y2 - y1) }, Between: (min,max) => min };',
+      shortCircuit: true
+    };
+  }
+  return defaultLoad(url, context, defaultLoad);
+}

--- a/tests/js/httpsLoaderNoStubBall.mjs
+++ b/tests/js/httpsLoaderNoStubBall.mjs
@@ -1,0 +1,17 @@
+export async function resolve(specifier, context, defaultResolve) {
+  if (specifier.startsWith('https://')) {
+    return { url: specifier, format: 'module', shortCircuit: true };
+  }
+  return defaultResolve(specifier, context, defaultResolve);
+}
+
+export async function load(url, context, defaultLoad) {
+  if (url.startsWith('https://')) {
+    return {
+      format: 'module',
+      source: 'export const Math = { Distance: { Between: (x1,y1,x2,y2) => globalThis.Math.hypot(x2 - x1, y2 - y1) }, Between: (min,max) => min };',
+      shortCircuit: true
+    };
+  }
+  return defaultLoad(url, context, defaultLoad);
+}

--- a/tests/js/runPlayTurnAnimation.mjs
+++ b/tests/js/runPlayTurnAnimation.mjs
@@ -1,0 +1,50 @@
+import { playTurnAnimation } from '../../FrontEnd/static/js/phaser/animation/playTurnAnimation.js';
+import { calls } from './ballManagerStub.mjs';
+
+function createScene() {
+  return {
+    skipToEnd: false,
+    tweens: {
+      add: ({ onUpdate, onComplete, onStop }) => {
+        if (onUpdate) onUpdate();
+        if (onComplete) onComplete();
+        return { stop: () => { if (onStop) onStop(); } };
+      },
+      killTweensOf: () => {}
+    },
+    game: { config: { width: 100, height: 50 } },
+    playerInfo: {},
+    time: { delayedCall: (ms, fn) => fn() }
+  };
+}
+
+function createSprite(team_id) {
+  return { x: 0, y: 0, team_id, setPosition() {}, setVisible() {} };
+}
+
+async function runCase(startingTeamId) {
+  calls.length = 0;
+  const scene = createScene();
+  const ballSprite = { setPosition() {}, setVisible() {} };
+  const playerSprites = { p1: createSprite(startingTeamId) };
+  const turnData = {
+    starting_possession_team_id: startingTeamId,
+    possession_team_id: startingTeamId,
+    result_type: 'MAKE',
+    animations: [{
+      playerId: 'p1',
+      movement: [
+        { timestamp: 0, coords: { x: 0, y: 0 }, action: 'handle_ball' },
+        { timestamp: 10, coords: { x: 0, y: 0 }, action: 'shoot' }
+      ],
+      hasBallAtStep: [true, true]
+    }]
+  };
+  const simData = { home_team_id: 'HOME' };
+  await playTurnAnimation({ scene, simData, playerSprites, turnData, ballSprite });
+  return calls[0].isHomeTeam;
+}
+
+const homeResult = await runCase('HOME');
+const awayResult = await runCase('AWAY');
+console.log(JSON.stringify({ homeResult, awayResult }));

--- a/tests/js/runShootBall.mjs
+++ b/tests/js/runShootBall.mjs
@@ -1,0 +1,39 @@
+import { shootBall } from '../../FrontEnd/static/js/phaser/animation/ballManager.js';
+
+function createScene() {
+  const tweens = [];
+  const scene = {
+    tweens: {
+      add: (cfg) => {
+        tweens.push(cfg);
+        cfg.onComplete && cfg.onComplete();
+        return {};
+      },
+      killTweensOf: () => {}
+    },
+    time: { delayedCall: (ms, fn) => fn() },
+    game: { config: { width: 100, height: 50 } }
+  };
+  scene._tweens = tweens;
+  return scene;
+}
+
+async function run(isHomeTeam) {
+  const scene = createScene();
+  const ballSprite = { setPosition() {}, setVisible() {} };
+  await shootBall({
+    scene,
+    ballSprite,
+    fromCoords: { x: 0, y: 0 },
+    startTimestamp: 0,
+    result: 'MAKE',
+    shooterPos: 'PG',
+    isHomeTeam
+  });
+  const last = scene._tweens[scene._tweens.length - 1];
+  return { x: last.x, y: last.y };
+}
+
+const home = await run(true);
+const away = await run(false);
+console.log(JSON.stringify({ home, away }));

--- a/tests/test_frontend_rim_animation.py
+++ b/tests/test_frontend_rim_animation.py
@@ -1,0 +1,23 @@
+import json
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def run_node(loader, script):
+    cmd = ["node", "--loader", str(ROOT / loader), str(ROOT / script)]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return json.loads(completed.stdout.strip().splitlines()[-1])
+
+
+def test_play_turn_animation_passes_starting_team():
+    result = run_node("tests/js/httpsLoader.mjs", "tests/js/runPlayTurnAnimation.mjs")
+    assert result["homeResult"] is True
+    assert result["awayResult"] is False
+
+
+def test_shoot_ball_rim_selection():
+    result = run_node("tests/js/httpsLoaderNoStubBall.mjs", "tests/js/runShootBall.mjs")
+    assert result["home"] == {"x": 94, "y": 25}
+    assert result["away"] == {"x": 6, "y": 25}


### PR DESCRIPTION
## Summary
- Ensure shot animations use `starting_possession_team_id` to determine home side
- Add tests verifying rim selection for home and away possessions

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e724f60d48328a0a8e8eea78f4cc8