### PR TITLE
Disable caching for tournament fetch requests

### DIFF
--- a/FrontEnd/static/tournament.js
+++ b/FrontEnd/static/tournament.js
@@ -326,7 +326,7 @@ async function loadTournament() {
     } else {
       url = `/tournament/active?user_team_id=${encodeURIComponent(userTeamId)}`;
     }
-    const res = await fetch(url);
+    const res = await fetch(`${url}?_=${Date.now()}`, { cache: "no-store" });
     tournament = await res.json();
     localStorage.setItem("activeTournament", JSON.stringify(tournament));
     console.log("Bracket data arrives", tournament);


### PR DESCRIPTION
## Summary
- prevent caching of tournament fetch by appending timestamp query and setting `cache: no-store`

## Testing
- `python -m http.server 8000 & sleep 1; kill $! && echo server stopped`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0e45361c483289677404c54be1dc5