### PR TITLE
Refresh tournament state after save

### DIFF
--- a/FrontEnd/static/js/phaser/finalizeGame.js
+++ b/FrontEnd/static/js/phaser/finalizeGame.js
@@ -38,12 +38,22 @@ export async function finalizeGame({ simData, tournamentId, franchiseId, game })
       } else {
         console.log("✅ Tournament result saved.");
         try {
+          const updated = await fetch(`/tournament/state/${tournamentId}`).then((r) =>
+            r.json()
+          );
+          localStorage.setItem("activeTournament", JSON.stringify(updated));
           if (window && window.opener) {
             if (typeof window.opener.refreshTeamStats === "function") {
               window.opener.refreshTeamStats();
             }
             if (typeof window.opener.refreshLeaders === "function") {
               window.opener.refreshLeaders();
+            }
+          } else {
+            if (typeof window.refreshTeamStats === "function") {
+              window.refreshTeamStats();
+            } else {
+              window.location.href = "/static/tournament.html";
             }
           }
         } catch (e) {


### PR DESCRIPTION
## Summary
- fetch and store updated tournament state after saving results
- refresh bracket from parent or current window

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'BackEnd')*

------
https://chatgpt.com/codex/tasks/task_e_68a073cceaac8328a17ff57fbd15dde8