### PR TITLE
fix: wrap turn animation for legacy script loaders

### DIFF
--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -1,0 +1,21 @@
+/**
+ * Legacy wrapper for turn animation.
+ *
+ * Some pages still load this file as a classic script which cannot parse
+ * ES module syntax like `export`.  The actual implementation lives in
+ * `playTurnAnimation.js` which uses ES modules.
+ *
+ * This stub dynamically imports the modern module and exposes
+ * `playTurnAnimation` on the global `window` object for any legacy callers.
+ */
+(async () => {
+  try {
+    const module = await import('./playTurnAnimation.js');
+    // Expose for legacy consumers expecting a global function
+    if (typeof window !== 'undefined') {
+      window.playTurnAnimation = module.playTurnAnimation;
+    }
+  } catch (err) {
+    console.error('Failed to load playTurnAnimation module', err);
+  }
+})();


### PR DESCRIPTION
## Summary
- avoid `export` syntax error by adding a non-module wrapper

## Testing
- `node tests/js/runPlayTurnAnimation.mjs` *(fails: Unexpected token 'export')*
- `PYTHONPATH=. pytest tests/test_utils.py` *(0 tests collected)*

------
https://chatgpt.com/codex/tasks/task_e_689fcf000be0832899a4a03e1ab0c179