### PR TITLE
Use shooter team for home/away detection in shoot animation

### DIFF
--- a/FrontEnd/static/js/phaser/animation/playTurnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/playTurnAnimation.js
@@ -273,6 +273,8 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
     if (shotInfo) {
       currentBallOwnerRef.value = null;
       const shooterPos = scene.playerInfo?.[shotInfo.playerId]?.pos;
+      const shooterTeamId = playerSprites[shotInfo.playerId]?.team_id;
+      const isHomeTeam = shooterTeamId === simData.home_team_id;
       await shootBall({
         scene,
         ballSprite,
@@ -280,7 +282,7 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
         startTimestamp: shotInfo.step.timestamp,
         result: turnData.result_type,
         shooterPos,
-        isHomeTeam: turnData.starting_possession_team_id === simData.home_team_id
+        isHomeTeam
       });
       break;
     }


### PR DESCRIPTION
## Summary
- Determine home team for shot animations using the shooter's team instead of starting possession

## Testing
- ❌ `npm test` *(package.json missing)*
- ❌ `pytest` *(ModuleNotFoundError: No module named 'BackEnd')*

------
https://chatgpt.com/codex/tasks/task_e_689e87c0c6ac832891016ac87911ae63