### PR TITLE
Fix tournament bracket progression and CTA updates

### DIFF
--- a/BackEnd/api/tournament_routes.py
+++ b/BackEnd/api/tournament_routes.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
+from typing import Optional, Dict
 from BackEnd.db import (
     tournaments_collection,
     teams_collection,
@@ -25,6 +26,7 @@ class TournamentResultRequest(BaseModel):
     tournament_id: str
     game_id: str
     winner: str
+    score: Optional[Dict[str, int]] = None
 
 class SimulateRequest(BaseModel):
     tournament_id: str
@@ -192,7 +194,7 @@ def save_result(request: TournamentResultRequest):
         raise HTTPException(status_code=404, detail="Tournament not found")
 
     round_num = tournament["current_round"]
-    round_key = f"round{round_num}"
+    round_key = "final" if round_num == 3 else f"round{round_num}"
 
     manager = TournamentManager(tournaments_collection=tournaments_collection)
     manager.tournament = tournament
@@ -243,8 +245,13 @@ def save_result(request: TournamentResultRequest):
                 else request.game_id
             )
             summary = games_collection.find_one({"_id": gid}) or {}
+            score_map = (
+                request.score
+                or summary.get("score")
+                or summary.get("final_score")
+            )
             manager.save_game_result(
-                round_key, i, request.game_id, request.winner, summary.get("score")
+                round_key, i, request.game_id, request.winner, score_map
             )
             stat_updater.finalize_game(
                 gid,
@@ -254,7 +261,7 @@ def save_result(request: TournamentResultRequest):
             user_result = {
                 "home_team": home_team,
                 "away_team": away_team,
-                "score": summary.get("score", {}),
+                "score": score_map or {},
                 "winner": request.winner,
                 "round": round_num,
                 "match_index": i,
@@ -276,12 +283,13 @@ def save_result(request: TournamentResultRequest):
                 else match["game_id"]
             )
             summary = games_collection.find_one({"_id": gid}) or {}
+            score_map = summary.get("score") or summary.get("final_score")
             manager.save_game_result(
                 round_key,
                 i,
                 match["game_id"],
                 match["winner"],
-                summary.get("score"),
+                score_map,
             )
             stat_updater.finalize_game(
                 gid,
@@ -291,7 +299,7 @@ def save_result(request: TournamentResultRequest):
             result_doc = {
                 "home_team": match["home_team"],
                 "away_team": match["away_team"],
-                "score": summary.get("score", {}),
+                "score": score_map or {},
                 "winner": match["winner"],
                 "round": round_num,
                 "match_index": i,
@@ -318,13 +326,14 @@ def save_result(request: TournamentResultRequest):
 
         home = match["home_team"]
         away = match["away_team"]
-        winner = home if summary["score"][home] > summary["score"][away] else away
-        manager.save_game_result(round_key, i, str(game_id), winner, summary.get("score"))
+        score_map = summary.get("score") or summary.get("final_score")
+        winner = home if score_map[home] > score_map[away] else away
+        manager.save_game_result(round_key, i, str(game_id), winner, score_map)
 
         result_doc = {
             "home_team": home,
             "away_team": away,
-            "score": summary.get("score", {}),
+            "score": score_map or {},
             "winner": winner,
             "round": round_num,
             "match_index": i,
@@ -415,10 +424,11 @@ def sim_remaining(request: SimulateRequest):
                         mode="tournament",
                         tournament_id=request.tournament_id,
                     )
+                    score_map = summary.get("score") or summary.get("final_score")
                     result_doc = {
                         "home_team": match["home_team"],
                         "away_team": match["away_team"],
-                        "score": summary.get("score", {}),
+                        "score": score_map or {},
                         "winner": match.get("winner"),
                         "round": round_num,
                         "match_index": i,
@@ -437,11 +447,12 @@ def sim_remaining(request: SimulateRequest):
             home = match["home_team"]
             away = match["away_team"]
             winner = home if summary["score"][home] > summary["score"][away] else away
-            manager.save_game_result(round_key, i, str(game_id), winner, summary.get("score"))
+            score_map = summary.get("score") or summary.get("final_score")
+            manager.save_game_result(round_key, i, str(game_id), winner, score_map)
             result_doc = {
                 "home_team": home,
                 "away_team": away,
-                "score": summary.get("score", {}),
+                "score": score_map or {},
                 "winner": winner,
                 "round": round_num,
                 "match_index": i,

--- a/FrontEnd/static/js/phaser/finalizeGame.js
+++ b/FrontEnd/static/js/phaser/finalizeGame.js
@@ -4,9 +4,13 @@ export async function finalizeGame({ simData, tournamentId, franchiseId, game })
   // Extract score and winner
   const homeTeamObj = simData.homeTeam || { name: simData.home_team };
   const awayTeamObj = simData.awayTeam || { name: simData.away_team };
-  const scoreMap = simData.final_score || simData.score || {};
-  const homeScore = homeTeamObj.score ?? scoreMap[homeTeamObj.name] ?? 0;
-  const awayScore = awayTeamObj.score ?? scoreMap[awayTeamObj.name] ?? 0;
+  const rawScoreMap = simData.final_score || simData.score || {};
+  const homeScore = homeTeamObj.score ?? rawScoreMap[homeTeamObj.name] ?? 0;
+  const awayScore = awayTeamObj.score ?? rawScoreMap[awayTeamObj.name] ?? 0;
+  const scoreMap = {
+    [homeTeamObj.name]: homeScore,
+    [awayTeamObj.name]: awayScore,
+  };
   const winner = homeScore > awayScore ? homeTeamObj.name : awayTeamObj.name;
   const params = new URLSearchParams(window.location.search);
   let week = parseInt(params.get('week'), 10);
@@ -33,6 +37,7 @@ export async function finalizeGame({ simData, tournamentId, franchiseId, game })
           tournament_id: tournamentId,
           game_id: simData.game_id || simData._id,
           winner: winner,
+          score: scoreMap,
         }),
       });
       if (!res.ok) {

--- a/FrontEnd/static/tournament.js
+++ b/FrontEnd/static/tournament.js
@@ -61,8 +61,8 @@ function renderBracket() {
   bracket.innerHTML = "";
 
   const round1 = tournament.bracket?.round1 || [];
-  const round2 = tournament.bracket?.round2 || [];
-  const finalRound = tournament.bracket?.final || [];
+  let round2 = tournament.bracket?.round2 || [];
+  let finalRound = tournament.bracket?.final || [];
   const results = tournament.results || [];
 
   const seedMap = {};
@@ -80,6 +80,37 @@ function renderBracket() {
   function getResult(round, index) {
     return results.find(r => r.round === round && r.match_index === index) || null;
   }
+
+  // Derive next-round matchups from results if bracket slots are missing
+  if (!round2.length) {
+    const r1Winners = round1
+      .map((m, i) => m.winner ?? getResult(1, i)?.winner)
+      .filter(Boolean);
+    if (r1Winners.length === 4) {
+      round2 = [
+        { home_team: r1Winners[0], away_team: r1Winners[1], game_id: null, winner: null, score: {} },
+        { home_team: r1Winners[2], away_team: r1Winners[3], game_id: null, winner: null, score: {} },
+      ];
+      tournament.bracket.round2 = round2;
+      if (tournament.current_round < 2) tournament.current_round = 2;
+    }
+  }
+
+  if (!finalRound.length && round2.length === 2) {
+    const r2Winners = round2
+      .map((m, i) => m.winner ?? getResult(2, i)?.winner)
+      .filter(Boolean);
+    if (r2Winners.length === 2) {
+      finalRound = [
+        { home_team: r2Winners[0], away_team: r2Winners[1], game_id: null, winner: null, score: {} },
+      ];
+      tournament.bracket.final = finalRound;
+      if (tournament.current_round < 3) tournament.current_round = 3;
+    }
+  }
+
+  // persist any derived bracket updates
+  localStorage.setItem("activeTournament", JSON.stringify(tournament));
 
   if (DEBUG_BRACKET) {
     console.log("[DebugBracket] renderBracket", {


### PR DESCRIPTION
## Summary
- post final user game scores when saving tournament results so bracket shows them
- allow `/tournament/save-result` to accept an explicit score map

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a11d520e648328ab8a4b65e07dc866