### PR TITLE
feat: expand shot debug logging

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -3,7 +3,7 @@ import { generateBallTween } from "./generateBallTween.js";
 import { gridToPixels } from "../utils/gridToPixels.js";
 
 // Debug flag for logging shot details
-const SHOT_DEBUG = false;
+export const SHOT_DEBUG = false;
 
 // Hoop locations in grid coordinates for each team
 const HOME_RIM_COORDS = { x: 91, y: 25 };
@@ -70,9 +70,16 @@ export function shootBall({
   startTimestamp,
   result,
   shooterPos,
-  isHomeTeam
+  shooterId,
+  shooterTeamId,
+  homeTeamId,
+  stepIndex,
+  turnIndex
 }) {
   if (!scene || !ballSprite) return Promise.resolve();
+
+  const isHomeTeam = shooterTeamId === homeTeamId;
+
   const start = gridToPixels(
     fromCoords.x,
     fromCoords.y,
@@ -99,7 +106,11 @@ export function shootBall({
     const endTs = startTimestamp + duration;
     const outcomeSource = result ? "explicit" : "inferred";
     console.log(
-      `[shot] pos=${shooterPos} start=(${start.x},${start.y}) rim=(${rim.x},${rim.y}) ` +
+      `[shot] shooter=${shooterId} team=${shooterTeamId} ` +
+        `(matches home? ${isHomeTeam}) ` +
+        `pos=${shooterPos} start=(${start.x},${start.y}) ` +
+        `rim=(${rim.x},${rim.y}) ` +
+        `step=${stepIndex ?? "?"} turn=${turnIndex ?? "?"} ` +
         `ts=${startTimestamp}->${endTs} outcome=${result || "UNKNOWN"} source=${outcomeSource}`
     );
   }

--- a/FrontEnd/static/js/phaser/animation/playTurnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/playTurnAnimation.js
@@ -1,6 +1,6 @@
 import { animateStep } from "./animateStep.js";
 import { gridToPixels } from "../utils/gridToPixels.js";
-import { lockBallToPlayer, shootBall } from "./ballManager.js";
+import { lockBallToPlayer, shootBall, SHOT_DEBUG } from "./ballManager.js";
 
 // Cap the time spent on any single movement step. Large timestamp gaps can
 // otherwise produce multi‑second tweens that appear as animation stalls.
@@ -253,7 +253,7 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
       const duration = Math.min(MAX_STEP_DURATION, rawDuration);
 
       if (curr.action === "shoot") {
-        shotInfo = { step: curr, playerId: anim.playerId };
+        shotInfo = { step: curr, playerId: anim.playerId, stepIndex };
       }
 
       const promise = animateStep({
@@ -274,16 +274,22 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
       currentBallOwnerRef.value = null;
       const shooterPos = scene.playerInfo?.[shotInfo.playerId]?.pos;
       const shooterTeamId = playerSprites[shotInfo.playerId]?.team_id;
-      const isHomeTeam = shooterTeamId === simData.home_team_id;
-      await shootBall({
+      const shootParams = {
         scene,
         ballSprite,
         fromCoords: shotInfo.step.coords,
         startTimestamp: shotInfo.step.timestamp,
         result: turnData.result_type,
         shooterPos,
-        isHomeTeam
-      });
+        shooterId: shotInfo.playerId,
+        shooterTeamId,
+        homeTeamId: simData.home_team_id
+      };
+      if (SHOT_DEBUG) {
+        shootParams.stepIndex = shotInfo.stepIndex;
+        shootParams.turnIndex = scene.currentTurn;
+      }
+      await shootBall(shootParams);
       break;
     }
   }

--- a/tests/js/ballManagerStub.mjs
+++ b/tests/js/ballManagerStub.mjs
@@ -1,3 +1,4 @@
 export function lockBallToPlayer() {}
 export const calls = [];
+export const SHOT_DEBUG = false;
 export function shootBall(opts) { calls.push(opts); return Promise.resolve(); }

--- a/tests/js/runPlayTurnAnimation.mjs
+++ b/tests/js/runPlayTurnAnimation.mjs
@@ -42,7 +42,7 @@ async function runCase(startingTeamId) {
   };
   const simData = { home_team_id: 'HOME' };
   await playTurnAnimation({ scene, simData, playerSprites, turnData, ballSprite });
-  return calls[0].isHomeTeam;
+  return calls[0].shooterTeamId === calls[0].homeTeamId;
 }
 
 const homeResult = await runCase('HOME');

--- a/tests/js/runShootBall.mjs
+++ b/tests/js/runShootBall.mjs
@@ -21,6 +21,7 @@ function createScene() {
 async function run(isHomeTeam) {
   const scene = createScene();
   const ballSprite = { setPosition() {}, setVisible() {} };
+  const shooterTeamId = isHomeTeam ? 1 : 2;
   await shootBall({
     scene,
     ballSprite,
@@ -28,7 +29,9 @@ async function run(isHomeTeam) {
     startTimestamp: 0,
     result: 'MAKE',
     shooterPos: 'PG',
-    isHomeTeam
+    shooterId: 1,
+    shooterTeamId,
+    homeTeamId: 1
   });
   const last = scene._tweens[scene._tweens.length - 1];
   return { x: last.x, y: last.y };


### PR DESCRIPTION
## Summary
- export `SHOT_DEBUG` flag and enhance `shootBall` to log shooter/team IDs, rim coords, and step/turn indices
- pass debug metadata from `playTurnAnimation` when SHOT_DEBUG is enabled
- adjust tests and stubs for updated `shootBall` signature

## Testing
- `node --loader ./tests/js/httpsLoaderNoStubBall.mjs tests/js/runShootBall.mjs`
- `node --loader ./tests/js/httpsLoader.mjs tests/js/runPlayTurnAnimation.mjs`
- `PYTHONPATH=. pytest tests/test_frontend_rim_animation.py -q`
- ⚠️ `PYTHONPATH=. pytest -q` *(interrupted after partial run)*

------
https://chatgpt.com/codex/tasks/task_e_689e88ae903c8328916e82482a8af77c