### PR TITLE
Add rebound handling animations

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -2,8 +2,9 @@ import * as Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.60.0/dist/phaser.
 import { generateBallTween } from "./generateBallTween.js";
 import { gridToPixels } from "../utils/gridToPixels.js";
 
-// Debug flag for logging shot details
+// Debug flags for logging shot / rebound details
 export const SHOT_DEBUG = false;
+export const REBOUND_DEBUG = false;
 
 // Hoop locations in grid coordinates for each team
 const HOME_RIM_COORDS = { x: 91, y: 25 };
@@ -149,13 +150,124 @@ export function shootBall({
             y: bounce.y,
             duration: duration / 3,
             ease: "Sine.easeOut",
-            onComplete: resolve
+            onComplete: () =>
+              resolve({ grid: { x: bounceGridX, y: bounceGridY } })
           });
         } else {
           resolve();
         }
       }
     });
+  });
+}
+
+/**
+ * Animate players collapsing toward a missed shot for a rebound.
+ *
+ * @param {Object} opts
+ * @param {Phaser.Scene} opts.scene
+ * @param {Phaser.GameObjects.Image} opts.ballSprite
+ * @param {Object} opts.playerSprites - map of playerId -> sprite
+ * @param {Array} opts.animations - original turn animations
+ * @param {string} opts.rebounderId - playerId of the rebounder
+ * @param {{x:number, y:number}} opts.ballSpot - grid coordinates where ball landed
+ */
+export function animateRebound({
+  scene,
+  ballSprite,
+  playerSprites,
+  animations,
+  rebounderId,
+  ballSpot
+}) {
+  if (!scene || !ballSprite || !ballSpot) return Promise.resolve();
+
+  const promises = [];
+  const spotPx = gridToPixels(
+    ballSpot.x,
+    ballSpot.y,
+    scene.game.config.width,
+    scene.game.config.height
+  );
+
+  ballSprite.setPosition(spotPx.x, spotPx.y);
+  ballSprite.setVisible(true);
+
+  const rebounderSprite = playerSprites[rebounderId];
+  if (rebounderSprite) {
+    promises.push(
+      new Promise((resolve) => {
+        scene.tweens.add({
+          targets: rebounderSprite,
+          x: spotPx.x,
+          y: spotPx.y,
+          duration: 300,
+          ease: "Linear",
+          onComplete: () => {
+            lockBallToPlayer(scene, ballSprite, rebounderSprite);
+            resolve();
+          },
+          onStop: resolve
+        });
+      })
+    );
+  }
+
+  const offsets = [
+    { x: 1, y: 0 },
+    { x: -1, y: 0 },
+    { x: 0, y: 1 },
+    { x: 0, y: -1 },
+    { x: 1, y: 1 },
+    { x: -1, y: 1 },
+    { x: 1, y: -1 },
+    { x: -1, y: -1 }
+  ];
+  let offsetIndex = 0;
+
+  for (const anim of animations || []) {
+    if (anim.playerId === rebounderId) continue;
+    const sprite = playerSprites[anim.playerId];
+    const lastStep = anim.movement?.[anim.movement.length - 1];
+    if (!sprite || !lastStep) continue;
+
+    const dist =
+      Math.abs(lastStep.coords.x - ballSpot.x) +
+      Math.abs(lastStep.coords.y - ballSpot.y);
+    if (dist > 15) continue;
+
+    const offset = offsets[offsetIndex++] || { x: 0, y: 0 };
+    const targetGrid = { x: ballSpot.x + offset.x, y: ballSpot.y + offset.y };
+    const targetPx = gridToPixels(
+      targetGrid.x,
+      targetGrid.y,
+      scene.game.config.width,
+      scene.game.config.height
+    );
+
+    promises.push(
+      new Promise((resolve) => {
+        scene.tweens.add({
+          targets: sprite,
+          x: targetPx.x,
+          y: targetPx.y,
+          duration: 300,
+          ease: "Linear",
+          onComplete: resolve,
+          onStop: resolve
+        });
+      })
+    );
+  }
+
+  return Promise.all(promises).then(() => {
+    if (REBOUND_DEBUG) {
+      console.log("[rebound]", {
+        rebounderId,
+        ballSpot,
+        movers: promises.length
+      });
+    }
   });
 }
 

