### PR TITLE
Implement single-step offensive rebound resolution

### DIFF
--- a/BackEnd/engine/phase_resolution.py
+++ b/BackEnd/engine/phase_resolution.py
@@ -18,8 +18,8 @@ from BackEnd.utils.shared import (
     get_fast_break_chance, 
     calculate_rebound_score, 
     choose_rebounder, 
-    default_rebounder_dict, 
-    resolve_offensive_rebound_loop,
+    default_rebounder_dict,
+    resolve_offensive_rebound,
     record_team_points,
     unpack_game_context
 )
@@ -304,10 +304,32 @@ def resolve_free_throw_logic(game):
                 if random.random() < get_fast_break_chance(game):
                     game_state["offensive_state"] = "FAST_BREAK"
             else:
-                # 🟡 Offensive rebound → putback loop
-                result = resolve_offensive_rebound_loop(game, rebounder)
-                result["shooter"] = shooter
-                return result
+                # Offensive rebound handling
+                off_event = resolve_offensive_rebound(game, rebounder)
+                if off_event["event_type"] == "PUTBACK_ATTEMPT":
+                    text += f" {get_name_safe(rebounder)} goes back up."
+                    result = {
+                        "result_type": "MAKE" if off_event["result"] == "MAKE" else "MISS",
+                        "ball_handler": rebounder,
+                        "shooter": rebounder,
+                        "text": text,
+                        "time_elapsed": off_event["timeElapsed"],
+                        "possession_flips": off_event.get("possession_flips", False),
+                    }
+                    if off_event["result"] == "MAKE":
+                        result["points"] = off_event.get("points", 2)
+                        result["scoring_team"] = off_team.name
+                    return result
+                else:
+                    text += f" {get_name_safe(rebounder)} kicks it out to reset."
+                    return {
+                        "result_type": "MISS",
+                        "ball_handler": rebounder,
+                        "shooter": shooter,
+                        "text": text,
+                        "time_elapsed": off_event["timeElapsed"],
+                        "possession_flips": False,
+                    }
         else:
             possession_flips = True
 

