### PR TITLE
Use team IDs for inbound animation

### DIFF
--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -94,11 +94,12 @@ async function animateInboundSequence({
   ballSprite,
   playerSprites,
   scoringTeamId,
-  homeTeamId
+  homeTeamId,
+  awayTeamId
 }) {
   scene.isInboundSetup = true;
   const isHomeScoring = scoringTeamId === homeTeamId;
-  const inboundTeamId = isHomeScoring ? "AWAY" : "HOME";
+  const inboundTeamId = isHomeScoring ? awayTeamId : homeTeamId;
   const ballSpot = isHomeScoring ? { x: 98, y: 16 } : { x: 3, y: 16 };
 
   const width = scene.game.config.width;
@@ -337,7 +338,8 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
           ballSprite,
           playerSprites,
           scoringTeamId: shooterTeamId,
-          homeTeamId: simData.home_team_id
+          homeTeamId: simData.home_team_id,
+          awayTeamId: simData.away_team_id
         });
       } else if (ballSpot) {
         const rebounderName = turnData.ball_handler?.trim();


### PR DESCRIPTION
## Summary
- Drive inbound sequence using actual home and away team IDs instead of hard-coded labels.
- Tween only the small forward of the inbounding team to the ball spot and freeze other players.
- Pass away team ID when invoking `animateInboundSequence` after a made basket.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1df86e8bc8328ad34c68cb61cf35a