### PR TITLE
Disable repeated tournament simulation

### DIFF
--- a/FrontEnd/static/tournament.js
+++ b/FrontEnd/static/tournament.js
@@ -559,7 +559,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         alert('Tournament not loaded');
         return;
       }
-      if (simBtn.disabled) return;
+      if (tournament.completed || simBtn.disabled) return;
       console.log('#sim-remaining click start');
       simBtn.disabled = true;
       try {
@@ -583,7 +583,6 @@ document.addEventListener("DOMContentLoaded", async () => {
       } catch (err) {
         console.error('Failed to simulate remaining games', err);
         alert('Unable to simulate remaining games');
-      } finally {
         simBtn.disabled = false;
       }
     });


### PR DESCRIPTION
## Summary
- Prevent `Sim Remaining` button from firing when tournament is completed or a request is already running
- Only re-enable the button on error so successful simulations can't be triggered twice

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1df454b748328b33571cd72b5eddb