### PR TITLE
Ensure BackEnd imports in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,11 @@
+import os
+import sys
+
 import pytest
+
+# Ensure the project root is on sys.path so 'import BackEnd' succeeds
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 from BackEnd.models.game_manager import GameManager
 from BackEnd.constants import POSITION_LIST
 


### PR DESCRIPTION
## Summary
- prepend project root to `sys.path` in test configuration so `BackEnd` module is importable

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a07ae376448328a42c32547487bb45