### PR TITLE
Add configurable text scroll flag and settings

### DIFF
--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -4,6 +4,12 @@ import { setCourtOffsets } from './utils/gridToPixels.js';
 import { on, emit } from './utils/eventBus.js';
 import { finalizeGame } from './finalizeGame.js';
 
+if (typeof window !== 'undefined') {
+  window.TEXT_SCROLL_ENABLED =
+    window.TEXT_SCROLL_ENABLED !== undefined ? window.TEXT_SCROLL_ENABLED : true;
+  window.TEXT_SCROLL_CONFIG = window.TEXT_SCROLL_CONFIG || {};
+}
+
 function updateScoreboardScores({ home, away }) {
   const homeScoreEl = document.getElementById('home-score');
   const awayScoreEl = document.getElementById('away-score');

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -314,7 +314,9 @@ export function createGameScene(Phaser) {
         }
 
         if (turn.text && turn.index !== lastTurnShown) {
-          appendToTextScroll(formatTurnText(turn));
+          if (typeof window !== 'undefined' && window.TEXT_SCROLL_ENABLED) {
+            appendToTextScroll(formatTurnText(turn));
+          }
           lastTurnShown = turn.index;
         }
       };

--- a/FrontEnd/static/js/phaser/utils/textScroll.js
+++ b/FrontEnd/static/js/phaser/utils/textScroll.js
@@ -1,20 +1,29 @@
 export const config = {
   containerId: 'text-scroll',
   maxLines: 100,
+  autoScroll: true,
+  timestampPrefix: undefined,
 };
 
 export function appendToTextScroll(message, cfg = {}) {
+  const globalCfg =
+    (typeof window !== 'undefined' && window.TEXT_SCROLL_CONFIG) || {};
+  const finalCfg = { ...config, ...globalCfg, ...cfg };
   const {
-    container = document.getElementById(config.containerId),
-    maxLines = config.maxLines,
+    containerId,
+    maxLines,
+    autoScroll,
     timestampPrefix,
-  } = cfg;
+  } = finalCfg;
+  const container = finalCfg.container || document.getElementById(containerId);
 
   if (!container) {
     return;
   }
 
-  const atBottom = container.scrollTop + container.clientHeight === container.scrollHeight;
+  const atBottom =
+    autoScroll &&
+    container.scrollTop + container.clientHeight === container.scrollHeight;
 
   const line = document.createElement('div');
   line.textContent = timestampPrefix ? `${timestampPrefix} ${message}` : message;
@@ -24,7 +33,7 @@ export function appendToTextScroll(message, cfg = {}) {
     container.removeChild(container.firstChild);
   }
 
-  if (atBottom) {
+  if (autoScroll && atBottom) {
     container.scrollTop = container.scrollHeight - container.clientHeight;
   }
 


### PR DESCRIPTION
## Summary
- Provide global `TEXT_SCROLL_ENABLED` flag with default `true` to toggle log output.
- Allow global `TEXT_SCROLL_CONFIG` to override text scroll behavior such as max lines, auto scroll, and timestamp prefix.
- Guard text scroll updates in game scene so they run only when enabled.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a25555f3fc8328b631051a0a415127