### PR TITLE
Track text scroll index and guard DOM updates

### DIFF
--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -9,6 +9,7 @@ export function createGameScene(Phaser) {
   return class GameScene extends Phaser.Scene {
     constructor() {
       super("GameScene");
+      this.lastTurnShown = -1;
     }
 
     init(data) {
@@ -275,7 +276,6 @@ export function createGameScene(Phaser) {
       let liveClock = simData.clock || '8:00';
       let liveQuarter = this.quarter;
       let livePeriodLabel = simData.period_label || `Q${this.quarter}`;
-      let lastTurnShown = -1;
 
       const updateScoreboard = (turn = {}) => {
         const prevHome = liveScore[homeTeam];
@@ -313,11 +313,11 @@ export function createGameScene(Phaser) {
           });
         }
 
-        if (turn.text && turn.index !== lastTurnShown) {
+        if (turn.text && turn.index !== this.lastTurnShown) {
           if (typeof window !== 'undefined' && window.TEXT_SCROLL_ENABLED) {
             appendToTextScroll(formatTurnText(turn));
           }
-          lastTurnShown = turn.index;
+          this.lastTurnShown = turn.index;
         }
       };
 

--- a/FrontEnd/static/js/phaser/utils/textScroll.js
+++ b/FrontEnd/static/js/phaser/utils/textScroll.js
@@ -6,6 +6,7 @@ export const config = {
 };
 
 export function appendToTextScroll(message, cfg = {}) {
+  if (!message) return;
   const globalCfg =
     (typeof window !== 'undefined' && window.TEXT_SCROLL_CONFIG) || {};
   const finalCfg = { ...config, ...globalCfg, ...cfg };
@@ -21,22 +22,30 @@ export function appendToTextScroll(message, cfg = {}) {
     return;
   }
 
-  const atBottom =
-    autoScroll &&
-    container.scrollTop + container.clientHeight === container.scrollHeight;
+  const appendLine = () => {
+    const atBottom =
+      autoScroll &&
+      container.scrollTop + container.clientHeight === container.scrollHeight;
 
-  const line = document.createElement('div');
-  line.textContent = timestampPrefix ? `${timestampPrefix} ${message}` : message;
-  container.appendChild(line);
+    const line = document.createElement('div');
+    line.textContent = timestampPrefix ? `${timestampPrefix} ${message}` : message;
+    container.appendChild(line);
 
-  while (container.children.length > maxLines) {
-    container.removeChild(container.firstChild);
+    while (container.children.length > maxLines) {
+      container.removeChild(container.firstChild);
+    }
+
+    if (autoScroll && atBottom) {
+      container.scrollTop = container.scrollHeight - container.clientHeight;
+    }
+
+    console.log('textScroll:append', line.textContent.slice(0, 40));
+  };
+
+  const heavyUpdate = container.children.length > maxLines + 20;
+  if (heavyUpdate && typeof requestAnimationFrame === 'function') {
+    requestAnimationFrame(appendLine);
+  } else {
+    appendLine();
   }
-
-  if (autoScroll && atBottom) {
-    container.scrollTop = container.scrollHeight - container.clientHeight;
-  }
-
-  console.log('textScroll:append', line.textContent.slice(0, 40));
 }
-


### PR DESCRIPTION
## Summary
- retain last displayed turn index in `GameScene` to avoid duplicate log lines
- guard text scroll when message missing and optionally defer heavy DOM work with `requestAnimationFrame`

## Testing
- `/usr/local/bin/pytest` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'node')*


------
https://chatgpt.com/codex/tasks/task_e_68a25669867483288976a9c81aac081c