### PR TITLE
Reduce rebound animation hold to one second

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -296,9 +296,9 @@ export function animateRebound({
           console.log("[rebound]", logPayload);
         }
         if (scene.time?.delayedCall) {
-          scene.time.delayedCall(2000, resolve);
+          scene.time.delayedCall(1000, resolve);
         } else {
-          setTimeout(resolve, 2000);
+          setTimeout(resolve, 1000);
         }
       })
   );


### PR DESCRIPTION
## Summary
- shorten post-rebound pause from 2s to 1s without altering animation logic

## Testing
- `node --loader ./tests/js/httpsLoaderNoStubBall.mjs tests/js/animateReboundSpacing.mjs`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fc7d4ffd883288d79f6e648e48d7f