### PR TITLE
Refactor pass animation for offensive plays

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animateGameTurns.js
+++ b/FrontEnd/static/js/phaser/animation/animateGameTurns.js
@@ -84,17 +84,18 @@ export async function animateGameTurns({ //hasBallAtStep
               ? { x: receiverSprite.x, y: receiverSprite.y }
               : undefined;
 
-            if (animationConfig.enableBallTween) {
-              await runPass(scene, {
-                fromId: playerId,
-                toId: receiverAnim.playerId,
-                endCoords,
-                duration: receiveStep.timestamp - passStep.timestamp,
-                easing: animationConfig.pass.easing
-              });
-            } else if (receiverSprite) {
-              lockBallToPlayer(scene, ballSprite, receiverSprite);
-            }
+            scene.events?.once('passStart', () => console.log('passStart'));
+            scene.events?.once('ballDetached', () => console.log('ballDetached'));
+            scene.events?.once('ballAttached', () => console.log('ballAttached'));
+            scene.events?.once('passEnd', () => console.log('passEnd'));
+
+            await runPass(scene, {
+              fromId: playerId,
+              toId: receiverAnim.playerId,
+              endCoords,
+              duration: animationConfig.pass.duration,
+              easing: animationConfig.pass.easing
+            });
           }
         }
 


### PR DESCRIPTION
## Summary
- Always run ball tween for player-to-player passes
- Use configured pass duration and easing for tween
- Add console logs for pass lifecycle events

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a262524958832899ded40e09fd2fb8