### PR TITLE
feat: add ball tween helpers

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -3,6 +3,7 @@ import { generateBallTween } from "./generateBallTween.js";
 import { gridToPixels } from "../utils/gridToPixels.js";
 import { runInboundSetup } from "./turnAnimation.js";
 import animationConfig from "./animation_config.js";
+export { attachBallToPlayer, detachBall, tweenBallTo, runPass } from "./ballTween.js";
 
 // Debug flags for logging shot / rebound details
 export const SHOT_DEBUG = false;

--- a/FrontEnd/static/js/phaser/animation/ballTween.js
+++ b/FrontEnd/static/js/phaser/animation/ballTween.js
@@ -1,0 +1,127 @@
+import * as Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.60.0/dist/phaser.esm.js';
+
+const BALL_DEPTH = 1000;
+
+/**
+ * Position the ball sprite on top of a player's sprite and optionally adjust depth.
+ * Any active tweens on the ball are killed before attaching.
+ * @param {Phaser.Scene} scene
+ * @param {Phaser.GameObjects.Image} ballSprite
+ * @param {Phaser.GameObjects.Sprite} playerSprite
+ * @param {{depth?: number}} opts
+ */
+export function attachBallToPlayer(scene, ballSprite, playerSprite, opts = {}) {
+  if (!scene || !ballSprite || !playerSprite) return;
+  const depth = opts.depth ?? (playerSprite.depth != null ? playerSprite.depth + 1 : BALL_DEPTH);
+  if (scene.tweens) scene.tweens.killTweensOf(ballSprite);
+  ballSprite.setPosition(playerSprite.x, playerSprite.y);
+  ballSprite.setVisible(true);
+  ballSprite.setDepth(depth);
+  if (typeof playerSprite.playerId !== 'undefined') {
+    scene.ballAttachedToPlayerId = playerSprite.playerId;
+  }
+}
+
+/**
+ * Detach ball from any player and optionally hide it.
+ * Currently just clears active tweens and ownership reference.
+ */
+export function detachBall(scene, ballSprite) {
+  if (!scene || !ballSprite) return;
+  if (scene.tweens) scene.tweens.killTweensOf(ballSprite);
+  if (typeof scene.ballAttachedToPlayerId !== 'undefined') {
+    scene.ballAttachedToPlayerId = null;
+  }
+}
+
+/**
+ * Tween the ball to a specific position. Returns a promise that resolves when tween completes.
+ * Supports optional arc motion via quadratic bezier.
+ * @param {Phaser.Scene} scene
+ * @param {Phaser.GameObjects.Image} ballSprite
+ * @param {{x:number, y:number}} target
+ * @param {{duration?:number, easing?:string, arc?:{height?:number}|boolean}} opts
+ */
+export function tweenBallTo(scene, ballSprite, target, opts = {}) {
+  if (!scene || !ballSprite || !target) return Promise.resolve();
+  const { duration = 300, easing = 'Linear', arc } = opts;
+  if (scene.tweens) scene.tweens.killTweensOf(ballSprite);
+  ballSprite.setDepth(BALL_DEPTH);
+  ballSprite.setVisible(true);
+
+  return new Promise((resolve) => {
+    if (arc) {
+      const startX = ballSprite.x;
+      const startY = ballSprite.y;
+      const controlX = (startX + target.x) / 2;
+      const height = typeof arc === 'object' && arc.height ? arc.height : 50;
+      const controlY = Math.min(startY, target.y) - height;
+      const curve = new Phaser.Curves.QuadraticBezier(
+        new Phaser.Math.Vector2(startX, startY),
+        new Phaser.Math.Vector2(controlX, controlY),
+        new Phaser.Math.Vector2(target.x, target.y)
+      );
+      const progress = { t: 0 };
+      scene.tweens.add({
+        targets: progress,
+        t: 1,
+        duration,
+        ease: easing,
+        onUpdate: () => {
+          const p = curve.getPoint(progress.t);
+          ballSprite.setPosition(p.x, p.y);
+        },
+        onComplete: resolve
+      });
+    } else {
+      scene.tweens.add({
+        targets: ballSprite,
+        x: target.x,
+        y: target.y,
+        duration,
+        ease: easing,
+        onComplete: resolve
+      });
+    }
+  });
+}
+
+/**
+ * Execute a full pass animation between players or coordinates.
+ * Uses scene.ballSprite and scene.playerSprites to resolve sprites by id.
+ * @param {Phaser.Scene} scene
+ * @param {{fromId?:string|number, toId?:string|number, startCoords?:{x:number,y:number}, endCoords?:{x:number,y:number}, duration?:number, easing?:string}} cfg
+ */
+export async function runPass(scene, cfg = {}) {
+  if (!scene) return;
+  const { fromId, toId, startCoords, endCoords, duration, easing } = cfg;
+  const ballSprite = scene.ballSprite;
+  if (!ballSprite) return;
+  const fromSprite = fromId != null ? scene.playerSprites?.[fromId] : null;
+  const toSprite = toId != null ? scene.playerSprites?.[toId] : null;
+
+  if (fromSprite) {
+    attachBallToPlayer(scene, ballSprite, fromSprite);
+  } else if (startCoords) {
+    if (scene.tweens) scene.tweens.killTweensOf(ballSprite);
+    ballSprite.setPosition(startCoords.x, startCoords.y);
+    ballSprite.setVisible(true);
+    ballSprite.setDepth(BALL_DEPTH);
+  }
+
+  detachBall(scene, ballSprite);
+
+  const end = endCoords || (toSprite ? { x: toSprite.x, y: toSprite.y } : null);
+  if (!end) return;
+  await tweenBallTo(scene, ballSprite, end, { duration, easing });
+  if (toSprite) {
+    attachBallToPlayer(scene, ballSprite, toSprite);
+  }
+}
+
+export default {
+  attachBallToPlayer,
+  detachBall,
+  tweenBallTo,
+  runPass
+};


### PR DESCRIPTION
## Summary
- add ball tween helper module with attach, detach, tween, and pass utilities
- re-export tween helpers through existing ballManager for compatibility

## Testing
- `pytest tests/test_frontend_rim_animation.py::test_shoot_ball_rim_selection -q`
- `pytest tests/test_frontend_rebound_animation.py::test_rebound_animation_flows -q`
- `pytest tests/test_frontend_rim_animation.py::test_play_turn_animation_passes_starting_team -q`


------
https://chatgpt.com/codex/tasks/task_e_68a24d7f36ac8328b7a8030e5f358222