### PR TITLE
Cache tournament leaderboards

### DIFF
--- a/BackEnd/api/tournament_routes.py
+++ b/BackEnd/api/tournament_routes.py
@@ -31,8 +31,11 @@ class SimulateRequest(BaseModel):
 
 
 @router.get("/tournament/leaders")
-def get_tournament_leaders(tournament_id: str):
-    """Return top 10 leaders for key stats within a tournament."""
+def get_tournament_leaders(tournament_id: str, recompute: bool = False):
+    """Return top leaders for key stats within a tournament.
+
+    Leaderboards are cached on the tournament document. Pass ``recompute=true``
+    to rebuild them on demand."""
     try:
         tid = ObjectId(tournament_id)
     except Exception:
@@ -42,85 +45,12 @@ def get_tournament_leaders(tournament_id: str):
     if not tourney:
         raise HTTPException(status_code=404, detail="Tournament not found")
 
-    teams: set[str] = set()
-    for round_matches in tourney.get("bracket", {}).values():
-        for match in round_matches:
-            teams.add(match.get("home_team"))
-            teams.add(match.get("away_team"))
-    teams.discard(None)
+    if recompute or "leaderboards" not in tourney:
+        leaderboards = stat_updater.recompute_tournament_leaders(str(tid))
+    else:
+        leaderboards = tourney.get("leaderboards", {})
 
-    # Use stats stored in the tournament document; ignore players from other teams.
-    players = []
-    for pid, pdata in tourney.get("player_stats", {}).items():
-        if pdata.get("team") not in teams:
-            continue
-        players.append(
-            {
-                "player_id": str(pid),
-                "first_name": pdata.get("first_name", ""),
-                "last_name": pdata.get("last_name", ""),
-                "team_name": pdata.get("team", ""),
-                "stats": pdata.get("season", {}),
-            }
-        )
-
-    categories = [
-        ("PTS", "MIN"),
-        ("TPM", "TPA"),
-        ("REB", "MIN"),
-        ("AST", "MIN"),
-        ("STL", "MIN"),
-        ("BLK", "MIN"),
-    ]
-
-    def stat_val(stats: dict, key: str) -> float:
-        if key in stats:
-            return stats.get(key, 0)
-        if key == "TPM":
-            return stats.get("3PTM", 0)
-        if key == "TPA":
-            return stats.get("3PTA", 0)
-        return stats.get(key, 0)
-
-    result: dict[str, list] = {}
-    for stat, tie_key in categories:
-        entries = []
-        for p in players:
-            season = p.get("stats", {})
-            value = stat_val(season, stat)
-            tie_val = stat_val(season, tie_key) if tie_key else 0
-            entries.append(
-                {
-                    "player_id": p.get("player_id"),
-                    "first_name": p.get("first_name", ""),
-                    "last_name": p.get("last_name", ""),
-                    "team_name": p.get("team_name", ""),
-                    "value": value,
-                    "_tie": tie_val,
-                }
-            )
-        entries.sort(
-            key=lambda x: (
-                -x["value"],
-                -x["_tie"],
-                f"{x['first_name']} {x['last_name']}",
-            )
-        )
-        top = []
-        for idx, e in enumerate(entries[:10], start=1):
-            top.append(
-                {
-                    "rank": idx,
-                    "player_id": e["player_id"],
-                    "first_name": e["first_name"],
-                    "last_name": e["last_name"],
-                    "team_name": e["team_name"],
-                    "value": e["value"],
-                }
-            )
-        result[stat] = top
-
-    return result
+    return leaderboards
 
 @router.post("/start-tournament")
 def start_tournament(request: StartTournamentRequest):

--- a/BackEnd/utils/__init__.py
+++ b/BackEnd/utils/__init__.py
@@ -1,9 +1,15 @@
 """Utility helpers for stats and other shared operations."""
 
-from .stat_updater import apply_stats_from_summary, finalize_game, update_game_stats
+from .stat_updater import (
+    apply_stats_from_summary,
+    finalize_game,
+    recompute_tournament_leaders,
+    update_game_stats,
+)
 
 __all__ = [
     "apply_stats_from_summary",
     "finalize_game",
+    "recompute_tournament_leaders",
     "update_game_stats",
 ]

--- a/BackEnd/utils/stat_updater.py
+++ b/BackEnd/utils/stat_updater.py
@@ -78,6 +78,121 @@ def apply_stats_from_summary(summary: Dict[str, Any], game_id: str, tournament_i
                 )
 
 
