### PR TITLE
Hide play button for finished tournament matchups

### DIFF
--- a/FrontEnd/static/tournament.js
+++ b/FrontEnd/static/tournament.js
@@ -288,7 +288,7 @@ function updateCTA() {
   const matchups = tournament.bracket?.[roundKey] || [];
   const userMatch = matchups.find(m => m.home_team === userTeamId || m.away_team === userTeamId);
 
-  if (userMatch) {
+  if (userMatch && !userMatch.winner && !userMatch.game_id) {
     const opponent = userMatch.home_team === userTeamId ? userMatch.away_team : userMatch.home_team;
     playBtn.style.display = 'inline-flex';
     opponentEl.textContent = `vs ${opponent}`;


### PR DESCRIPTION
## Summary
- Only show "Play Now" button when the user's matchup has no winner and no game assigned
- Fall back to "Sim Remaining" when the matchup is finished or scheduled

## Testing
- `PYTHONPATH=. pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68a079f75d54832884c2609899f72e40