### PR TITLE
Handle already played tournament round in frontend

### DIFF
--- a/FrontEnd/static/tournament.js
+++ b/FrontEnd/static/tournament.js
@@ -424,6 +424,9 @@ document.addEventListener("DOMContentLoaded", async () => {
         if (!res.ok) throw new Error('Request failed');
         const data = await res.json();
         if (data.already_played) {
+          playBtn.disabled = false;
+          await refreshTeamStats();
+          await refreshLeaders();
           alert('This round has already been played.');
           return;
         }


### PR DESCRIPTION
## Summary
- Refresh team stats and leaders when a user tries to replay an already-simulated round
- Re-enable the play button on already played rounds to keep the UI interactive

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0e0550e048328b823070870da1bb5