### PR TITLE
Normalize team ID comparison for inbound setup

### DIFF
--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -382,8 +382,9 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
       const shotResult = await shootBall(shootParams);
       const ballSpot = shotResult?.grid;
       if (turnData.result_type === "MAKE") {
-        const newOffenseSide =
-          shooterTeamId === simData.home_team_id ? "away" : "home";
+        const shooterTeamIsHome =
+          String(shooterTeamId) === String(simData.home_team_id);
+        const newOffenseSide = shooterTeamIsHome ? "away" : "home";
         await runInboundSetup({
           scene,
           ballSprite,


### PR DESCRIPTION
## Summary
- Compare shooter and home team IDs as strings before deciding inbound side
- Use derived offense side when setting up inbound after made baskets

## Testing
- `node --experimental-loader=./t/js/httpsLoader.mjs ./inb.mjs`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a1fb1e0c5483289bf795e4efabd275