### PR TITLE
Refine shot animation rim targets

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -6,8 +6,8 @@ import { gridToPixels } from "../utils/gridToPixels.js";
 const SHOT_DEBUG = false;
 
 // Hoop locations in grid coordinates for each team
-const HOME_RIM_COORDS = { x: 94, y: 25 };
-const AWAY_RIM_COORDS = { x: 6, y: 25 };
+const HOME_RIM_COORDS = { x: 91, y: 25 };
+const AWAY_RIM_COORDS = { x: 9, y: 25 };
 
 export function lockBallToPlayer(scene, ballSprite, playerSprite) {
   if (!ballSprite || !playerSprite) {

--- a/tests/test_frontend_rim_animation.py
+++ b/tests/test_frontend_rim_animation.py
@@ -19,5 +19,5 @@ def test_play_turn_animation_passes_starting_team():
 
 def test_shoot_ball_rim_selection():
     result = run_node("tests/js/httpsLoaderNoStubBall.mjs", "tests/js/runShootBall.mjs")
-    assert result["home"] == {"x": 94, "y": 25}
-    assert result["away"] == {"x": 6, "y": 25}
+    assert result["home"] == {"x": 91, "y": 25}
+    assert result["away"] == {"x": 9, "y": 25}


### PR DESCRIPTION
## Summary
- tweak rim x-coordinates so home shots aim 3px left and away shots 3px right for better alignment
- update rim animation test expectations

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e751f16bc8328b1314f7f98eb9c92