### PR TITLE
Add kickout reset animation

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -451,6 +451,73 @@ export function animateRebound({
 }
 
 /**
+ * Animate an offensive rebound kickout pass to reset the half‑court offense.
+ * Attaches the ball to the rebounder, tweens the pass to the point guard,
+ * then locks the ball to the PG on completion.
+ *
+ * @param {Phaser.Scene} scene
+ * @param {Phaser.GameObjects.Image} ballSprite
+ * @param {string} rebounderId
+ * @param {string} pgId
+ * @param {{fromCoords:{x:number,y:number}, toCoords:{x:number,y:number}, duration?:number}} pass
+ * @param {number} [duration]
+ */
+export function animateKickoutReset(
+  scene,
+  ballSprite,
+  rebounderId,
+  pgId,
+  pass = {},
+  duration
+) {
+  if (!scene || !ballSprite) return Promise.resolve();
+
+  const rebounderSprite = scene.playerSprites?.[rebounderId];
+  const pgSprite = scene.playerSprites?.[pgId];
+  if (!rebounderSprite || !pgSprite) return Promise.resolve();
+
+  // Ensure ball starts with rebounder
+  lockBallToPlayer(scene, ballSprite, rebounderSprite);
+
+  const width = scene.game.config.width;
+  const height = scene.game.config.height;
+
+  const start = gridToPixels(
+    pass.fromCoords?.x ?? rebounderSprite.x,
+    pass.fromCoords?.y ?? rebounderSprite.y,
+    width,
+    height
+  );
+  const end = gridToPixels(
+    pass.toCoords?.x ?? pgSprite.x,
+    pass.toCoords?.y ?? pgSprite.y,
+    width,
+    height
+  );
+
+  ballSprite.setPosition(start.x, start.y);
+  ballSprite.setVisible(true);
+
+  return new Promise((resolve) => {
+    scene.tweens.add({
+      targets: ballSprite,
+      x: end.x,
+      y: end.y,
+      duration: duration ?? pass.duration ?? 300,
+      ease: "Sine.easeInOut",
+      onComplete: () => {
+        lockBallToPlayer(scene, ballSprite, pgSprite);
+        resolve();
+      },
+      onStop: () => {
+        lockBallToPlayer(scene, ballSprite, pgSprite);
+        resolve();
+      }
+    });
+  });
+}
+
+/**
  * Checks which player has the ball at the current animation step
  * and locks the ball to that player's sprite.
  *

--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -6,7 +6,8 @@ import {
   shootBall,
   SHOT_DEBUG,
   animateRebound,
-  animatePutbackAttempt
+  animatePutbackAttempt,
+  animateKickoutReset
 } from "./ballManager.js";
 
 // Cap the time spent on any single movement step. Large timestamp gaps can
@@ -624,6 +625,18 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
             rebounderId: evt.rebound.rebounderId,
             ballSpot: putbackResult?.grid || evt.rebound.ballSpot
           });
+        }
+      } else if (evt.event_type === "KICKOUT_RESET") {
+        await animateKickoutReset(
+          scene,
+          ballSprite,
+          evt.rebounderId,
+          evt.pgId,
+          evt.pass,
+          evt.pass?.duration
+        );
+        if (typeof scene.startNextHalfCourtOffense === "function") {
+          scene.startNextHalfCourtOffense();
         }
       }
     }

--- a/tests/js/ballManagerStub.mjs
+++ b/tests/js/ballManagerStub.mjs
@@ -20,6 +20,11 @@ export function animatePutbackAttempt(scene, ballSprite, shooterId, rimCoords, d
   return Promise.resolve();
 }
 
+export function animateKickoutReset(scene, ballSprite, rebounderId, pgId, pass, duration) {
+  calls.push({ type: 'kickoutReset', scene, ballSprite, rebounderId, pgId, pass, duration });
+  return Promise.resolve();
+}
+
 export function animateInboundPass(scene, ballSprite, fromCoords, toCoords, startTs, endTs) {
   calls.push({
     type: 'inboundPass',


### PR DESCRIPTION
## Summary
- implement kickout reset animation from rebounder to PG
- trigger new animation on KICKOUT_RESET and start next half-court offense
- extend test stub for kickout reset

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a20ddd393c8328a136901dc62ed1b4