### PR TITLE
Animate pass actions with ball tween and onAction callback

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animateStep.js
+++ b/FrontEnd/static/js/phaser/animation/animateStep.js
@@ -10,7 +10,7 @@ import { gridToPixels } from "../utils/gridToPixels.js";
  * @param {number} duration - Milliseconds for tween duration
  * @returns {Promise} resolves when tween completes
  */
-export function animateStep({ scene, sprite, step, duration, ballSprite, currentBallOwnerRef }) {
+export function animateStep({ scene, sprite, step, duration, ballSprite, currentBallOwnerRef, onAction }) {
   if (scene.skipToEnd) return Promise.resolve();
   return new Promise((resolve) => {
     const { x: targetX, y: targetY } = gridToPixels(
@@ -26,6 +26,11 @@ export function animateStep({ scene, sprite, step, duration, ballSprite, current
       y: targetY,
       duration,
       ease: "Linear",
+      onStart: () => {
+        if (step.action && onAction) {
+          onAction(step.action, sprite, step.timestamp);
+        }
+      },
       onUpdate: () => {
         if (currentBallOwnerRef?.value === sprite && ballSprite?.setPosition) {
           ballSprite.setPosition(sprite.x, sprite.y);

--- a/FrontEnd/static/js/phaser/animation/generateBallTween.js
+++ b/FrontEnd/static/js/phaser/animation/generateBallTween.js
@@ -10,7 +10,7 @@ export function generateBallTween({
   }) {
     if (!ballSprite || !scene) return;
   
-    const duration = endTimestamp - startTimestamp;
+    const duration = Math.max(endTimestamp - startTimestamp, 150);
   
     const startPixels = gridToPixels(startCoords.x, startCoords.y, scene.game.config.width, scene.game.config.height);
     const endPixels = gridToPixels(endCoords.x, endCoords.y, scene.game.config.width, scene.game.config.height);

--- a/FrontEnd/static/js/phaser/animation/playTurnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/playTurnAnimation.js
@@ -17,38 +17,23 @@ const MAX_STEP_DURATION = 1000; // ms
  */
 function updateBallOwnership({ scene, ballSprite, animations, playerSprites, stepIndex, offenseTeamId, currentBallOwnerRef }) {
   if (scene?.skipToEnd) return;
-  console.log("🟡 inside updateBallOwnership → stepIndex:", stepIndex);
+
+  const passHappening = animations.some(
+    anim => anim.movement?.[stepIndex]?.action === "pass"
+  );
+  if (passHappening) return;
+
   for (const anim of animations) {
     if (scene.skipToEnd) break;
     const sprite = playerSprites[anim.playerId];
     const hasBall = anim.hasBallAtStep?.[stepIndex];
-    const team = sprite?.team_id;
-
-    console.log("hasBall", hasBall);
-    console.log("sprite", sprite);
-    console.log("team = sprite.team_id", team);
-    console.log("offenseTeamId", offenseTeamId);
-    console.log("ballSprite", ballSprite);
-    console.log("currentBallOwnerRef", currentBallOwnerRef);
-
-    // if (hasBall && sprite && team === offenseTeamId && ballSprite?.setPosition) {
     if (hasBall && ballSprite?.setPosition) {
-      console.log("All four conditions are met")
       ballSprite.setPosition(sprite.x, sprite.y);
       ballSprite.setVisible(true);
       if (currentBallOwnerRef) currentBallOwnerRef.value = sprite;
       break;
+    }
 
-      console.log("🟡 also inside updateBallOwnership → Ball assigned at step", stepIndex, {
-        playerId: anim.playerId,
-        hasBall,
-        team: sprite?.team_id,
-        offenseTeamId
-      });
-    } else {
-      console.log("🟡 all four conditions are not met at step", stepIndex);
-    }
-    }
   }
 
 
@@ -189,7 +174,6 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
     if (anim.hasBallAtStep?.[0]) {
       step0OwnerSprite = playerSprites[anim.playerId];
       break;
-    }
   }
 
   if (step0OwnerSprite) {
@@ -267,7 +251,8 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
         step: curr,
         duration,
         ballSprite,
-        currentBallOwnerRef
+        currentBallOwnerRef,
+        onAction
       });
 
       promises.push(promise);
@@ -327,6 +312,5 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
         }
       }
       break;
-    }
   }
 }


### PR DESCRIPTION
## Summary
- allow animateStep to invoke optional onAction callbacks
- skip ball repositioning during pass and forward onAction in playTurnAnimation
- enforce minimum tween duration for ball passes

## Testing
- `PYTHONPATH=$PYTHONPATH:$(pwd) pytest` *(fails: Command '['node', '--loader', '/workspace/gob-simplified/tests/js/httpsLoader.mjs', '/workspace/gob-simplified/tests/js/runPlayTurnAnimation.mjs']' returned non-zero exit status 1)*
- `node --loader tests/js/httpsLoader.mjs tests/js/runPlayTurnAnimation.mjs` *(fails: Cannot find package 'tests')*

------
https://chatgpt.com/codex/tasks/task_e_689fc9583ab883289969c45e0f92d55c