### PR TITLE
Expose ball tween flag via runtime config

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animation_config.js
+++ b/FrontEnd/static/js/phaser/animation/animation_config.js
@@ -1,20 +1,30 @@
-export const animationConfig = {
+const defaults = {
   enableBallTween: false,
   pass: {
     duration: 150,
     easing: 'Sine.easeInOut',
-    arc: null
+    arc: null,
   },
   inbound: {
     duration: 150,
     easing: 'Sine.easeInOut',
-    arc: null
+    arc: null,
   },
   kickout: {
     duration: 300,
     easing: 'Sine.easeInOut',
-    arc: null
-  }
+    arc: null,
+  },
+};
+
+const overrides =
+  (typeof globalThis !== 'undefined' && globalThis.animation_config) || {};
+
+export const animationConfig = {
+  enableBallTween: overrides.enableBallTween ?? defaults.enableBallTween,
+  pass: { ...defaults.pass, ...(overrides.pass || {}) },
+  inbound: { ...defaults.inbound, ...(overrides.inbound || {}) },
+  kickout: { ...defaults.kickout, ...(overrides.kickout || {}) },
 };
 
 export default animationConfig;

--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -8,6 +8,7 @@ if (typeof window !== 'undefined') {
   window.TEXT_SCROLL_ENABLED =
     window.TEXT_SCROLL_ENABLED !== undefined ? window.TEXT_SCROLL_ENABLED : true;
   window.TEXT_SCROLL_CONFIG = window.TEXT_SCROLL_CONFIG || {};
+  window.animation_config = window.animation_config || {};
 }
 
 function updateScoreboardScores({ home, away }) {

--- a/tests/js/runGenerateBallTween.mjs
+++ b/tests/js/runGenerateBallTween.mjs
@@ -1,0 +1,36 @@
+const enable = process.argv.includes('--enable');
+
+globalThis.animation_config = { enableBallTween: enable };
+
+const { generateBallTween } = await import('../../FrontEnd/static/js/phaser/animation/generateBallTween.js');
+
+let tweenCalled = false;
+
+const scene = {
+  tweens: {
+    add: () => {
+      tweenCalled = true;
+      return { stop: () => {} };
+    },
+    killTweensOf: () => {},
+  },
+  game: { config: { width: 100, height: 100 } },
+};
+
+const ballSprite = {
+  setPosition() {},
+  setVisible() {},
+  setDepth() {},
+};
+
+await generateBallTween({
+  scene,
+  ballSprite,
+  startCoords: { x: 0, y: 0 },
+  endCoords: { x: 1, y: 1 },
+  startTimestamp: 0,
+  endTimestamp: 10,
+  type: 'pass',
+});
+
+console.log(JSON.stringify({ tweenCalled }));

--- a/tests/test_generate_ball_tween_flag.py
+++ b/tests/test_generate_ball_tween_flag.py
@@ -1,0 +1,25 @@
+import json
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def run_case(enable: bool):
+    cmd = [
+        "node",
+        "--loader",
+        str(ROOT / "tests/js/httpsLoaderNoStubBall.mjs"),
+        str(ROOT / "tests/js/runGenerateBallTween.mjs"),
+    ]
+    if enable:
+        cmd.append("--enable")
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return json.loads(completed.stdout.strip().splitlines()[-1])
+
+
+def test_ball_tween_respects_flag():
+    off = run_case(False)
+    assert off["tweenCalled"] is False
+    on = run_case(True)
+    assert on["tweenCalled"] is True


### PR DESCRIPTION
## Summary
- allow overriding ball tween defaults via global `animation_config`
- expose `animation_config` on boot so debug can toggle tween behavior
- add tests covering `enableBallTween` flag

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2579e46f48328a6bfb5b23a38b6d5