### PR TITLE
feat: persist user provided tournament scores

### DIFF
--- a/BackEnd/api/tournament_routes.py
+++ b/BackEnd/api/tournament_routes.py
@@ -25,6 +25,7 @@ class TournamentResultRequest(BaseModel):
     tournament_id: str
     game_id: str
     winner: str
+    score: dict[str, int] | None = None
 
 class SimulateRequest(BaseModel):
     tournament_id: str
@@ -243,7 +244,11 @@ def save_result(request: TournamentResultRequest):
                 else request.game_id
             )
             summary = games_collection.find_one({"_id": gid}) or {}
-            score_map = summary.get("score") or summary.get("final_score")
+            score_map = (
+                summary.get("score")
+                or summary.get("final_score")
+                or request.score
+            )
             manager.save_game_result(
                 round_key, i, request.game_id, request.winner, score_map
             )

--- a/FrontEnd/static/js/phaser/finalizeGame.js
+++ b/FrontEnd/static/js/phaser/finalizeGame.js
@@ -33,6 +33,10 @@ export async function finalizeGame({ simData, tournamentId, franchiseId, game })
           tournament_id: tournamentId,
           game_id: simData.game_id || simData._id,
           winner: winner,
+          score: {
+            [homeTeamObj.name]: homeScore,
+            [awayTeamObj.name]: awayScore,
+          },
         }),
       });
       if (!res.ok) {

--- a/tests/test_tournament_save_results.py
+++ b/tests/test_tournament_save_results.py
@@ -51,3 +51,57 @@ def test_save_result_simulates_remaining_games(monkeypatch):
     assert "results" in updated
     assert len(updated["results"]) == 4
     assert any(r["match_index"] == user_index and r["winner"] == "A" for r in updated["results"])
+
+
+def test_save_result_uses_request_score(monkeypatch):
+    tournaments_collection.delete_many({})
+    games_collection.delete_many({})
+
+    manager = TournamentManager(
+        user_team_id="A",
+        tournaments_collection=tournaments_collection,
+        team_ids=["A", "B", "C", "D", "E", "F", "G", "H"],
+    )
+    tournament = manager.create_tournament()
+    tid = ObjectId(tournament["_id"])
+
+    round1 = tournament["bracket"]["round1"]
+    for idx, match in enumerate(round1):
+        if "A" in (match["home_team"], match["away_team"]):
+            user_index = idx
+            home = match["home_team"]
+            away = match["away_team"]
+            break
+
+    # insert game summary without score so request.score is used
+    game_id = games_collection.insert_one({}).inserted_id
+
+    def fake_run_simulation(h, a):
+        return {"home": h, "away": a}
+
+    def fake_summarize_game_state(game):
+        h = game["home"]
+        a = game["away"]
+        return {"score": {h: 1, a: 0}}
+
+    monkeypatch.setattr("BackEnd.api.tournament_routes.run_simulation", fake_run_simulation)
+    monkeypatch.setattr("BackEnd.api.tournament_routes.summarize_game_state", fake_summarize_game_state)
+
+    score_payload = {
+        home: 70 if home == "A" else 65,
+        away: 70 if away == "A" else 65,
+    }
+
+    req = TournamentResultRequest(
+        tournament_id=str(tid),
+        game_id=str(game_id),
+        winner="A",
+        score=score_payload,
+    )
+    save_result(req)
+
+    updated = tournaments_collection.find_one({"_id": tid})
+    match_doc = updated["bracket"]["round1"][user_index]
+    assert match_doc["score"] == score_payload
+    result_doc = next(r for r in updated["results"] if r["match_index"] == user_index)
+    assert result_doc["score"] == score_payload


### PR DESCRIPTION
## Summary
- accept optional score map in `TournamentResultRequest`
- use request-provided scores when saving tournament results
- send final score from front-end finalizeGame call
- test that user supplied scores persist in bracket and results

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a12d9e228c832893936bf45f4886cb