### PR TITLE
Ensure turn index propagates to scoreboard updates

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animateGameTurns.js
+++ b/FrontEnd/static/js/phaser/animation/animateGameTurns.js
@@ -19,6 +19,7 @@ export async function animateGameTurns({ //hasBallAtStep
   for (let i = 0; i < turns.length; i++) {
     scene.currentTurn = i;
     const turn = turns[i];
+    turn.index = i;
     if (scene.skipToEnd) break;
     console.log(`🔁 Turn ${i + 1}`, turn);
 
@@ -114,6 +115,7 @@ export async function animateGameTurns({ //hasBallAtStep
     if (scene.skipToEnd) {
       for (let j = i + 1; j < turns.length; j++) {
         try {
+          turns[j].index = j;
           if (onUpdate) onUpdate(turns[j]);
         } catch (err) {
           console.error('Scoreboard update failed:', err);


### PR DESCRIPTION
## Summary
- Set `turn.index` within the main loop and skip-ahead branch of `animateGameTurns`
- Guarantees `updateScoreboard` receives unique turn indexes so text scroll updates each turn

## Testing
- `pytest tests/test_scoreboard_turn_updates.py tests/test_animation_ball_ownership.py tests/test_generate_ball_tween_flag.py tests/test_frontend_rim_animation.py tests/test_frontend_rebound_animation.py tests/test_frontend_navigation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a25f6db9048328bb05268263757839