### PR TITLE
test: cover rebound event paths

### DIFF
--- a/tests/js/runReboundAnimation.mjs
+++ b/tests/js/runReboundAnimation.mjs
@@ -1,9 +1,7 @@
 import { playTurnAnimation } from '../../FrontEnd/static/js/phaser/animation/turnAnimation.js';
-import { calls } from './ballManagerStub.mjs';
 
-function createScene() {
+function makeScene() {
   return {
-    skipToEnd: false,
     tweens: {
       add: ({ onUpdate, onComplete, onStop }) => {
         if (onUpdate) onUpdate();
@@ -12,42 +10,94 @@ function createScene() {
       },
       killTweensOf: () => {}
     },
+    time: { delayedCall: (ms, fn) => fn() },
     game: { config: { width: 100, height: 50 } },
-    playerInfo: { p1: { name: 'Rebounder' } },
-    nameToId: { Rebounder: 'p1' },
-    time: { delayedCall: (ms, fn) => fn() }
+    playerSprites: {
+      pg: { x: 0, y: 0, team: 'home', team_id: 'HOME' },
+      sg: { x: 0, y: 0, team: 'home', team_id: 'HOME' },
+      sf: { x: 0, y: 0, team: 'home', team_id: 'HOME' },
+      pf: { x: 0, y: 0, team: 'home', team_id: 'HOME' },
+      c: { x: 0, y: 0, team: 'home', team_id: 'HOME' },
+      pgA: { x: 0, y: 0, team: 'away', team_id: 'AWAY' },
+      sfA: { x: 0, y: 0, team: 'away', team_id: 'AWAY' },
+      sgA: { x: 0, y: 0, team: 'away', team_id: 'AWAY' },
+      pfA: { x: 0, y: 0, team: 'away', team_id: 'AWAY' },
+      cA: { x: 0, y: 0, team: 'away', team_id: 'AWAY' }
+    },
+    playerInfo: {
+      pg: { pos: 'PG', team_id: 'HOME', name: 'PG' },
+      sg: { pos: 'SG', team_id: 'HOME', name: 'SG' },
+      sf: { pos: 'SF', team_id: 'HOME', name: 'SF' },
+      pf: { pos: 'PF', team_id: 'HOME', name: 'PF' },
+      c: { pos: 'C', team_id: 'HOME', name: 'C' },
+      pgA: { pos: 'PG', team_id: 'AWAY', name: 'PG A' },
+      sfA: { pos: 'SF', team_id: 'AWAY', name: 'SF A' },
+      sgA: { pos: 'SG', team_id: 'AWAY', name: 'SG A' },
+      pfA: { pos: 'PF', team_id: 'AWAY', name: 'PF A' },
+      cA: { pos: 'C', team_id: 'AWAY', name: 'C A' }
+    },
+    nameToId: { PG: 'pg', C: 'c', Rebounder: 'c' }
   };
 }
 
-function createSprite(team_id) {
-  const team = team_id === 'HOME' ? 'home' : 'away';
-  return { x: 0, y: 0, team_id, team, setPosition() {}, setVisible() {} };
-}
-
-const scene = createScene();
-const ballSprite = { setPosition() {}, setVisible() {} };
-const playerSprites = { p1: createSprite('HOME') };
-const turnData = {
-  starting_possession_team_id: 'HOME',
-  possession_team_id: 'HOME',
-  result_type: 'DREB',
-  ball_handler: 'Rebounder',
-  text: '',
-  animations: [{
-    playerId: 'p1',
-    movement: [
-      { timestamp: 0, coords: { x: 0, y: 0 }, action: 'handle_ball' },
-      { timestamp: 10, coords: { x: 0, y: 0 }, action: 'shoot' }
-    ],
-    hasBallAtStep: [true, true]
-  }]
-};
 const simData = { home_team_id: 'HOME', away_team_id: 'AWAY' };
 
-await playTurnAnimation({ scene, simData, playerSprites, turnData, ballSprite });
-const shootOpts = calls.find(c => !c.type);
-const reboundCall = calls.find(c => c.type === 'rebound');
-console.log(JSON.stringify({
-  resultMapped: shootOpts?.result,
-  rebounderId: reboundCall?.opts?.rebounderId
-}));
+function createBallSprite() {
+  return {
+    setPosition(x, y) { this.x = x; this.y = y; },
+    setVisible() {},
+  };
+}
+
+// Putback make should trigger inbound setup
+{
+  const scene = makeScene();
+  const ballSprite = createBallSprite();
+  const turnData = {
+    starting_possession_team_id: 'HOME',
+    possession_team_id: 'HOME',
+    result_type: 'MISS',
+    ball_handler: 'C',
+    animations: [],
+    events: [{ event_type: 'PUTBACK_ATTEMPT', shooterId: 'c', result: 'MAKE', duration: 0 }]
+  };
+  await playTurnAnimation({ scene, simData, playerSprites: scene.playerSprites, turnData, ballSprite });
+  var inboundSetup = scene.ballAttachedToPlayerId === 'pgA';
+}
+
+// Putback miss should trigger rebound animation attaching ball to rebounderId
+let reboundAttached;
+{
+  const scene = makeScene();
+  const ballSprite = createBallSprite();
+  const turnData = {
+    starting_possession_team_id: 'HOME',
+    possession_team_id: 'HOME',
+    result_type: 'MISS',
+    ball_handler: 'C',
+    animations: [],
+    events: [{ event_type: 'PUTBACK_ATTEMPT', shooterId: 'c', result: 'MISS', duration: 0, rebound: { rebounderId: 'pg', ballSpot: { x: 0, y: 0 } } }]
+  };
+  await playTurnAnimation({ scene, simData, playerSprites: scene.playerSprites, turnData, ballSprite });
+  reboundAttached = scene.ballAttachedToPlayerId;
+}
+
+// Kickout reset should attach ball to PG and start new turn
+let kickoutResult;
+{
+  const scene = makeScene();
+  const ballSprite = createBallSprite();
+  scene.startNextHalfCourtOffense = () => { scene.newTurn = true; };
+  const turnData = {
+    starting_possession_team_id: 'HOME',
+    possession_team_id: 'HOME',
+    result_type: 'MISS',
+    ball_handler: 'C',
+    animations: [],
+    events: [{ event_type: 'KICKOUT_RESET', rebounderId: 'c', pgId: 'pg', pass: { fromCoords: { x: 0, y: 0 }, toCoords: { x: 1, y: 1 }, duration: 0 } }]
+  };
+  await playTurnAnimation({ scene, simData, playerSprites: scene.playerSprites, turnData, ballSprite });
+  kickoutResult = { attached: scene.ballAttachedToPlayerId, newTurn: scene.newTurn === true };
+}
+
+console.log(JSON.stringify({ inboundSetup, reboundAttached, kickoutResult }));

--- a/tests/test_frontend_rebound_animation.py
+++ b/tests/test_frontend_rebound_animation.py
@@ -1,0 +1,18 @@
+import json
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def run_node(loader, script):
+    cmd = ["node", "--loader", str(ROOT / loader), str(ROOT / script)]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return json.loads(completed.stdout.strip().splitlines()[-1])
+
+
+def test_rebound_animation_flows():
+    result = run_node("tests/js/httpsLoaderNoStubBall.mjs", "tests/js/runReboundAnimation.mjs")
+    assert result["inboundSetup"] is True
+    assert result["reboundAttached"] == "pg"
+    assert result["kickoutResult"] == {"attached": "pg", "newTurn": True}

--- a/tests/test_shot_manager.py
+++ b/tests/test_shot_manager.py
@@ -96,3 +96,69 @@ def test_offensive_rebound_putback_updates_stats(monkeypatch):
     assert game.score[game.offense_team.name] == 2
 
 
+def _force_putback_path(monkeypatch, made=True, defensive_reb=False):
+    """Helper to drive resolve_offensive_rebound down specific branches."""
+    from BackEnd.utils.shared import resolve_offensive_rebound
+
+    game = build_mock_game()
+    rebounder = game.offense_team.lineup["C"]
+
+    # Choose putback path
+    monkeypatch.setattr("BackEnd.utils.shared.random.random", lambda: 0.1)
+    # Deterministic scores
+    monkeypatch.setattr("BackEnd.utils.shared.random.randint", lambda a, b: 6)
+
+    if made:
+        game.offense_team.team_attributes["shot_threshold"] = 0
+    else:
+        game.offense_team.team_attributes["shot_threshold"] = 1000
+
+        def fake_determine(game_param):
+            team = game.defense_team if defensive_reb else game.offense_team
+            player = team.lineup["PF"]
+            stat = "DREB" if team == game.defense_team else "OREB"
+            return player, team, stat
+
+        monkeypatch.setattr("BackEnd.utils.shared.determine_rebounder", fake_determine)
+
+    event = resolve_offensive_rebound(game, rebounder)
+    return event
+
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "made,def_reb,expected_flip",
+    [
+        (True, False, True),
+        (False, True, True),
+        (False, False, False),
+    ],
+)
+def test_putback_event_payload_and_possession(monkeypatch, made, def_reb, expected_flip):
+    event = _force_putback_path(monkeypatch, made=made, defensive_reb=def_reb)
+    assert event["event_type"] == "PUTBACK_ATTEMPT"
+    assert event["result"] == ("MAKE" if made else "MISS")
+    assert event["possession_flips"] is expected_flip
+    base_keys = {"event_type", "shooterId", "timeElapsed", "result", "possession_flips"}
+    if made:
+        base_keys.add("points")
+    assert base_keys <= event.keys()
+
+
+def test_kickout_reset_event_payload(monkeypatch):
+    from BackEnd.utils.shared import resolve_offensive_rebound
+
+    game = build_mock_game()
+    rebounder = game.offense_team.lineup["C"]
+
+    # Force kickout branch and deterministic duration
+    monkeypatch.setattr("BackEnd.utils.shared.random.random", lambda: 0.99)
+    monkeypatch.setattr("BackEnd.utils.shared.random.randint", lambda a, b: 1)
+
+    event = resolve_offensive_rebound(game, rebounder)
+    assert event["event_type"] == "KICKOUT_RESET"
+    assert {"event_type", "rebounderId", "pgId", "pass", "timeElapsed"} == set(event.keys())
+
+


### PR DESCRIPTION
## Summary
- add regression tests covering putback and kickout rebound events and possession flips
- verify inbound setup, rebound, and kickout flows in animation layer

## Testing
- `pytest tests/test_shot_manager.py::test_putback_event_payload_and_possession tests/test_shot_manager.py::test_kickout_reset_event_payload tests/test_frontend_rebound_animation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a210a729e083288448bb549efb3cce