### PR TITLE
Align tournament score keys with bracket identifiers

### DIFF
--- a/FrontEnd/static/js/phaser/finalizeGame.js
+++ b/FrontEnd/static/js/phaser/finalizeGame.js
@@ -5,9 +5,13 @@ export async function finalizeGame({ simData, tournamentId, franchiseId, game })
   const homeTeamObj = simData.homeTeam || { name: simData.home_team };
   const awayTeamObj = simData.awayTeam || { name: simData.away_team };
   const scoreMap = simData.final_score || simData.score || {};
-  const homeScore = homeTeamObj.score ?? scoreMap[homeTeamObj.name] ?? 0;
-  const awayScore = awayTeamObj.score ?? scoreMap[awayTeamObj.name] ?? 0;
-  const winner = homeScore > awayScore ? homeTeamObj.name : awayTeamObj.name;
+  const homeKey = simData.home_team || homeTeamObj.name;
+  const awayKey = simData.away_team || awayTeamObj.name;
+  const homeScore =
+    homeTeamObj.score ?? scoreMap[homeKey] ?? scoreMap[homeTeamObj.name] ?? 0;
+  const awayScore =
+    awayTeamObj.score ?? scoreMap[awayKey] ?? scoreMap[awayTeamObj.name] ?? 0;
+  const winner = homeScore > awayScore ? homeKey : awayKey;
   const params = new URLSearchParams(window.location.search);
   let week = parseInt(params.get('week'), 10);
   const homeIdParam = params.get('home_id');
@@ -34,8 +38,8 @@ export async function finalizeGame({ simData, tournamentId, franchiseId, game })
           game_id: simData.game_id || simData._id,
           winner: winner,
           score: {
-            [homeTeamObj.name]: homeScore,
-            [awayTeamObj.name]: awayScore,
+            [homeKey]: homeScore,
+            [awayKey]: awayScore,
           },
         }),
       });

--- a/tests/test_render_bracket_scores.py
+++ b/tests/test_render_bracket_scores.py
@@ -1,0 +1,75 @@
+import json
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+def test_render_bracket_displays_scores():
+    js_path = Path('FrontEnd/static/tournament.js').resolve()
+    node_template = """
+    const fs = require('fs');
+    const vm = require('vm');
+    const code = fs.readFileSync(__PATH__, 'utf8');
+    const script = code;
+    const originalLog = console.log;
+    console.log = () => {};
+    global.window = { DEBUG_BRACKET: false };
+    global.formatTeamName = (n) => n;
+    const tournamentData = {
+      bracket: {
+        round1: [
+          {home_team:'Alpha', away_team:'Bravo', game_id:null, winner:'Alpha', score:{Alpha:70, Bravo:65}},
+          {home_team:'Charlie', away_team:'Delta', game_id:null, winner:'Delta', score:{Charlie:60, Delta:80}},
+          {home_team:'Echo', away_team:'Foxtrot', game_id:null, winner:'Foxtrot', score:{Echo:55, Foxtrot:85}},
+          {home_team:'Golf', away_team:'Hotel', game_id:null, winner:'Golf', score:{Golf:75, Hotel:72}}
+        ],
+        round2: [],
+        final: []
+      },
+      results: [
+        {round:1, match_index:0, home_team:'Alpha', away_team:'Bravo', score:{Alpha:70,Bravo:65}, winner:'Alpha'},
+        {round:1, match_index:1, home_team:'Charlie', away_team:'Delta', score:{Charlie:60,Delta:80}, winner:'Delta'},
+        {round:1, match_index:2, home_team:'Echo', away_team:'Foxtrot', score:{Echo:55,Foxtrot:85}, winner:'Foxtrot'},
+        {round:1, match_index:3, home_team:'Golf', away_team:'Hotel', score:{Golf:75,Hotel:72}, winner:'Golf'}
+      ],
+      current_round:2
+    };
+    global.localStorage = { getItem: () => JSON.stringify(tournamentData), setItem: () => null };
+    const bracketEl = {
+        children: [],
+        style: {},
+        appendChild(child) { this.children.push(child); },
+        set innerHTML(v) { this.children = []; }
+    };
+    global.document = {
+      getElementById(id) { return bracketEl; },
+      addEventListener() {},
+      createElement(tag) { const el = {
+         tagName: tag,
+         className: '',
+         style: {},
+         children: [],
+         appendChild(child) { this.children.push(child); },
+         set textContent(v) { this._text = v; },
+         get textContent() { return this._text; },
+         set innerHTML(v) { this._innerHTML = v; },
+         get innerHTML() { return this._innerHTML || ''; }
+      }; el.classList = { add(cls){ el.className += (el.className ? ' ' : '') + cls; } }; return el; }
+    };
+    vm.runInThisContext(script);
+    renderBracket();
+    const scores = [];
+    function collect(node) {
+        if(node.className && node.className.includes('score') && node.textContent !== undefined){
+            scores.push(node.textContent);
+        }
+        if(node.children) node.children.forEach(collect);
+    }
+    bracketEl.children.forEach(collect);
+    console.log = originalLog;
+    console.log(JSON.stringify(scores));
+    """
+    node_script = textwrap.dedent(node_template).replace('__PATH__', json.dumps(str(js_path)))
+    result = subprocess.check_output(['node', '-e', node_script])
+    scores = json.loads(result.decode().strip())
+    assert 70 in scores and 65 in scores

--- a/tests/test_tournament_state_scores.py
+++ b/tests/test_tournament_state_scores.py
@@ -1,0 +1,42 @@
+from bson import ObjectId
+from BackEnd.tournament.tournament_manager import TournamentManager
+from BackEnd.api.tournament_routes import save_result, tournament_state, TournamentResultRequest
+from BackEnd.db import tournaments_collection, games_collection
+
+
+def test_tournament_state_includes_scores(monkeypatch):
+    tournaments_collection.delete_many({})
+    games_collection.delete_many({})
+
+    manager = TournamentManager(
+        user_team_id="A",
+        tournaments_collection=tournaments_collection,
+        team_ids=["A", "B", "C", "D", "E", "F", "G", "H"],
+    )
+    tournament = manager.create_tournament()
+    tid = ObjectId(tournament["_id"])
+
+    round1 = tournament["bracket"]["round1"]
+    for idx, match in enumerate(round1):
+        if "A" in (match["home_team"], match["away_team"]):
+            user_index = idx
+            home = match["home_team"]
+            away = match["away_team"]
+            break
+
+    score_payload = {home: 75, away: 70}
+    game_id = games_collection.insert_one({}).inserted_id
+
+    req = TournamentResultRequest(
+        tournament_id=str(tid),
+        game_id=str(game_id),
+        winner=home,
+        score=score_payload,
+    )
+    save_result(req)
+
+    state = tournament_state(str(tid))
+    result_doc = next(r for r in state["results"] if r["match_index"] == user_index)
+    assert result_doc["score"] == score_payload
+    match_doc = state["bracket"]["round1"][user_index]
+    assert match_doc["score"] == score_payload


### PR DESCRIPTION
## Summary
- ensure `finalizeGame` posts tournament results using `simData.home_team` and `simData.away_team` keys
- add tests confirming tournament state and bracket rendering include saved scores

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a1cd301b108328ae6372a18b911db8