### PR TITLE
feat: propagate tournament updates

### DIFF
--- a/FrontEnd/static/js/phaser/finalizeGame.js
+++ b/FrontEnd/static/js/phaser/finalizeGame.js
@@ -41,15 +41,15 @@ export async function finalizeGame({ simData, tournamentId, franchiseId, game })
           const updated = await fetch(`/tournament/state/${tournamentId}`).then((r) =>
             r.json()
           );
-          localStorage.setItem("activeTournament", JSON.stringify(updated));
-          if (window.opener) {
-            window.opener.refreshTeamStats?.();
+          if (window.opener && window.opener.handleTournamentUpdate) {
+            window.opener.handleTournamentUpdate(updated);
             window.opener.refreshLeaders?.();
+          } else if (window.handleTournamentUpdate) {
+            window.handleTournamentUpdate(updated);
+            window.refreshLeaders?.();
           } else {
-            window.refreshTeamStats?.();
-            if (!window.refreshTeamStats) {
-              window.location.href = "/static/tournament.html";
-            }
+            localStorage.setItem("activeTournament", JSON.stringify(updated));
+            window.location.href = "/static/tournament.html";
           }
         } catch (e) {
           console.error("Failed to update tournament state", e);

--- a/FrontEnd/static/tournament.js
+++ b/FrontEnd/static/tournament.js
@@ -402,6 +402,17 @@ async function refreshTeamStats() {
 
 window.refreshTeamStats = refreshTeamStats;
 
+function handleTournamentUpdate(doc) {
+  tournament = doc;
+  localStorage.setItem("activeTournament", JSON.stringify(doc));
+  renderBracket();
+  renderRoster();
+  renderStats();
+  updateCTA();
+}
+
+window.handleTournamentUpdate = handleTournamentUpdate;
+
 document.addEventListener("DOMContentLoaded", async () => {
   await loadTournament();
   if (!userTeamId && tournament && tournament.user_team_id) {


### PR DESCRIPTION
## Summary
- Trigger `handleTournamentUpdate` when a tournament game finishes to sync opener or same-window views
- Add `handleTournamentUpdate` helper to update bracket, roster, stats, and CTA on the tournament page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0faacd2d08328be4c8dd1226cc2f5