### PR TITLE
Avoid simulating after tournament ends

### DIFF
--- a/FrontEnd/static/tournament.js
+++ b/FrontEnd/static/tournament.js
@@ -369,6 +369,7 @@ function updateCTA() {
   if (tournament.completed) {
     playBtn.style.display = 'none';
     simBtn.style.display = 'none';
+    simBtn.disabled = true;
     container.style.display = 'none';
     exitBtn.style.display = 'inline-block';
     opponentEl.textContent = '';
@@ -388,6 +389,7 @@ function updateCTA() {
     playBtn.style.display = 'none';
     opponentEl.textContent = '';
     simBtn.style.display = 'inline-block';
+    simBtn.disabled = false;
     return;
   }
 
@@ -396,10 +398,12 @@ function updateCTA() {
     playBtn.style.display = 'inline-flex';
     opponentEl.textContent = `vs ${opponent}`;
     simBtn.style.display = 'none';
+    simBtn.disabled = true;
   } else {
     playBtn.style.display = 'none';
     opponentEl.textContent = '';
     simBtn.style.display = 'inline-block';
+    simBtn.disabled = false;
   }
 }
 
@@ -570,13 +574,14 @@ document.addEventListener("DOMContentLoaded", async () => {
   if (simBtn) {
     simBtn.addEventListener('click', async () => {
       if (simBtn.disabled) return;
-      simBtn.disabled = true;
-      if (!tournament || !tournament._id) {
+      if (!tournament) {
         alert('Tournament not loaded');
-        simBtn.disabled = false;
         return;
       }
-      if (tournament.completed) {
+      if (tournament.completed) return;
+      simBtn.disabled = true;
+      if (!tournament._id) {
+        alert('Tournament not loaded');
         simBtn.disabled = false;
         return;
       }


### PR DESCRIPTION
## Summary
- Stop the "Sim Remaining" button from running after a tournament is completed by returning early in its click handler.
- Disable and hide the simulation button when the tournament finishes, resetting the button's state appropriately in `updateCTA`.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1ec233b1c8328997739b34243ca1d