### PR TITLE
Add text scroll panel to stats sidebar

### DIFF
--- a/FrontEnd/static/court.html
+++ b/FrontEnd/static/court.html
@@ -257,6 +257,9 @@
           <tbody id="away-stats-body"></tbody>
         </table>
       </div>
+      <div id="text-scroll-panel">
+        <div id="text-scroll"></div>
+      </div>
       <div class="controls">
         <button id="pause-btn">Pause</button>
         <button id="skip-btn">Skip To End</button>


### PR DESCRIPTION
## Summary
- add text scroll panel beneath stat boxes in right-rail

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a250bf82688328afd01d2c8178a123