### PR TITLE
Handle pass duration from timestamps

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animateGameTurns.js
+++ b/FrontEnd/static/js/phaser/animation/animateGameTurns.js
@@ -84,6 +84,10 @@ export async function animateGameTurns({ //hasBallAtStep
               ? { x: receiverSprite.x, y: receiverSprite.y }
               : undefined;
 
+            const delta = receiveStep.timestamp - passStep.timestamp;
+            const duration = delta > 0 ? delta : animationConfig.pass.duration;
+            console.log(`⏱️ Resolved pass duration: ${duration}ms (delta=${delta})`);
+
             scene.events?.once('passStart', () => console.log('passStart'));
             scene.events?.once('ballDetached', () => console.log('ballDetached'));
             scene.events?.once('ballAttached', () => console.log('ballAttached'));
@@ -93,7 +97,7 @@ export async function animateGameTurns({ //hasBallAtStep
               fromId: playerId,
               toId: receiverAnim.playerId,
               endCoords,
-              duration: animationConfig.pass.duration,
+              duration,
               easing: animationConfig.pass.easing
             });
           }


### PR DESCRIPTION
## Summary
- derive pass tween duration from receive and pass timestamps
- fall back to default pass duration when timestamps are non-positive
- log resolved pass duration for troubleshooting

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2636f4a8883288d54ecb5c61c104e