### PR TITLE
Add utility to flip away team coordinates

### DIFF
--- a/BackEnd/utils/shared.py
+++ b/BackEnd/utils/shared.py
@@ -447,9 +447,18 @@ def get_away_player_coords(playerCoords):
         coordsX = playerCoords["x"]
         baseValue = coordsX - 51
         xSpot = coordsX - (1 + (baseValue * 2))   
-        playerCoords = {"x": xSpot, "y": ySpot} 
-        
+        playerCoords = {"x": xSpot, "y": ySpot}
+
         return playerCoords
+
+def getAwayTeamCoords(coordsDict):
+       for position, coords in coordsDict.items():
+           ySpot = coords["y"]
+           coordsX = coords["x"]
+           baseValue = coordsX - 51
+           xSpot = coordsX - (1 + (baseValue * 2))
+           coordsDict[position] = {"x": xSpot, "y": ySpot}
+       return coordsDict
 
 def update_player_coords_from_animations(game, animations):
     for anim in animations:


### PR DESCRIPTION
## Summary
- add `getAwayTeamCoords` to mirror coordinates for away team's players

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a21beb24e0832898428644a2fe2d7f