### PR TITLE
Respect ball detachment during passes

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballTween.js
+++ b/FrontEnd/static/js/phaser/animation/ballTween.js
@@ -169,6 +169,7 @@ export async function runPass(scene, cfg = {}) {
       await tweenBallTo(scene, ballSprite, end, { duration: usedDuration, easing: usedEasing });
       if (toSprite) {
         attachBallToPlayer(scene, ballSprite, toSprite);
+        scene.ballDetached = false;
         scene.events?.emit('ballAttached', { toId });
         if (PASS_DEBUG) console.log(`ballAttached(${toId})`);
       }

--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -31,6 +31,11 @@ function updateBallOwnership({ scene, ballSprite, animations, playerSprites, ste
   );
   if (passHappening) return;
 
+  if (scene.ballDetached) {
+    console.log('ownershipSkipped');
+    return;
+  }
+
   for (const anim of animations) {
     if (scene.skipToEnd) break;
     const sprite = playerSprites[anim.playerId];
@@ -39,6 +44,7 @@ function updateBallOwnership({ scene, ballSprite, animations, playerSprites, ste
       ballSprite.setPosition(sprite.x, sprite.y);
       ballSprite.setVisible(true);
       if (currentBallOwnerRef) currentBallOwnerRef.value = sprite;
+      console.log('ownershipApplied');
       break;
     }
 


### PR DESCRIPTION
## Summary
- Skip ball ownership updates while the ball is detached and log the decision
- Restore ownership updates once a pass completes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a26ff92350832891930c26e9357855