### PR TITLE
Refresh bracket before lineup screen

### DIFF
--- a/FrontEnd/static/tournament.js
+++ b/FrontEnd/static/tournament.js
@@ -493,6 +493,7 @@ document.addEventListener("DOMContentLoaded", async () => {
           alert('This round has already been played.');
           return;
         }
+        await refreshTeamStats();
         await refreshLeaders();
         const { home, away } = data;
         if (!home || !away) throw new Error('Matchup not found');


### PR DESCRIPTION
## Summary
- Refresh team stats and bracket after starting a round before redirecting to lineup

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1089993708328973264411854e276