### PR TITLE
Persist quarter simulation summaries

### DIFF
--- a/BackEnd/api/api.py
+++ b/BackEnd/api/api.py
@@ -217,6 +217,12 @@ def simulate_quarter_endpoint(request: QuarterSimulationRequest):
         }
     )
 
+    try:
+        games_collection.update_one({"_id": game_id}, {"$set": summary}, upsert=True)
+    except Exception as e:
+        print("🚨 Mongo upsert failed:", e)
+        traceback.print_exc()
+
     if is_final and game_id:
         # Scrimmage simulations should not generate aggregate stats.
         # Finalizing with ``mode="scrimmage"`` is a no-op but documents intent.


### PR DESCRIPTION
## Summary
- Persist quarter simulation summaries in Mongo using upsert keyed by game_id

## Testing
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fc171d5588328882739c612d13ab0