### PR TITLE
Record simulated game results

### DIFF
--- a/BackEnd/api/tournament_routes.py
+++ b/BackEnd/api/tournament_routes.py
@@ -136,6 +136,17 @@ def simulate_round(request: SimulateRequest):
             stat_updater.finalize_game(
                 str(game_id), mode="tournament", tournament_id=request.tournament_id
             )
+            result_doc = {
+                "home_team": matchup["home_team"],
+                "away_team": matchup["away_team"],
+                "score": summary.get("score", {}),
+                "winner": winner,
+                "round": tournament_doc["current_round"],
+                "match_index": i,
+            }
+            tournaments_collection.update_one(
+                {"_id": tournament_id}, {"$push": {"results": result_doc}}
+            )
 
         # Reload tournament to check if round is complete
         updated_doc = tournaments_collection.find_one({"_id": tournament_id})
@@ -144,6 +155,11 @@ def simulate_round(request: SimulateRequest):
             if all_done:
                 manager.tournament = updated_doc
                 manager.advance_round()
+
+        # Sync bracket state with stored results
+        update_bracket_from_results(
+            tournament_id, tournaments_collection=tournaments_collection
+        )
 
         if already_played:
             return {"already_played": True}

--- a/tests/test_simulate_round_results.py
+++ b/tests/test_simulate_round_results.py
@@ -1,0 +1,52 @@
+from bson import ObjectId
+
+from BackEnd.tournament.tournament_manager import TournamentManager
+from BackEnd.api.tournament_routes import simulate_round, SimulateRequest
+from BackEnd.db import tournaments_collection, games_collection
+
+
+def test_simulate_round_records_results(monkeypatch):
+    tournaments_collection.delete_many({})
+    games_collection.delete_many({})
+
+    manager = TournamentManager(
+        user_team_id="A",
+        tournaments_collection=tournaments_collection,
+        team_ids=["A", "B", "C", "D", "E", "F", "G", "H"],
+    )
+    tournament = manager.create_tournament()
+    tid = ObjectId(tournament["_id"])
+
+    def fake_run_simulation(home, away):
+        return {"home": home, "away": away}
+
+    def fake_summarize(game):
+        h = game["home"]
+        a = game["away"]
+        return {"score": {h: 80, a: 70}}
+
+    monkeypatch.setattr("BackEnd.api.tournament_routes.run_simulation", fake_run_simulation)
+    monkeypatch.setattr("BackEnd.api.tournament_routes.summarize_game_state", fake_summarize)
+    monkeypatch.setattr(
+        "BackEnd.api.tournament_routes.stat_updater.finalize_game",
+        lambda *args, **kwargs: None,
+    )
+
+    resp = simulate_round(SimulateRequest(tournament_id=str(tid)))
+    assert "home" in resp and "away" in resp
+
+    updated = tournaments_collection.find_one({"_id": tid})
+    results = updated.get("results", [])
+    assert len(results) == 3
+
+    for idx, match in enumerate(updated["bracket"]["round1"]):
+        if "A" in (match["home_team"], match["away_team"]):
+            continue
+        res = next(
+            r for r in results if r["round"] == 1 and r["match_index"] == idx
+        )
+        assert res["home_team"] == match["home_team"]
+        assert res["away_team"] == match["away_team"]
+        assert res["score"][match["home_team"]] == 80
+        assert res["score"][match["away_team"]] == 70
+        assert res["winner"] == match["home_team"]


### PR DESCRIPTION
## Summary
- Track results for each non-user game during tournament round simulation
- Sync bracket with stored results after simulating games
- Test that `simulate_round` records results for non-user matchups

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0ecf428008328a84f67e182db6ace