### PR TITLE
Handle rebound animation using ball_handler

### DIFF
--- a/FrontEnd/static/js/phaser/animation/playTurnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/playTurnAnimation.js
@@ -284,7 +284,10 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
         ballSprite,
         fromCoords: shotInfo.step.coords,
         startTimestamp: shotInfo.step.timestamp,
-        result: turnData.result_type,
+        // Map rebound result types to "MISS" so shootBall returns a landing spot
+        result: ["DREB", "OREB"].includes(turnData.result_type)
+          ? "MISS"
+          : turnData.result_type,
         shooterPos,
         shooterId: shotInfo.playerId,
         shooterTeamId,
@@ -297,16 +300,18 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
       const shotResult = await shootBall(shootParams);
       const ballSpot = shotResult?.grid;
       if (ballSpot) {
-        const match = turnData.text?.match(/rebound(?:ed)? by ([^\.]+)$/i);
-        const rebounderName = match?.[1]?.trim();
+        const rebounderName = turnData.ball_handler?.trim();
         let rebounderId = null;
-        if (rebounderName && scene.playerInfo) {
-          for (const [id, info] of Object.entries(scene.playerInfo)) {
-            const fullName =
-              info?.name || `${info.first_name ?? ""} ${info.last_name ?? ""}`.trim();
-            if (fullName.toLowerCase() === rebounderName.toLowerCase()) {
-              rebounderId = id;
-              break;
+        if (rebounderName) {
+          rebounderId = scene.nameToId?.[rebounderName];
+          if (!rebounderId && scene.playerInfo) {
+            for (const [id, info] of Object.entries(scene.playerInfo)) {
+              const fullName =
+                info?.name || `${info.first_name ?? ""} ${info.last_name ?? ""}`.trim();
+              if (fullName.toLowerCase() === rebounderName.toLowerCase()) {
+                rebounderId = id;
+                break;
+              }
             }
           }
         }

--- a/tests/js/ballManagerStub.mjs
+++ b/tests/js/ballManagerStub.mjs
@@ -4,6 +4,9 @@ export const SHOT_DEBUG = false;
 export const REBOUND_DEBUG = false;
 export function shootBall(opts) {
   calls.push(opts);
-  return Promise.resolve();
+  // return a fake landing spot so rebound logic can run in tests
+  return Promise.resolve({ grid: { x: 0, y: 0 } });
 }
-export function animateRebound() {}
+export function animateRebound(opts) {
+  calls.push({ type: 'rebound', opts });
+}

--- a/tests/js/runReboundAnimation.mjs
+++ b/tests/js/runReboundAnimation.mjs
@@ -1,0 +1,52 @@
+import { playTurnAnimation } from '../../FrontEnd/static/js/phaser/animation/playTurnAnimation.js';
+import { calls } from './ballManagerStub.mjs';
+
+function createScene() {
+  return {
+    skipToEnd: false,
+    tweens: {
+      add: ({ onUpdate, onComplete, onStop }) => {
+        if (onUpdate) onUpdate();
+        if (onComplete) onComplete();
+        return { stop: () => { if (onStop) onStop(); } };
+      },
+      killTweensOf: () => {}
+    },
+    game: { config: { width: 100, height: 50 } },
+    playerInfo: { p1: { name: 'Rebounder' } },
+    nameToId: { Rebounder: 'p1' },
+    time: { delayedCall: (ms, fn) => fn() }
+  };
+}
+
+function createSprite(team_id) {
+  return { x: 0, y: 0, team_id, setPosition() {}, setVisible() {} };
+}
+
+const scene = createScene();
+const ballSprite = { setPosition() {}, setVisible() {} };
+const playerSprites = { p1: createSprite('HOME') };
+const turnData = {
+  starting_possession_team_id: 'HOME',
+  possession_team_id: 'HOME',
+  result_type: 'DREB',
+  ball_handler: 'Rebounder',
+  text: '',
+  animations: [{
+    playerId: 'p1',
+    movement: [
+      { timestamp: 0, coords: { x: 0, y: 0 }, action: 'handle_ball' },
+      { timestamp: 10, coords: { x: 0, y: 0 }, action: 'shoot' }
+    ],
+    hasBallAtStep: [true, true]
+  }]
+};
+const simData = { home_team_id: 'HOME' };
+
+await playTurnAnimation({ scene, simData, playerSprites, turnData, ballSprite });
+const shootOpts = calls.find(c => !c.type);
+const reboundCall = calls.find(c => c.type === 'rebound');
+console.log(JSON.stringify({
+  resultMapped: shootOpts?.result,
+  rebounderId: reboundCall?.opts?.rebounderId
+}));


### PR DESCRIPTION
## Summary
- Map `DREB`/`OREB` result types to `"MISS"` before invoking `shootBall`
- Resolve rebounder via `turnData.ball_handler` and animate rebound if ID found
- Stub and test cover rebound animations

## Testing
- `node --experimental-loader ./tests/js/httpsLoader.mjs tests/js/runPlayTurnAnimation.mjs | tail -n 1`
- `node --experimental-loader ./tests/js/httpsLoader.mjs tests/js/runReboundAnimation.mjs | tail -n 1`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fbcb1d3e483289b2acf07671958f5