### PR TITLE
Reset tweens during inbound setup and keep ball above players

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -10,6 +10,7 @@ export const INBOUND_DEBUG = false;
 // Hoop locations in grid coordinates for each team
 const HOME_RIM_COORDS = { x: 91, y: 25 };
 const AWAY_RIM_COORDS = { x: 9, y: 25 };
+const BALL_SPRITE_DEPTH = 1000;
 
 export function lockBallToPlayer(scene, ballSprite, playerSprite) {
   if (!ballSprite || !playerSprite) {
@@ -30,8 +31,8 @@ export function lockBallToPlayer(scene, ballSprite, playerSprite) {
   ballSprite.setPosition(x, y);
   ballSprite.setVisible(true);
 
-  if (typeof playerSprite.depth === "number" && ballSprite.setDepth) {
-    ballSprite.setDepth(playerSprite.depth + 1);
+  if (ballSprite.setDepth) {
+    ballSprite.setDepth(BALL_SPRITE_DEPTH);
   }
 
   // Track final ball owner on the scene if possible

--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -164,6 +164,7 @@ async function runInboundSetup({
   if (scene.tweens) {
     scene.tweens.killTweensOf(ballSprite);
     scene.tweens.killTweensOf(sfSprite);
+    scene.tweens.killTweensOf(pgSprite);
   }
 
   ballSprite.setPosition(rimPx.x, rimPx.y);
@@ -199,6 +200,11 @@ async function runInboundSetup({
   scene.ballAttachedToPlayerId = sfId;
 
   await new Promise((resolve) => scene.time.delayedCall(1000, resolve));
+
+  if (scene.tweens) {
+    scene.tweens.killTweensOf(ballSprite);
+    scene.tweens.killTweensOf(pgSprite);
+  }
 
   await new Promise((resolve) => {
     scene.tweens.add({


### PR DESCRIPTION
## Summary
- Kill existing tweens on inbound ball, SF, and PG to prevent lingering animations
- Always set ball sprite depth high when attaching to a player

## Testing
- `pytest -q`
- `node tests/js/runPlayTurnAnimation.mjs` *(fails: ERR_UNSUPPORTED_ESM_URL_SCHEME)*
- `node tests/js/runShootBall.mjs` *(fails: ERR_UNSUPPORTED_ESM_URL_SCHEME)*
- `node tests/js/runReboundAnimation.mjs` *(fails: ERR_UNSUPPORTED_ESM_URL_SCHEME)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e9712f288328bbb17ca1ec9553dd