### PR TITLE
Use runPass for kickout reset pass

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -3,7 +3,13 @@ import { generateBallTween } from "./generateBallTween.js";
 import { gridToPixels } from "../utils/gridToPixels.js";
 import { runInboundSetup } from "./turnAnimation.js";
 import animationConfig from "./animation_config.js";
-export { attachBallToPlayer, detachBall, tweenBallTo, runPass } from "./ballTween.js";
+import {
+  attachBallToPlayer,
+  detachBall,
+  tweenBallTo,
+  runPass
+} from "./ballTween.js";
+export { attachBallToPlayer, detachBall, tweenBallTo, runPass };
 
 // Debug flags for logging shot / rebound details
 export const SHOT_DEBUG = false;
@@ -483,46 +489,43 @@ export function animateKickoutReset(
   const pgSprite = scene.playerSprites?.[pgId];
   if (!rebounderSprite || !pgSprite) return Promise.resolve();
 
-  // Ensure ball starts with rebounder
-  lockBallToPlayer(scene, ballSprite, rebounderSprite);
+  // Ensure runPass can locate the ball sprite on the scene
+  if (!scene.ballSprite) {
+    scene.ballSprite = ballSprite;
+  }
 
   const width = scene.game.config.width;
   const height = scene.game.config.height;
-
-  const start = gridToPixels(
-    pass.fromCoords?.x ?? rebounderSprite.x,
-    pass.fromCoords?.y ?? rebounderSprite.y,
-    width,
-    height
-  );
-  const end = gridToPixels(
-    pass.toCoords?.x ?? pgSprite.x,
-    pass.toCoords?.y ?? pgSprite.y,
-    width,
-    height
-  );
-
-  ballSprite.setPosition(start.x, start.y);
-  ballSprite.setVisible(true);
-
   const cfg = animationConfig.kickout;
 
-  return new Promise((resolve) => {
-    scene.tweens.add({
-      targets: ballSprite,
-      x: end.x,
-      y: end.y,
-      duration: duration ?? pass.duration ?? cfg.duration,
-      ease: cfg.easing,
-      onComplete: () => {
-        lockBallToPlayer(scene, ballSprite, pgSprite);
-        resolve();
-      },
-      onStop: () => {
-        lockBallToPlayer(scene, ballSprite, pgSprite);
-        resolve();
-      }
-    });
+  const opts = {
+    fromId: rebounderId,
+    toId: pgId,
+    duration: duration ?? pass.duration ?? cfg.duration,
+    easing: cfg.easing
+  };
+
+  if (pass.fromCoords) {
+    opts.startCoords = gridToPixels(
+      pass.fromCoords.x,
+      pass.fromCoords.y,
+      width,
+      height
+    );
+  }
+  if (pass.toCoords) {
+    opts.endCoords = gridToPixels(
+      pass.toCoords.x,
+      pass.toCoords.y,
+      width,
+      height
+    );
+  }
+
+  return runPass(scene, opts).then(() => {
+    if (!pgSprite.playerId) {
+      scene.ballAttachedToPlayerId = pgId;
+    }
   });
 }
 

--- a/FrontEnd/static/js/phaser/animation/ballTween.js
+++ b/FrontEnd/static/js/phaser/animation/ballTween.js
@@ -104,6 +104,9 @@ export async function runPass(scene, cfg = {}) {
 
   if (fromSprite) {
     attachBallToPlayer(scene, ballSprite, fromSprite);
+    if (startCoords) {
+      ballSprite.setPosition(startCoords.x, startCoords.y);
+    }
   } else if (startCoords) {
     if (scene.tweens) scene.tweens.killTweensOf(ballSprite);
     ballSprite.setPosition(startCoords.x, startCoords.y);

--- a/tests/js/runReboundAnimation.mjs
+++ b/tests/js/runReboundAnimation.mjs
@@ -46,6 +46,7 @@ function createBallSprite() {
   return {
     setPosition(x, y) { this.x = x; this.y = y; },
     setVisible() {},
+    setDepth() {},
   };
 }
 


### PR DESCRIPTION
## Summary
- refactor kickout reset to use shared `runPass` helper with config-driven duration and coordinate overrides
- allow `runPass` to honor custom start coordinates
- adjust rebound animation test stub for new ball tween behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a25435c6ec8328ad61ba34c7daeeb7