### PR TITLE
feat: customize text scroll spacing

### DIFF
--- a/FrontEnd/static/court.html
+++ b/FrontEnd/static/court.html
@@ -155,6 +155,10 @@
       gap: 2px;
     }
 
+    .turn-line {
+      margin-bottom: var(--line-spacing, 1em);
+    }
+
     .controls {
       margin-top: auto;
       display: flex;

--- a/FrontEnd/static/js/phaser/utils/textScroll.js
+++ b/FrontEnd/static/js/phaser/utils/textScroll.js
@@ -3,6 +3,7 @@ export const config = {
   maxLines: 100,
   autoScroll: true,
   timestampPrefix: undefined,
+  lineSpacing: '1em',
 };
 
 export function appendToTextScroll(message, cfg = {}) {
@@ -29,8 +30,16 @@ export function appendToTextScroll(message, cfg = {}) {
       autoScroll &&
       container.scrollTop + container.clientHeight === container.scrollHeight;
 
+    const lineText = timestampPrefix ? `${timestampPrefix} ${message}` : message;
+    const lastLine = container.lastElementChild;
+    if (lastLine && lastLine.textContent === lineText) {
+      return;
+    }
+
     const line = document.createElement('div');
-    line.textContent = timestampPrefix ? `${timestampPrefix} ${message}` : message;
+    line.className = 'turn-line';
+    line.textContent = lineText;
+    line.style.marginBottom = finalCfg.lineSpacing;
     container.appendChild(line);
 
     while (container.children.length > maxLines) {


### PR DESCRIPTION
## Summary
- wrap each appended message in a `turn-line` div and skip duplicate turns
- add configurable `lineSpacing` option with default `1em`
- style `turn-line` entries via CSS

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2633187148328a58ce96249b9059b