--- a/FrontEnd/static/js/phaser/animation/playTurnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/playTurnAnimation.js
@@ -1,6 +1,11 @@
 import { animateStep } from "./animateStep.js";
 import { gridToPixels } from "../utils/gridToPixels.js";
-import { lockBallToPlayer, shootBall, SHOT_DEBUG } from "./ballManager.js";
+import {
+  lockBallToPlayer,
+  shootBall,
+  SHOT_DEBUG,
+  animateRebound
+} from "./ballManager.js";
 
 // Cap the time spent on any single movement step. Large timestamp gaps can
 // otherwise produce multi‑second tweens that appear as animation stalls.
@@ -289,7 +294,33 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
         shootParams.stepIndex = shotInfo.stepIndex;
         shootParams.turnIndex = scene.currentTurn;
       }
-      await shootBall(shootParams);
+      const shotResult = await shootBall(shootParams);
+      const ballSpot = shotResult?.grid;
+      if (ballSpot) {
+        const match = turnData.text?.match(/rebound(?:ed)? by ([^\.]+)$/i);
+        const rebounderName = match?.[1]?.trim();
+        let rebounderId = null;
+        if (rebounderName && scene.playerInfo) {
+          for (const [id, info] of Object.entries(scene.playerInfo)) {
+            const fullName =
+              info?.name || `${info.first_name ?? ""} ${info.last_name ?? ""}`.trim();
+            if (fullName.toLowerCase() === rebounderName.toLowerCase()) {
+              rebounderId = id;
+              break;
+            }
+          }
+        }
+        if (rebounderId) {
+          await animateRebound({
+            scene,
+            ballSprite,
+            playerSprites,
+            animations: turnData.animations,
+            rebounderId,
+            ballSpot
+          });
+        }
+      }
       break;
     }
   }

--- a/tests/js/ballManagerStub.mjs
+++ b/tests/js/ballManagerStub.mjs
@@ -1,4 +1,9 @@
 export function lockBallToPlayer() {}
 export const calls = [];
 export const SHOT_DEBUG = false;
-export function shootBall(opts) { calls.push(opts); return Promise.resolve(); }
+export const REBOUND_DEBUG = false;
+export function shootBall(opts) {
+  calls.push(opts);
+  return Promise.resolve();
+}
+export function animateRebound() {}

--- a/tests/js/runPlayTurnAnimation.mjs
+++ b/tests/js/runPlayTurnAnimation.mjs
@@ -31,6 +31,7 @@ async function runCase(startingTeamId) {
     starting_possession_team_id: startingTeamId,
     possession_team_id: startingTeamId,
     result_type: 'MAKE',
+    text: '',
     animations: [{
       playerId: 'p1',
       movement: [

--- a/tests/js/runShootBall.mjs
+++ b/tests/js/runShootBall.mjs
@@ -22,7 +22,7 @@ async function run(isHomeTeam) {
   const scene = createScene();
   const ballSprite = { setPosition() {}, setVisible() {} };
   const shooterTeamId = isHomeTeam ? 1 : 2;
-  await shootBall({
+  const _res = await shootBall({
     scene,
     ballSprite,
     fromCoords: { x: 0, y: 0 },


### PR DESCRIPTION
## Summary
- add REBOUND_DEBUG flag and rebound ball spot return in `shootBall`
- implement `animateRebound` to move players toward missed shot
- wire rebound flow in `playTurnAnimation` and update tests

## Testing
- `node --loader ./tests/js/httpsLoaderNoStubBall.mjs tests/js/runShootBall.mjs`
- `node --loader ./tests/js/httpsLoader.mjs tests/js/runPlayTurnAnimation.mjs`


------
https://chatgpt.com/codex/tasks/task_e_689f9b23be2883289341bab6644052ed