### PR TITLE
Add inbound pass and sequence after made baskets

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -5,6 +5,7 @@ import { gridToPixels } from "../utils/gridToPixels.js";
 // Debug flags for logging shot / rebound details
 export const SHOT_DEBUG = false;
 export const REBOUND_DEBUG = false;
+export const INBOUND_DEBUG = false;
 
 // Hoop locations in grid coordinates for each team
 const HOME_RIM_COORDS = { x: 91, y: 25 };
@@ -50,6 +51,25 @@ export function passBall({
     endCoords: toCoords,
     startTimestamp: fromTimestamp,
     endTimestamp: toTimestamp
+  });
+}
+
+// Baseline inbound pass from one coordinate to another
+export function animateInboundPass(
+  scene,
+  ballSprite,
+  fromCoords,
+  toCoords,
+  startTs,
+  endTs
+) {
+  generateBallTween({
+    scene,
+    ballSprite,
+    startCoords: fromCoords,
+    endCoords: toCoords,
+    startTimestamp: startTs,
+    endTimestamp: endTs
   });
 }
 

--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -4,7 +4,9 @@ import {
   lockBallToPlayer,
   shootBall,
   SHOT_DEBUG,
-  animateRebound
+  animateRebound,
+  animateInboundPass,
+  INBOUND_DEBUG
 } from "./ballManager.js";
 
 // Cap the time spent on any single movement step. Large timestamp gaps can
@@ -83,6 +85,103 @@ async function runSetupTween({ scene, ballSprite, animations, playerSprites, cur
   }
 
   await Promise.all(promises);
+}
+
+// Animate baseline inbound play after a made basket
+async function animateInboundSequence({
+  scene,
+  ballSprite,
+  playerSprites,
+  scoringTeamId,
+  homeTeamId
+}) {
+  const isHomeScoring = scoringTeamId === homeTeamId;
+  const inboundTeamId = isHomeScoring ? "AWAY" : "HOME";
+  const dir = inboundTeamId === "HOME" ? 1 : -1;
+
+  const baselineX = inboundTeamId === "HOME" ? 6 : 94;
+  const randY = 25 + Math.floor(Math.random() * 6) - 3;
+  const ballSpot = { x: baselineX, y: randY };
+
+  const oDestinationDict = {
+    PG: { x: baselineX, y: randY },
+    SG: { x: baselineX + dir * 4, y: randY + Math.floor(Math.random() * 4 - 2) },
+    SF: { x: baselineX + dir * 8, y: randY + Math.floor(Math.random() * 4 - 2) },
+    PF: { x: baselineX + dir * 12, y: randY + Math.floor(Math.random() * 4 - 2) },
+    C: { x: baselineX + dir * 16, y: randY + Math.floor(Math.random() * 4 - 2) }
+  };
+
+  if (INBOUND_DEBUG) {
+    console.log("[inbound]", { scoringTeamId, ballSpot, destinations: oDestinationDict });
+  }
+
+  const movePromises = [];
+  let inbounderSprite = null;
+  let receiverSprite = null;
+  for (const [id, sprite] of Object.entries(playerSprites)) {
+    const info = scene.playerInfo?.[id];
+    if (!info) continue;
+    if (sprite.team_id === inboundTeamId) {
+      const dest = oDestinationDict[info.pos];
+      if (dest) {
+        const px = gridToPixels(
+          dest.x,
+          dest.y,
+          scene.game.config.width,
+          scene.game.config.height
+        );
+        movePromises.push(
+          new Promise((resolve) => {
+            scene.tweens.add({
+              targets: sprite,
+              x: px.x,
+              y: px.y,
+              duration: 500,
+              ease: "Sine.easeInOut",
+              onComplete: resolve,
+              onStop: resolve
+            });
+          })
+        );
+      }
+      if (info.pos === "PG") inbounderSprite = sprite;
+      if (info.pos === "SF") receiverSprite = sprite;
+    } else if (sprite.team_id === scoringTeamId) {
+      const targetX = gridToPixels(
+        isHomeScoring ? 45 : 55,
+        25,
+        scene.game.config.width,
+        scene.game.config.height
+      ).x;
+      movePromises.push(
+        new Promise((resolve) => {
+          scene.tweens.add({
+            targets: sprite,
+            x: targetX,
+            y: sprite.y,
+            duration: 500,
+            ease: "Sine.easeInOut",
+            onComplete: resolve,
+            onStop: resolve
+          });
+        })
+      );
+    }
+  }
+
+  await Promise.all(movePromises);
+
+  if (inbounderSprite && receiverSprite) {
+    animateInboundPass(scene, ballSprite, ballSpot, oDestinationDict.SF, 0, 500);
+    await new Promise((resolve) => {
+      if (scene.time?.delayedCall) {
+        scene.time.delayedCall(500, resolve);
+      } else {
+        setTimeout(resolve, 500);
+      }
+    });
+    lockBallToPlayer(scene, ballSprite, receiverSprite);
+  }
 }
 
 /**
@@ -218,7 +317,15 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
       }
       const shotResult = await shootBall(shootParams);
       const ballSpot = shotResult?.grid;
-      if (ballSpot) {
+      if (turnData.result_type === "MAKE") {
+        await animateInboundSequence({
+          scene,
+          ballSprite,
+          playerSprites,
+          scoringTeamId: shooterTeamId,
+          homeTeamId: simData.home_team_id
+        });
+      } else if (ballSpot) {
         const rebounderName = turnData.ball_handler?.trim();
         let rebounderId = null;
         if (rebounderName) {

--- a/tests/js/ballManagerStub.mjs
+++ b/tests/js/ballManagerStub.mjs
@@ -2,6 +2,7 @@ export function lockBallToPlayer() {}
 export const calls = [];
 export const SHOT_DEBUG = false;
 export const REBOUND_DEBUG = false;
+export const INBOUND_DEBUG = false;
 export function shootBall(opts) {
   calls.push(opts);
   // return a fake landing spot so rebound logic can run in tests
@@ -9,4 +10,16 @@ export function shootBall(opts) {
 }
 export function animateRebound(opts) {
   calls.push({ type: 'rebound', opts });
+}
+
+export function animateInboundPass(scene, ballSprite, fromCoords, toCoords, startTs, endTs) {
+  calls.push({
+    type: 'inboundPass',
+    scene,
+    ballSprite,
+    fromCoords,
+    toCoords,
+    startTs,
+    endTs
+  });
 }


### PR DESCRIPTION
## Summary
- add INBOUND_DEBUG flag and animateInboundPass helper
- animate inbound baseline sequence after made shots and move players across half
- extend ballManager test stub for inbound pass

## Testing
- `pytest`
- `node --loader tests/js/httpsLoader.mjs tests/js/animateReboundSpacing.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68a0fc5ac6c08328b545e8e1a983ee2f