### PR TITLE
Use tournament results to show winners

### DIFF
--- a/FrontEnd/static/tournament.css
+++ b/FrontEnd/static/tournament.css
@@ -302,7 +302,8 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 /* --- Bracket State Styles --- */
-.winner {
+/* Highlight winning team entries in every round with a green outline */
+.team-entry.winner {
   outline: 3px solid #00e676;
 }
 

--- a/FrontEnd/static/tournament.js
+++ b/FrontEnd/static/tournament.js
@@ -179,19 +179,14 @@ function renderBracket() {
     const matchup = document.createElement("div");
     matchup.className = "matchup";
 
-    // Pull score/winner primarily from tournament.results to ensure
-    // consistency for both user-simmed and computer-simmed games. If no
-    // result exists, fall back to any data stored directly on the matchup.
-    const res = getResult(round, index) || {};
-    let homeScore = res.score ? res.score[m.home_team] : undefined;
-    let awayScore = res.score ? res.score[m.away_team] : undefined;
-    let winner = res.winner;
-
-    if (homeScore == null || awayScore == null || winner == null) {
-      homeScore = homeScore ?? (m.score ? m.score[m.home_team] : null);
-      awayScore = awayScore ?? (m.score ? m.score[m.away_team] : null);
-      winner = winner ?? m.winner ?? null;
-    }
+    // Always prefer results pulled from ``tournament.results`` so the
+    // bracket reflects finalized scores, even after the tournament is
+    // completed.  Fall back to any score/winner information stored
+    // directly on the matchup if results have not yet been recorded.
+    const res = getResult(round, index);
+    const homeScore = res?.score?.[m.home_team] ?? m.score?.[m.home_team];
+    const awayScore = res?.score?.[m.away_team] ?? m.score?.[m.away_team];
+    const winner = res?.winner ?? m.winner ?? null;
 
     if (side === "center") {
       matchup.appendChild(createTeamEntry(m.home_team, "left", homeScore, winner === m.home_team));


### PR DESCRIPTION
## Summary
- Prefer `tournament.results` when rendering bracket matchups and add a `winner` class to victorious team entries
- Style `.team-entry.winner` with the green outline so winners stand out in every round

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1e0a78b388328a5b1434d8b8222a7