### PR TITLE
Gate handle_ball lock with possession checks

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animateGameTurns.js
+++ b/FrontEnd/static/js/phaser/animation/animateGameTurns.js
@@ -62,8 +62,14 @@ export async function animateGameTurns({ //hasBallAtStep
         const movement = anim?.movement || [];
 
         if (action === "handle_ball" && anim?.hasBallAtStep?.length) {
-          console.log("🔒 Locking ball to ball handler:", playerId);
-          lockBallToPlayer(scene, ballSprite, sprite);
+          const stepIndex = movement.findIndex(m => m.timestamp === timestamp);
+          const ownsBall = anim.hasBallAtStep?.[stepIndex];
+          if (ownsBall && !scene.ballDetached) {
+            console.log('handleBallAttach', { playerId, stepIndex });
+            lockBallToPlayer(scene, ballSprite, sprite);
+          } else {
+            console.log('handleBallIgnored', { playerId, stepIndex, ownsBall, ballDetached: scene.ballDetached });
+          }
         }
 
         if (action === "pass") {


### PR DESCRIPTION
## Summary
- guard handle_ball event to lock ball only when player owns possession and ball is attached
- remove unconditional locking and add handleBallAttach/handleBallIgnored debug logs

## Testing
- `node --experimental-loader ./tests/js/httpsLoader.mjs ./tests/js/runPlayTurnAnimation.mjs`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a26f2075e48328a38c8760420a29c6