### PR TITLE
Update tournament state after save

### DIFF
--- a/FrontEnd/static/js/phaser/finalizeGame.js
+++ b/FrontEnd/static/js/phaser/finalizeGame.js
@@ -42,22 +42,17 @@ export async function finalizeGame({ simData, tournamentId, franchiseId, game })
             r.json()
           );
           localStorage.setItem("activeTournament", JSON.stringify(updated));
-          if (window && window.opener) {
-            if (typeof window.opener.refreshTeamStats === "function") {
-              window.opener.refreshTeamStats();
-            }
-            if (typeof window.opener.refreshLeaders === "function") {
-              window.opener.refreshLeaders();
-            }
+          if (window.opener) {
+            window.opener.refreshTeamStats?.();
+            window.opener.refreshLeaders?.();
           } else {
-            if (typeof window.refreshTeamStats === "function") {
-              window.refreshTeamStats();
-            } else {
+            window.refreshTeamStats?.();
+            if (!window.refreshTeamStats) {
               window.location.href = "/static/tournament.html";
             }
           }
         } catch (e) {
-          console.error("Failed to trigger parent refresh", e);
+          console.error("Failed to update tournament state", e);
         }
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- Fetch updated tournament state after saving a result and store in `localStorage`
- Refresh parent or current window to keep team stats and leaders in sync

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a078e5a3188328bca85acb3aaea6df