+def recompute_tournament_leaders(tournament_id: str, limit: int = 10) -> Dict[str, Any]:
+    """Rebuild cached leaderboards for a tournament.
+
+    Returns the computed leaderboards dict.  If the tournament is not found,
+    an empty dict is returned.  Results are written back to the tournament
+    document under the ``leaderboards`` field.
+    """
+    try:
+        tid = ObjectId(tournament_id)
+    except Exception:
+        return {}
+
+    tourney = tournaments_collection.find_one({"_id": tid})
+    if not tourney:
+        return {}
+
+    teams: set[str] = set()
+    for round_matches in tourney.get("bracket", {}).values():
+        for match in round_matches:
+            teams.add(match.get("home_team"))
+            teams.add(match.get("away_team"))
+    teams.discard(None)
+
+    players: list[Dict[str, Any]] = []
+    for pid, pdata in tourney.get("player_stats", {}).items():
+        if pdata.get("team") not in teams:
+            continue
+        players.append(
+            {
+                "player_id": str(pid),
+                "first_name": pdata.get("first_name", ""),
+                "last_name": pdata.get("last_name", ""),
+                "team_name": pdata.get("team", ""),
+                "stats": pdata.get("season", {}),
+            }
+        )
+
+    categories = [
+        ("PTS", "MIN"),
+        ("REB", "MIN"),
+        ("AST", "MIN"),
+        ("STL", "MIN"),
+        ("BLK", "MIN"),
+        ("TPM", "TPA"),
+        ("FG%", "FGA"),
+        ("FT%", "FTA"),
+    ]
+
+    def stat_val(stats: Dict[str, Any], key: str) -> float:
+        if key == "FG%":
+            makes = stats.get("FGM", 0)
+            attempts = stats.get("FGA", 0)
+            return (makes / attempts * 100) if attempts else 0.0
+        if key == "FT%":
+            makes = stats.get("FTM", 0)
+            attempts = stats.get("FTA", 0)
+            return (makes / attempts * 100) if attempts else 0.0
+        if key == "TPM":
+            return stats.get("3PTM", 0)
+        if key == "TPA":
+            return stats.get("3PTA", 0)
+        return stats.get(key, 0)
+
+    leaderboards: Dict[str, list] = {}
+    for stat, tie_key in categories:
+        entries = []
+        for p in players:
+            season = p.get("stats", {})
+            value = stat_val(season, stat)
+            tie_val = stat_val(season, tie_key) if tie_key else 0
+            if stat == "FG%" and season.get("FGA", 0) == 0:
+                continue
+            if stat == "FT%" and season.get("FTA", 0) == 0:
+                continue
+            if stat == "TPM":
+                attempts = season.get("3PTA", season.get("TPA", 0))
+                if attempts == 0:
+                    continue
+            entries.append(
+                {
+                    "player_id": p["player_id"],
+                    "first_name": p.get("first_name", ""),
+                    "last_name": p.get("last_name", ""),
+                    "team_name": p.get("team_name", ""),
+                    "value": value,
+                    "_tie": tie_val,
+                }
+            )
+        entries.sort(
+            key=lambda x: (
+                -x["value"],
+                -x["_tie"],
+                f"{x['first_name']} {x['last_name']}",
+            )
+        )
+        top = []
+        for idx, e in enumerate(entries[:limit], start=1):
+            top.append(
+                {
+                    "rank": idx,
+                    "player_id": e["player_id"],
+                    "first_name": e["first_name"],
+                    "last_name": e["last_name"],
+                    "team_name": e["team_name"],
+                    "value": e["value"],
+                }
+            )
+        leaderboards[stat] = top
+
+    tournaments_collection.update_one(
+        {"_id": tid}, {"$set": {"leaderboards": leaderboards}}
+    )
+    return leaderboards
+
+
 def finalize_game(
     game_id: str,
     *,
@@ -116,6 +231,7 @@ def finalize_game(
 
         game = games_collection.find_one({"_id": gid}) or {}
         apply_stats_from_summary(game, game_id, tournament_id)
+        recompute_tournament_leaders(tournament_id)
 
         return
 

--- a/tests/test_tournament_leaders_endpoint.py
+++ b/tests/test_tournament_leaders_endpoint.py
@@ -81,3 +81,8 @@ def test_leaders_return_top_players_and_exclude_others():
     assert all(entry["player_id"] != "p3" for entry in leaders["PTS"])
     assert leaders["TPM"][0]["player_id"] == "p1"
     assert leaders["TPM"][1]["player_id"] == "p2"
+
+    # ensure leaderboards persisted to tournament document
+    stored = tournaments_collection.find_one({"_id": tid})
+    assert "leaderboards" in stored
+    assert stored["leaderboards"]["PTS"][0]["player_id"] == "p1"


### PR DESCRIPTION
## Summary
- compute and cache tournament leaderboards after each game
- expose cached stats via `/tournament/leaders` endpoint with optional recompute
- test tournament leaderboards persistence

## Testing
- `PYTHONPATH=. pytest tests/test_tournament_player_stats.py tests/test_tournament_leaders_endpoint.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f8091a4648328a31c900238f48721