### PR TITLE
Handle ObjectId serialization in tournament state

### DIFF
--- a/BackEnd/api/tournament_routes.py
+++ b/BackEnd/api/tournament_routes.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, HTTPException
+from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel
 from BackEnd.db import (
     tournaments_collection,
@@ -356,8 +357,7 @@ def tournament_state(tournament_id: str):
     doc = tournaments_collection.find_one({"_id": tid})
     if not doc:
         raise HTTPException(status_code=404, detail="Tournament not found")
-    doc["_id"] = str(doc["_id"])
-    return doc
+    return jsonable_encoder(doc, custom_encoder={ObjectId: str})
 
 
 @router.post("/tournament/sim-remaining")

--- a/tests/test_tournament_state_applied_games.py
+++ b/tests/test_tournament_state_applied_games.py
@@ -1,0 +1,23 @@
+from fastapi.testclient import TestClient
+from bson import ObjectId
+
+from BackEnd.api.api import app
+from BackEnd.db import tournaments_collection
+
+
+client = TestClient(app)
+
+
+def setup_function(fn):
+    tournaments_collection.delete_many({})
+
+
+def test_tournament_state_casts_applied_games_to_strings():
+    oid = ObjectId()
+    tid = tournaments_collection.insert_one({"applied_games": [oid]}).inserted_id
+
+    resp = client.get(f"/tournament/state/{tid}")
+    assert resp.status_code == 200
+
+    payload = resp.json()
+    assert payload["applied_games"] == [str(oid)]


### PR DESCRIPTION
## Summary
- ensure tournament_state endpoint encodes Mongo ObjectIds as strings
- add regression test for applied_games ObjectId serialization

## Testing
- `pytest tests/test_tournament_state_applied_games.py -q`
- `pytest tests/test_tournament_state_scores.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1d55040bc8328a9056ceae215dbae