### PR TITLE
Add scene ballDetached flag to guard ball locking

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -16,6 +16,9 @@ const AWAY_RIM_COORDS = { x: 9, y: 25 };
 const BALL_SPRITE_DEPTH = 1000;
 
 export function lockBallToPlayer(scene, ballSprite, playerSprite) {
+  if (scene?.ballDetached) {
+    return;
+  }
   if (!ballSprite || !playerSprite) {
     console.warn("⚠️ lockBallToPlayer skipped: missing sprite");
     return;

--- a/FrontEnd/static/js/phaser/animation/ballTween.js
+++ b/FrontEnd/static/js/phaser/animation/ballTween.js
@@ -12,6 +12,7 @@ const BALL_DEPTH = 1000;
  */
 export function attachBallToPlayer(scene, ballSprite, playerSprite, opts = {}) {
   if (!scene || !ballSprite || !playerSprite) return;
+  scene.ballDetached = false;
   const depth = opts.depth ?? (playerSprite.depth != null ? playerSprite.depth + 1 : BALL_DEPTH);
   if (scene.tweens) scene.tweens.killTweensOf(ballSprite);
   ballSprite.setPosition(playerSprite.x, playerSprite.y);
@@ -28,6 +29,7 @@ export function attachBallToPlayer(scene, ballSprite, playerSprite, opts = {}) {
  */
 export function detachBall(scene, ballSprite) {
   if (!scene || !ballSprite) return;
+  scene.ballDetached = true;
   if (scene.tweens) scene.tweens.killTweensOf(ballSprite);
   if (typeof scene.ballAttachedToPlayerId !== 'undefined') {
     scene.ballAttachedToPlayerId = null;


### PR DESCRIPTION
## Summary
- Track ball detachment state on Phaser scenes via `scene.ballDetached`
- Skip `lockBallToPlayer` when ball is flagged as detached

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a24f8c855c83288428ce61687acb17