### PR TITLE
Handle missing away team ID in animations

### DIFF
--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -99,6 +99,20 @@ async function runInboundSetup({
 }) {
   scene.isInboundSetup = true;
   const isAwayOffense = newOffenseSide === "away";
+
+  // Derive missing team IDs from sprite metadata
+  if (!homeTeamId || !awayTeamId) {
+    const sprites = Object.values(playerSprites);
+    if (!homeTeamId) {
+      homeTeamId = sprites.find(s => s.team === "home")?.team_id;
+    }
+    if (!awayTeamId) {
+      awayTeamId = sprites.find(s => s.team === "away")?.team_id;
+    }
+  }
+
+  const inboundTeamKey = isAwayOffense ? "away" : "home";
+  const scoringTeamKey = isAwayOffense ? "home" : "away";
   const inboundTeamId = isAwayOffense ? awayTeamId : homeTeamId;
   const scoringTeamId = isAwayOffense ? homeTeamId : awayTeamId;
   const ballSpot = isAwayOffense ? { x: 98, y: 16 } : { x: 3, y: 16 };
@@ -111,7 +125,10 @@ async function runInboundSetup({
   for (const [id, sprite] of Object.entries(playerSprites)) {
     const info = scene.playerInfo?.[id];
     if (!info) continue;
-    if (sprite.team_id === scoringTeamId) {
+    if (
+      sprite.team_id === scoringTeamId ||
+      (!scoringTeamId && sprite.team === scoringTeamKey)
+    ) {
       const targetX = gridToPixels(
         isAwayOffense ? 45 : 55,
         25,
@@ -141,7 +158,12 @@ async function runInboundSetup({
   let pgId = null;
   for (const [id, sprite] of Object.entries(playerSprites)) {
     const info = scene.playerInfo?.[id];
-    if (!info || sprite.team_id !== inboundTeamId) continue;
+    if (
+      !info ||
+      (sprite.team_id !== inboundTeamId &&
+        !(inboundTeamId === undefined && sprite.team === inboundTeamKey))
+    )
+      continue;
     if (info.pos === "SF") {
       sfSprite = sprite;
       sfId = id;
@@ -263,6 +285,14 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
     ballSprite.setVisible(false);
   }
 
+  const homeTeamId = simData.home_team_id;
+  let awayTeamId = simData.away_team_id;
+  if (!awayTeamId) {
+    const awaySprite = Object.values(playerSprites).find(s => s.team === "away");
+    awayTeamId = awaySprite?.team_id;
+    if (awayTeamId) simData.away_team_id = awayTeamId;
+  }
+
   // Determine which player owns the ball at step 0
   let step0OwnerSprite = null;
   for (const anim of turnData.animations) {
@@ -373,7 +403,7 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
         shooterPos,
         shooterId: shotInfo.playerId,
         shooterTeamId,
-        homeTeamId: simData.home_team_id
+        homeTeamId
       };
       if (SHOT_DEBUG) {
         shootParams.stepIndex = shotInfo.stepIndex;
@@ -383,15 +413,15 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
       const ballSpot = shotResult?.grid;
       if (turnData.result_type === "MAKE") {
         const shooterTeamIsHome =
-          String(shooterTeamId) === String(simData.home_team_id);
+          String(shooterTeamId) === String(homeTeamId);
         const newOffenseSide = shooterTeamIsHome ? "away" : "home";
         await runInboundSetup({
           scene,
           ballSprite,
           playerSprites,
           newOffenseSide,
-          homeTeamId: simData.home_team_id,
-          awayTeamId: simData.away_team_id
+          homeTeamId,
+          awayTeamId
         });
       } else if (ballSpot) {
         const rebounderName = turnData.ball_handler?.trim();

--- a/tests/js/runPlayTurnAnimation.mjs
+++ b/tests/js/runPlayTurnAnimation.mjs
@@ -19,7 +19,8 @@ function createScene() {
 }
 
 function createSprite(team_id) {
-  return { x: 0, y: 0, team_id, setPosition() {}, setVisible() {} };
+  const team = team_id === 'HOME' ? 'home' : 'away';
+  return { x: 0, y: 0, team_id, team, setPosition() {}, setVisible() {} };
 }
 
 async function runCase(startingTeamId) {
@@ -41,7 +42,7 @@ async function runCase(startingTeamId) {
       hasBallAtStep: [true, true]
     }]
   };
-  const simData = { home_team_id: 'HOME' };
+  const simData = { home_team_id: 'HOME', away_team_id: 'AWAY' };
   await playTurnAnimation({ scene, simData, playerSprites, turnData, ballSprite });
   return calls[0].shooterTeamId === calls[0].homeTeamId;
 }

--- a/tests/js/runReboundAnimation.mjs
+++ b/tests/js/runReboundAnimation.mjs
@@ -20,7 +20,8 @@ function createScene() {
 }
 
 function createSprite(team_id) {
-  return { x: 0, y: 0, team_id, setPosition() {}, setVisible() {} };
+  const team = team_id === 'HOME' ? 'home' : 'away';
+  return { x: 0, y: 0, team_id, team, setPosition() {}, setVisible() {} };
 }
 
 const scene = createScene();
@@ -41,7 +42,7 @@ const turnData = {
     hasBallAtStep: [true, true]
   }]
 };
-const simData = { home_team_id: 'HOME' };
+const simData = { home_team_id: 'HOME', away_team_id: 'AWAY' };
 
 await playTurnAnimation({ scene, simData, playerSprites, turnData, ballSprite });
 const shootOpts = calls.find(c => !c.type);


### PR DESCRIPTION
## Summary
- Derive `away_team_id` in `playTurnAnimation` when not provided
- Guard `runInboundSetup` against missing team IDs using sprite metadata
- Update JS tests to supply away team IDs and team tags

## Testing
- `node --experimental-loader ./tests/js/httpsLoader.mjs tests/js/runPlayTurnAnimation.mjs`
- `node --experimental-loader ./tests/js/httpsLoader.mjs tests/js/runReboundAnimation.mjs`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a20762e128832882beac8ecc4f1ea9