--- a/BackEnd/main.py
+++ b/BackEnd/main.py
@@ -24,7 +24,7 @@ from BackEnd.utils.shared import (
     get_fast_break_chance,
     get_time_elapsed,
     apply_help_defense_if_triggered,
-    resolve_offensive_rebound_loop,
+    resolve_offensive_rebound,
     weighted_random_from_dict,
     generate_pass_chain,
     get_name_safe,

--- a/BackEnd/models/shot_manager.py
+++ b/BackEnd/models/shot_manager.py
@@ -6,10 +6,10 @@ from BackEnd.constants import (
     AGGRESSION_FOUL_MULTIPLIER
 )
 from BackEnd.utils.shared import (
-    apply_help_defense_if_triggered, 
-    get_fast_break_chance, 
-    get_time_elapsed, 
-    resolve_offensive_rebound_loop,
+    apply_help_defense_if_triggered,
+    get_fast_break_chance,
+    get_time_elapsed,
+    resolve_offensive_rebound,
     get_player_position,
     record_team_points,
     calculate_screen_score,
@@ -34,6 +34,7 @@ class ShotManager:
         game_state, off_team, def_team, off_lineup, def_lineup = unpack_game_context(self.game)
         
         time_elapsed = 0
+        events = []
 
         shooter = roles["shooter"]
         passer = roles.get("passer", "")
@@ -155,18 +156,28 @@ class ShotManager:
                 possession_flips = rebound_team != off_team
 
                 if stat == "OREB":
-                    if random.random() < 0.65:
-                        text += "... he attempts the putback..."
-                        putback_result = resolve_offensive_rebound_loop(self.game, rebounder)
-                        text += putback_result["text"]
-                        possession_flips = putback_result["possession_flips"]
-                        time_elapsed += putback_result["time_elapsed"]
-                        if "points" in putback_result:
+                    events.append({"event_type": "offReb", "rebounderId": getattr(rebounder, "player_id", None)})
+                    self.game.turn_manager.logger.log("offReb")
+                    rebound_event = resolve_offensive_rebound(self.game, rebounder)
+                    events.append(rebound_event)
+                    time_elapsed += rebound_event.get("timeElapsed", 0)
+
+                    if rebound_event["event_type"] == "PUTBACK_ATTEMPT":
+                        self.game.turn_manager.logger.log("putbackStart")
+                        self.game.turn_manager.logger.log(rebound_event["result"].lower())
+                        if rebound_event["result"] == "MAKE":
                             shooter = rebounder
                             made = True
-                            points = putback_result["points"]
+                            points = rebound_event.get("points", 2)
+                            text += f" {get_name_safe(rebounder)} puts it back in."
+                            possession_flips = True
+                        else:
+                            text += f" {get_name_safe(rebounder)} misses the putback."
+                            possession_flips = rebound_event.get("possession_flips", possession_flips)
                     else:
-                        text += "...and he kicks it back out to reset the half-court offense"
+                        self.game.turn_manager.logger.log("kickoutStart")
+                        text += f" {get_name_safe(rebounder)} kicks it out to reset." 
+                        possession_flips = rebound_event.get("possession_flips", possession_flips)
                 else:
                     self.game_state["last_rebounder"] = rebounder
                     self.game_state["offensive_state"] = (
@@ -189,7 +200,8 @@ class ShotManager:
             "defender": defender,
             "text": text,
             "possession_flips": possession_flips,
-            "time_elapsed": time_elapsed
+            "time_elapsed": time_elapsed,
+            "events": events,
         }
 
         if made:

--- a/BackEnd/utils/shared.py
+++ b/BackEnd/utils/shared.py
@@ -110,15 +110,15 @@ def get_time_elapsed(tempo_call):
     else:
         return int(max(5, min(35, random.gauss(12, 6))))  # Fallback
 
-def resolve_offensive_rebound_loop(game, rebounder):
-    
-    game_state, off_team, def_team, off_lineup, def_lineup = unpack_game_context(game)
-    total_time = 0
-    text_log = ""
-    turns = 0
-    while True:
+def resolve_offensive_rebound(game, rebounder):
+    """Resolve an offensive rebound by choosing a putback or a kick-out.
 
-        # attempt putback
+    Returns an event dictionary describing the outcome.
+    """
+
+    game_state, off_team, def_team, off_lineup, def_lineup = unpack_game_context(game)
+
+    if random.random() < 0.65:  # putback attempt
         attrs = rebounder.attributes
         shot_score = (
             attrs["SC"] * 0.6 +
@@ -126,68 +126,58 @@ def resolve_offensive_rebound_loop(game, rebounder):
             attrs["IQ"] * 0.2
         ) * random.randint(1, 6)
         time_elapsed = random.randint(2, 5)
-        total_time += time_elapsed
 
-        # contested by random defender
         defender_pos = random.choice(["C", "C", "C", "PF", "PF", "SF", "SF", "SG", "PG"])
         defender = def_team.lineup[defender_pos]
         defense_attrs = defender.attributes
         defense_penalty = (
-            defense_attrs["ID"] * 0.8 + 
-            defense_attrs["IQ"] * 0.1 + 
+            defense_attrs["ID"] * 0.8 +
+            defense_attrs["IQ"] * 0.1 +
             defense_attrs["CH"] * 0.1
         ) * random.randint(1, 6)
         shot_score -= defense_penalty * 0.2
 
         made = shot_score >= off_team.team_attributes["shot_threshold"]
         rebounder.record_stat("FGA")
-        # print(f"{get_name_safe(rebounder)} attempts an offensive rebound shot")
+
+        event = {
+            "event_type": "PUTBACK_ATTEMPT",
+            "shooterId": getattr(rebounder, "player_id", None),
+            "timeElapsed": time_elapsed,
+            "result": "MAKE" if made else "MISS",
+            "possession_flips": False,
+        }
 
         if made:
             rebounder.record_stat("FGM")
             points = 2
             record_team_points(game, off_team, points)
-            text_log += f" and he scores!"
-            return {
-                "text": text_log,
-                "possession_flips": True,
-                "time_elapsed": total_time,
-                "points": points,
-                "shooter": rebounder,
-            }
+            event["points"] = points
+            event["possession_flips"] = True
+        else:
+            new_rebounder, new_team, new_stat = determine_rebounder(game)
+            new_rebounder.record_stat(new_stat)
+            event["possession_flips"] = new_team != off_team
 
-        # shot missed — determine rebound
-        new_rebounder, new_team, new_stat = determine_rebounder(game)
-        new_rebounder.record_stat(new_stat)
-        # print(f"+1 rebound for {get_name_safe(new_rebounder)} / utils/shared - resolve_offensive_rebound_loop")
-        text_log += f" but misses the shot. {new_rebounder} grabs the rebound."
+        return event
 
-        if new_team != off_team:
-            return {
-                "text": text_log,
-                "possession_flips": True,
-                "time_elapsed": total_time
-            }
+    # Kick out to PG
+    pg = off_team.lineup.get("PG")
+    duration = random.randint(1, 3)
+    from_coords = getattr(rebounder, "coords", {"x": 25, "y": 50})
+    to_coords = getattr(pg, "coords", {"x": 25, "y": 50}) if pg else {"x": 25, "y": 50}
 
-        # else: new offensive rebound, repeat loop
-        rebounder = new_rebounder
-        if random.random() > 0.65:
-            text_log += f"{get_name_safe(rebounder)} kicks it out."
-            return {
-                "text": text_log,
-                "possession_flips": False,
-                "time_elapsed": total_time
-            }
-        
-        if turns > 4:
-            text_log += f"{get_name_safe(rebounder)} kicks it out."
-            return {
-                "text": text_log,
-                "possession_flips": False,
-                "time_elapsed": total_time
-            }
-        
-        turns += 1
+    return {
+        "event_type": "KICKOUT_RESET",
+        "rebounderId": getattr(rebounder, "player_id", None),
+        "pgId": getattr(pg, "player_id", None) if pg else None,
+        "pass": {
+            "fromCoords": from_coords,
+            "toCoords": to_coords,
+            "duration": duration,
+        },
+        "timeElapsed": duration,
+    }
 
 def calculate_screen_score(screen_attrs):
     """

--- a/tests/test_shot_manager.py
+++ b/tests/test_shot_manager.py
@@ -75,14 +75,15 @@ def test_offensive_rebound_putback_updates_stats(monkeypatch):
         rebounder_param.record_stat("FGM")
         record_team_points(game_param, game_param.offense_team, 2)
         return {
-            "text": " and he scores!",
-            "possession_flips": True,
-            "time_elapsed": 0,
+            "event_type": "PUTBACK_ATTEMPT",
+            "shooterId": rebounder_param.player_id,
+            "result": "MAKE",
             "points": 2,
-            "shooter": rebounder_param,
+            "timeElapsed": 0,
+            "possession_flips": True,
         }
 
-    monkeypatch.setattr("BackEnd.models.shot_manager.resolve_offensive_rebound_loop", fake_putback)
+    monkeypatch.setattr("BackEnd.models.shot_manager.resolve_offensive_rebound", fake_putback)
 
     result = shot_manager.resolve_shot(roles)
 


### PR DESCRIPTION
## Summary
- replace offensive rebound loop with `resolve_offensive_rebound` that decides putback vs kickout and returns an event
- integrate new helper into `ShotManager.resolve_shot` and log rebound/putback/kickout events
- update related modules and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a207aaaa4883289ad462610cfdfd62