### PR TITLE
Add putback attempt animation support

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -1,6 +1,7 @@
 import * as Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.60.0/dist/phaser.esm.js';
 import { generateBallTween } from "./generateBallTween.js";
 import { gridToPixels } from "../utils/gridToPixels.js";
+import { runInboundSetup } from "./turnAnimation.js";
 
 // Debug flags for logging shot / rebound details
 export const SHOT_DEBUG = false;
@@ -201,6 +202,106 @@ export function shootBall({
         } else {
           resolve();
         }
+      }
+    });
+  });
+}
+
+/**
+ * Animate a putback attempt after an offensive rebound.
+ * Detaches the ball from the rebounder and tweens it to the rim.
+ * Resolves after inbound setup (for makes) or after ball lands (for misses).
+ *
+ * @param {Phaser.Scene} scene
+ * @param {Phaser.GameObjects.Image} ballSprite
+ * @param {string} shooterId
+ * @param {{x:number, y:number}} rimCoords - grid coordinates of the target rim
+ * @param {number} duration - tween duration in ms
+ * @param {string} result - "MAKE", "MISS", or "FOUL"
+ */
+export function animatePutbackAttempt(
+  scene,
+  ballSprite,
+  shooterId,
+  rimCoords,
+  duration = 500,
+  result
+) {
+  if (!scene || !ballSprite) return Promise.resolve();
+  const shooterSprite = scene.playerSprites?.[shooterId];
+  if (!shooterSprite) return Promise.resolve();
+
+  if (scene.tweens) scene.tweens.killTweensOf(ballSprite);
+  scene.ballAttachedToPlayerId = null;
+  ballSprite.setPosition(shooterSprite.x, shooterSprite.y);
+  ballSprite.setVisible(true);
+
+  const rim = gridToPixels(
+    rimCoords.x,
+    rimCoords.y,
+    scene.game.config.width,
+    scene.game.config.height
+  );
+
+  return new Promise((resolve) => {
+    scene.tweens.add({
+      targets: ballSprite,
+      x: rim.x,
+      y: rim.y,
+      duration,
+      ease: "Sine.easeInOut",
+      onComplete: () => {
+        const handleComplete = async () => {
+          if (result === "MAKE") {
+            const wait = () =>
+              scene.time?.delayedCall
+                ? new Promise((res) => scene.time.delayedCall(1000, res))
+                : new Promise((res) => setTimeout(res, 1000));
+            await wait();
+
+            const shooterTeamKey = shooterSprite.team;
+            const newOffenseSide = shooterTeamKey === "home" ? "away" : "home";
+            const sprites = Object.values(scene.playerSprites || {});
+            const homeTeamId = sprites.find(s => s.team === "home")?.team_id;
+            const awayTeamId = sprites.find(s => s.team === "away")?.team_id;
+
+            await runInboundSetup({
+              scene,
+              ballSprite,
+              playerSprites: scene.playerSprites,
+              newOffenseSide,
+              homeTeamId,
+              awayTeamId
+            });
+            resolve();
+          } else if (result === "MISS") {
+            const isHomeTeam = shooterSprite.team === "home";
+            const bounceGridX = isHomeTeam ? rimCoords.x - 6 : rimCoords.x + 6;
+            const bounceGridY =
+              rimCoords.y + Phaser.Math.Between(-6, 6);
+            const bounce = gridToPixels(
+              bounceGridX,
+              bounceGridY,
+              scene.game.config.width,
+              scene.game.config.height
+            );
+
+            scene.tweens.add({
+              targets: ballSprite,
+              x: bounce.x,
+              y: bounce.y,
+              duration: duration / 3,
+              ease: "Sine.easeOut",
+              onComplete: () =>
+                resolve({ grid: { x: bounceGridX, y: bounceGridY } })
+            });
+          } else {
+            // FOUL or unrecognized result: backend will handle next steps
+            resolve();
+          }
+        };
+
+        handleComplete();
       }
     });
   });

--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -4,7 +4,8 @@ import {
   lockBallToPlayer,
   shootBall,
   SHOT_DEBUG,
-  animateRebound
+  animateRebound,
+  animatePutbackAttempt
 } from "./ballManager.js";
 
 // Cap the time spent on any single movement step. Large timestamp gaps can
@@ -453,7 +454,42 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
       break;
     }
   }
+
+  // Process additional events (e.g., putback attempts)
+  if (!scene.skipToEnd && Array.isArray(turnData.events)) {
+    for (const evt of turnData.events) {
+      if (scene.skipToEnd) break;
+      if (evt.event_type === "PUTBACK_ATTEMPT") {
+        const shooterId = evt.shooterId;
+        const rebounderSprite = playerSprites[shooterId];
+        if (!rebounderSprite) continue;
+        lockBallToPlayer(scene, ballSprite, rebounderSprite);
+        const rimCoords =
+          rebounderSprite.team === "home" ? HOME_RIM_COORDS : AWAY_RIM_COORDS;
+        const putbackResult = await animatePutbackAttempt(
+          scene,
+          ballSprite,
+          shooterId,
+          rimCoords,
+          evt.duration || 500,
+          evt.result
+        );
+        if (evt.result === "MISS" && evt.rebound) {
+          await animateRebound({
+            scene,
+            ballSprite,
+            playerSprites,
+            animations: evt.rebound.animations || turnData.animations,
+            rebounderId: evt.rebound.rebounderId,
+            ballSpot: putbackResult?.grid || evt.rebound.ballSpot
+          });
+        }
+      }
+    }
+  }
 }
+
+export { runInboundSetup };
 
 if (typeof window !== "undefined") {
   window.playTurnAnimation = playTurnAnimation;

--- a/tests/js/ballManagerStub.mjs
+++ b/tests/js/ballManagerStub.mjs
@@ -12,6 +12,14 @@ export function animateRebound(opts) {
   calls.push({ type: 'rebound', opts });
 }
 
+export function animatePutbackAttempt(scene, ballSprite, shooterId, rimCoords, duration, result) {
+  calls.push({ type: 'putback', scene, ballSprite, shooterId, rimCoords, duration, result });
+  if (result === 'MISS') {
+    return Promise.resolve({ grid: { x: 0, y: 0 } });
+  }
+  return Promise.resolve();
+}
+
 export function animateInboundPass(scene, ballSprite, fromCoords, toCoords, startTs, endTs) {
   calls.push({
     type: 'inboundPass',


### PR DESCRIPTION
## Summary
- implement animatePutbackAttempt to handle putback shots and inbound setup
- trigger putback attempt and follow-up rebound events in turn animation
- extend ballManager test stub for putback animation

## Testing
- `node --experimental-loader=./tests/js/httpsLoader.mjs tests/js/runPlayTurnAnimation.mjs`
- `node --experimental-loader=./tests/js/httpsLoader.mjs tests/js/runReboundAnimation.mjs`
- `node --experimental-loader=./tests/js/httpsLoaderNoStubBall.mjs tests/js/runShootBall.mjs`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a20afaafc483289cbad42bfac8f7f2