### PR TITLE
fix: add dynamic import wrapper

### DIFF
--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -1,21 +1,8 @@
-/**
- * Legacy wrapper for turn animation.
- *
- * Some pages still load this file as a classic script which cannot parse
- * ES module syntax like `export`.  The actual implementation lives in
- * `playTurnAnimation.js` which uses ES modules.
- *
- * This stub dynamically imports the modern module and exposes
- * `playTurnAnimation` on the global `window` object for any legacy callers.
- */
+// Compatibility wrapper for legacy script imports.
+// Dynamically loads playTurnAnimation and exposes it on `window`.
 (async () => {
-  try {
-    const module = await import('./playTurnAnimation.js');
-    // Expose for legacy consumers expecting a global function
-    if (typeof window !== 'undefined') {
-      window.playTurnAnimation = module.playTurnAnimation;
-    }
-  } catch (err) {
-    console.error('Failed to load playTurnAnimation module', err);
+  const module = await import('./playTurnAnimation.js');
+  if (typeof window !== 'undefined') {
+    window.playTurnAnimation = module.playTurnAnimation;
   }
 })();


### PR DESCRIPTION
## Summary
- wrap playTurnAnimation import for legacy callers

## Testing
- `PYTHONPATH=. pytest` *(fails: subprocess.CalledProcessError: Command '['node', '--loader', '/workspace/gob-simplified/tests/js/httpsLoader.mjs', '/workspace/gob-simplified/tests/js/runPlayTurnAnimation.mjs']' returned non-zero exit status 1.)*


------
https://chatgpt.com/codex/tasks/task_e_689fd289e38483289a0a23816929b804