### PR TITLE
Handle pass tween cancellation and idempotence

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -51,10 +51,12 @@ export function lockBallToPlayer(scene, ballSprite, playerSprite) {
   if (scene) {
     if (playerSprite.playerId) {
       scene.ballAttachedToPlayerId = playerSprite.playerId;
+      scene.ballLastKnownOwnerId = playerSprite.playerId;
     } else if (scene.playerSprites) {
       for (const [pid, sprite] of Object.entries(scene.playerSprites)) {
         if (sprite === playerSprite) {
           scene.ballAttachedToPlayerId = pid;
+          scene.ballLastKnownOwnerId = pid;
           break;
         }
       }

--- a/FrontEnd/static/js/phaser/animation/ballTween.js
+++ b/FrontEnd/static/js/phaser/animation/ballTween.js
@@ -21,6 +21,7 @@ export function attachBallToPlayer(scene, ballSprite, playerSprite, opts = {}) {
   ballSprite.setDepth(depth);
   if (typeof playerSprite.playerId !== 'undefined') {
     scene.ballAttachedToPlayerId = playerSprite.playerId;
+    scene.ballLastKnownOwnerId = playerSprite.playerId;
   }
 }
 
@@ -52,7 +53,7 @@ export function tweenBallTo(scene, ballSprite, target, opts = {}) {
   ballSprite.setDepth(BALL_DEPTH);
   ballSprite.setVisible(true);
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     if (arc) {
       const startX = ballSprite.x;
       const startY = ballSprite.y;
@@ -65,7 +66,7 @@ export function tweenBallTo(scene, ballSprite, target, opts = {}) {
         new Phaser.Math.Vector2(target.x, target.y)
       );
       const progress = { t: 0 };
-      scene.tweens.add({
+      const tween = scene.tweens.add({
         targets: progress,
         t: 1,
         duration,
@@ -76,8 +77,9 @@ export function tweenBallTo(scene, ballSprite, target, opts = {}) {
         },
         onComplete: resolve
       });
+      tween?.once?.('stop', () => reject(new Error('tween stopped')));
     } else {
-      scene.tweens.add({
+      const tween = scene.tweens.add({
         targets: ballSprite,
         x: target.x,
         y: target.y,
@@ -85,6 +87,7 @@ export function tweenBallTo(scene, ballSprite, target, opts = {}) {
         ease: easing,
         onComplete: resolve
       });
+      tween?.once?.('stop', () => reject(new Error('tween stopped')));
     }
   });
 }
@@ -105,37 +108,89 @@ export async function runPass(scene, cfg = {}) {
   const fromSprite = fromId != null ? scene.playerSprites?.[fromId] : null;
   const toSprite = toId != null ? scene.playerSprites?.[toId] : null;
 
-  scene.events?.emit('passStart', { fromId, toId, duration: usedDuration, easing: usedEasing });
-  if (PASS_DEBUG)
-    console.log(`passStart(${fromId}→${toId})`, { duration: usedDuration, easing: usedEasing });
+  const frame = scene.game?.loop?.frame ?? 0;
+  const key = `${fromId ?? ''}-${toId ?? ''}`;
 
-  if (fromSprite) {
-    attachBallToPlayer(scene, ballSprite, fromSprite);
-    if (startCoords) {
-      ballSprite.setPosition(startCoords.x, startCoords.y);
-    }
-  } else if (startCoords) {
+  if (scene.__activePass && scene.__activePass.key === key && scene.__activePass.frame === frame) {
+    return scene.__activePass.promise;
+  }
+
+  if (scene.__activePass) {
     if (scene.tweens) scene.tweens.killTweensOf(ballSprite);
-    ballSprite.setPosition(startCoords.x, startCoords.y);
-    ballSprite.setVisible(true);
-    ballSprite.setDepth(BALL_DEPTH);
+    const lastId = scene.ballLastKnownOwnerId;
+    const lastSprite = lastId != null ? scene.playerSprites?.[lastId] : null;
+    if (lastSprite) {
+      attachBallToPlayer(scene, ballSprite, lastSprite);
+    }
+    scene.__activePass.reject?.(new Error('pass cancelled'));
+    scene.__activePass = null;
   }
 
-  detachBall(scene, ballSprite);
-  scene.events?.emit('ballDetached');
-  if (PASS_DEBUG) console.log('ballDetached');
-
-  const end = endCoords || (toSprite ? { x: toSprite.x, y: toSprite.y } : null);
-  if (!end) return;
-  await tweenBallTo(scene, ballSprite, end, { duration: usedDuration, easing: usedEasing });
-  if (toSprite) {
-    attachBallToPlayer(scene, ballSprite, toSprite);
-    scene.events?.emit('ballAttached', { toId });
-    if (PASS_DEBUG) console.log(`ballAttached(${toId})`);
+  if (scene.tweens) scene.tweens.killTweensOf(ballSprite);
+  if (scene.ballDetached && scene.ballLastKnownOwnerId != null) {
+    const owner = scene.playerSprites?.[scene.ballLastKnownOwnerId];
+    if (owner) attachBallToPlayer(scene, ballSprite, owner);
   }
 
-  scene.events?.emit('passEnd', { toId });
-  if (PASS_DEBUG) console.log(`passEnd(${toId})`);
+  let resolveFn, rejectFn;
+  const promise = new Promise((resolve, reject) => {
+    resolveFn = resolve;
+    rejectFn = reject;
+  });
+  scene.__activePass = { key, frame, promise, reject: rejectFn };
+
+  (async () => {
+    try {
+      scene.events?.emit('passStart', { fromId, toId, duration: usedDuration, easing: usedEasing });
+      if (PASS_DEBUG)
+        console.log(`passStart(${fromId}→${toId})`, { duration: usedDuration, easing: usedEasing });
+
+      if (fromSprite) {
+        attachBallToPlayer(scene, ballSprite, fromSprite);
+        if (startCoords) {
+          ballSprite.setPosition(startCoords.x, startCoords.y);
+        }
+      } else if (startCoords) {
+        if (scene.tweens) scene.tweens.killTweensOf(ballSprite);
+        ballSprite.setPosition(startCoords.x, startCoords.y);
+        ballSprite.setVisible(true);
+        ballSprite.setDepth(BALL_DEPTH);
+      }
+
+      detachBall(scene, ballSprite);
+      scene.events?.emit('ballDetached');
+      if (PASS_DEBUG) console.log('ballDetached');
+
+      const end = endCoords || (toSprite ? { x: toSprite.x, y: toSprite.y } : null);
+      if (!end) {
+        resolveFn();
+        return;
+      }
+      await tweenBallTo(scene, ballSprite, end, { duration: usedDuration, easing: usedEasing });
+      if (toSprite) {
+        attachBallToPlayer(scene, ballSprite, toSprite);
+        scene.events?.emit('ballAttached', { toId });
+        if (PASS_DEBUG) console.log(`ballAttached(${toId})`);
+      }
+
+      scene.events?.emit('passEnd', { toId });
+      if (PASS_DEBUG) console.log(`passEnd(${toId})`);
+      resolveFn();
+    } catch (err) {
+      const lastId = scene.ballLastKnownOwnerId;
+      const lastSprite = lastId != null ? scene.playerSprites?.[lastId] : null;
+      if (lastSprite) {
+        attachBallToPlayer(scene, ballSprite, lastSprite);
+      }
+      rejectFn(err);
+    } finally {
+      if (scene.__activePass && scene.__activePass.key === key && scene.__activePass.frame === frame) {
+        scene.__activePass = null;
+      }
+    }
+  })();
+
+  return promise;
 }
 
 export default {


### PR DESCRIPTION
## Summary
- track last known ball owner when attaching to a player
- make `runPass` cancel existing tweens, return same promise per-frame and reattach on cancel
- propagate tween stop as an error for callers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a259b5e4e08328acc9e12bb1bc74a4