### PR TITLE
Implement rebound hold and spacing

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -183,6 +183,9 @@ export function animateRebound({
   if (!scene || !ballSprite || !ballSpot) return Promise.resolve();
 
   const promises = [];
+  const finalPositions = [];
+  const MIN_X_SEP = 3;
+  const MIN_Y_SEP = 2;
   const spotPx = gridToPixels(
     ballSpot.x,
     ballSpot.y,
@@ -195,6 +198,7 @@ export function animateRebound({
 
   const rebounderSprite = playerSprites[rebounderId];
   if (rebounderSprite) {
+    finalPositions.push({ playerId: rebounderId, grid: { ...ballSpot } });
     promises.push(
       new Promise((resolve) => {
         scene.tweens.add({
@@ -237,7 +241,27 @@ export function animateRebound({
     if (dist > 15) continue;
 
     const offset = offsets[offsetIndex++] || { x: 0, y: 0 };
-    const targetGrid = { x: ballSpot.x + offset.x, y: ballSpot.y + offset.y };
+    let targetGrid = { x: ballSpot.x + offset.x, y: ballSpot.y + offset.y };
+
+    // Ensure minimum spacing from rebounder and other players
+    let adjusted = false;
+    while (!adjusted) {
+      adjusted = true;
+      for (const pos of finalPositions) {
+        if (Math.abs(targetGrid.x - pos.grid.x) < MIN_X_SEP) {
+          const dirX = targetGrid.x >= pos.grid.x ? 1 : -1;
+          targetGrid.x = pos.grid.x + dirX * MIN_X_SEP;
+          adjusted = false;
+        }
+        if (Math.abs(targetGrid.y - pos.grid.y) < MIN_Y_SEP) {
+          const dirY = targetGrid.y >= pos.grid.y ? 1 : -1;
+          targetGrid.y = pos.grid.y + dirY * MIN_Y_SEP;
+          adjusted = false;
+        }
+      }
+    }
+
+    finalPositions.push({ playerId: anim.playerId, grid: { ...targetGrid } });
     const targetPx = gridToPixels(
       targetGrid.x,
       targetGrid.y,
@@ -260,15 +284,24 @@ export function animateRebound({
     );
   }
 
-  return Promise.all(promises).then(() => {
-    if (REBOUND_DEBUG) {
-      console.log("[rebound]", {
-        rebounderId,
-        ballSpot,
-        movers: promises.length
-      });
-    }
-  });
+  return Promise.all(promises).then(
+    () =>
+      new Promise((resolve) => {
+        const logPayload = {
+          rebounderId,
+          ballSpot,
+          positions: finalPositions
+        };
+        if (REBOUND_DEBUG) {
+          console.log("[rebound]", logPayload);
+        }
+        if (scene.time?.delayedCall) {
+          scene.time.delayedCall(2000, resolve);
+        } else {
+          setTimeout(resolve, 2000);
+        }
+      })
+  );
 }
 
 /**

--- a/tests/js/animateReboundSpacing.mjs
+++ b/tests/js/animateReboundSpacing.mjs
@@ -1,0 +1,86 @@
+import { animateRebound } from '../../FrontEnd/static/js/phaser/animation/ballManager.js';
+
+function createScene() {
+  const delayedCalls = [];
+  return {
+    tweens: {
+      add: ({ targets, x, y, onComplete }) => {
+        if (targets) {
+          targets.x = x;
+          targets.y = y;
+        }
+        if (onComplete) onComplete();
+        return { stop: () => {} };
+      },
+      killTweensOf: () => {}
+    },
+    game: { config: { width: 100, height: 50 } },
+    time: {
+      delayedCalls,
+      delayedCall(ms, fn) {
+        delayedCalls.push(ms);
+        fn();
+      }
+    }
+  };
+}
+
+function createSprite(team_id) {
+  return {
+    team_id,
+    x: 0,
+    y: 0,
+    setPosition(x, y) {
+      this.x = x;
+      this.y = y;
+    },
+    setVisible() {}
+  };
+}
+
+const scene = createScene();
+const ballSprite = createSprite();
+const playerSprites = {
+  r1: createSprite('HOME'),
+  p2: createSprite('HOME'),
+  p3: createSprite('AWAY')
+};
+
+const animations = [
+  { playerId: 'r1', movement: [{ coords: { x: 50, y: 25 } }] },
+  { playerId: 'p2', movement: [{ coords: { x: 48, y: 24 } }] },
+  { playerId: 'p3', movement: [{ coords: { x: 52, y: 26 } }] }
+];
+
+await animateRebound({
+  scene,
+  ballSprite,
+  playerSprites,
+  animations,
+  rebounderId: 'r1',
+  ballSpot: { x: 50, y: 25 }
+});
+
+function pixelToGrid(sprite) {
+  return { x: sprite.x, y: 50 - sprite.y };
+}
+
+const r1 = pixelToGrid(playerSprites.r1);
+const p2 = pixelToGrid(playerSprites.p2);
+const p3 = pixelToGrid(playerSprites.p3);
+
+const spacingValid =
+  Math.abs(p2.x - r1.x) >= 3 &&
+  Math.abs(p2.y - r1.y) >= 2 &&
+  Math.abs(p3.x - r1.x) >= 3 &&
+  Math.abs(p3.y - r1.y) >= 2 &&
+  Math.abs(p3.x - p2.x) >= 3 &&
+  Math.abs(p3.y - p2.y) >= 2;
+
+console.log(
+  JSON.stringify({
+    delay: scene.time.delayedCalls[0],
+    spacingValid,
+    ballLocked: ballSprite.x === playerSprites.r1.x && ballSprite.y === playerSprites.r1.y
+  })
+);


### PR DESCRIPTION
## Summary
- enforce minimum player spacing around rebounds and log final positions when `REBOUND_DEBUG` is enabled
- pause play for 2s after rebounder secures ball
- add test covering rebound spacing and hold

## Testing
- `PYTHONPATH=. pytest`
- `node --experimental-loader=./tests/js/httpsLoaderNoStubBall.mjs tests/js/runShootBall.mjs`
- `node --experimental-loader=./tests/js/httpsLoader.mjs tests/js/runPlayTurnAnimation.mjs`
- `node --experimental-loader=./tests/js/httpsLoader.mjs tests/js/runReboundAnimation.mjs`
- `node --experimental-loader=./tests/js/httpsLoaderNoStubBall.mjs tests/js/animateReboundSpacing.mjs`


------
https://chatgpt.com/codex/tasks/task_e_689fc4ea78748328bfab74e0ff041e2c