### PR TITLE
Cap step duration to prevent pre-shot animation stalls

### DIFF
--- a/FrontEnd/static/js/phaser/animation/playTurnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/playTurnAnimation.js
@@ -2,6 +2,10 @@ import { animateStep } from "./animateStep.js";
 import { gridToPixels } from "../utils/gridToPixels.js";
 import { lockBallToPlayer, shootBall } from "./ballManager.js";
 
+// Cap the time spent on any single movement step. Large timestamp gaps can
+// otherwise produce multi‑second tweens that appear as animation stalls.
+const MAX_STEP_DURATION = 1000; // ms
+
 /**
  * Centralized ball ownership logic
  * Assigns the ball to the correct player for the current stepIndex
@@ -245,7 +249,8 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
 
       const prev = movement[stepIndex - 1];
       const curr = movement[stepIndex];
-      const duration = (curr.timestamp - prev.timestamp) * 3;
+      const rawDuration = (curr.timestamp - prev.timestamp) * 3;
+      const duration = Math.min(MAX_STEP_DURATION, rawDuration);
 
       if (curr.action === "shoot") {
         shotInfo = { step: curr, playerId: anim.playerId };


### PR DESCRIPTION
## Summary
- prevent long pauses before shot animations by capping step tween duration

## Testing
- `PYTHONPATH=. pytest`
- ⚠️ `node tests/js/runPlayTurnAnimation.mjs` (fails: ERR_UNSUPPORTED_ESM_URL_SCHEME)


------
https://chatgpt.com/codex/tasks/task_e_689e75bb65fc8328921a5d7754ae38a4