### PR TITLE
Route passes through runPass and add tween instrumentation

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animateGameTurns.js
+++ b/FrontEnd/static/js/phaser/animation/animateGameTurns.js
@@ -1,6 +1,6 @@
 import { playTurnAnimation, runSideInboundSetup } from "./turnAnimation.js";
 import { onAction } from "./onAction.js";
-import { runPass, lockBallToPlayer } from "./ballManager.js";
+import { runPass, attachBallToPlayer } from "./ballManager.js";
 import animationConfig from "./animation_config.js";
 
 /**
@@ -66,7 +66,7 @@ export async function animateGameTurns({ //hasBallAtStep
           const ownsBall = anim.hasBallAtStep?.[stepIndex];
           if (ownsBall && !scene.ballDetached) {
             console.log('handleBallAttach', { playerId, stepIndex });
-            lockBallToPlayer(scene, ballSprite, sprite);
+            attachBallToPlayer(scene, ballSprite, sprite);
           } else {
             console.log('handleBallIgnored', { playerId, stepIndex, ownsBall, ballDetached: scene.ballDetached });
           }
@@ -95,6 +95,8 @@ export async function animateGameTurns({ //hasBallAtStep
             console.log(`⏱️ Resolved pass duration: ${duration}ms (delta=${delta})`);
 
             scene.events?.once('passStart', () => console.log('passStart'));
+            scene.events?.once('tweenStart', () => console.log('tweenStart'));
+            scene.events?.once('tweenEnd', () => console.log('tweenEnd'));
             scene.events?.once('ballDetached', () => console.log('ballDetached'));
             scene.events?.once('ballAttached', () => console.log('ballAttached'));
             scene.events?.once('passEnd', () => console.log('passEnd'));

--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -19,50 +19,6 @@ export const INBOUND_DEBUG = false;
 // Hoop locations in grid coordinates for each team
 const HOME_RIM_COORDS = { x: 91, y: 25 };
 const AWAY_RIM_COORDS = { x: 9, y: 25 };
-const BALL_SPRITE_DEPTH = 1000;
-
-export function lockBallToPlayer(scene, ballSprite, playerSprite) {
-  if (scene?.ballDetached) {
-    return;
-  }
-  if (!ballSprite || !playerSprite) {
-    console.warn("⚠️ lockBallToPlayer skipped: missing sprite");
-    return;
-  }
-
-  console.log(
-    "🔒 lockBallToPlayer invoked for:",
-    playerSprite.name || playerSprite
-  );
-
-  if (scene?.tweens) {
-    scene.tweens.killTweensOf(ballSprite);
-  }
-
-  const { x, y } = playerSprite;
-  ballSprite.setPosition(x, y);
-  ballSprite.setVisible(true);
-
-  if (ballSprite.setDepth) {
-    ballSprite.setDepth(BALL_SPRITE_DEPTH);
-  }
-
-  // Track final ball owner on the scene if possible
-  if (scene) {
-    if (playerSprite.playerId) {
-      scene.ballAttachedToPlayerId = playerSprite.playerId;
-      scene.ballLastKnownOwnerId = playerSprite.playerId;
-    } else if (scene.playerSprites) {
-      for (const [pid, sprite] of Object.entries(scene.playerSprites)) {
-        if (sprite === playerSprite) {
-          scene.ballAttachedToPlayerId = pid;
-          scene.ballLastKnownOwnerId = pid;
-          break;
-        }
-      }
-    }
-  }
-}
 
 
 
@@ -369,7 +325,7 @@ export function animateRebound({
           duration: 300,
           ease: "Linear",
           onComplete: () => {
-            lockBallToPlayer(scene, ballSprite, rebounderSprite);
+            attachBallToPlayer(scene, ballSprite, rebounderSprite);
             resolve();
           },
           onStop: resolve
@@ -524,6 +480,10 @@ export function animateKickoutReset(
     );
   }
 
+  scene.events?.once('passStart', () => console.log('passStart'));
+  scene.events?.once('tweenStart', () => console.log('tweenStart'));
+  scene.events?.once('tweenEnd', () => console.log('tweenEnd'));
+
   return runPass(scene, opts).then(() => {
     if (!pgSprite.playerId) {
       scene.ballAttachedToPlayerId = pgId;
@@ -557,7 +517,7 @@ export function updateBallOwnership(scene, ballSprite, animations, playerSprites
     if (hasBallAtStep[stepIndex]) {
       const playerSprite = playerSprites[playerId];
       if (playerSprite) {
-        lockBallToPlayer(scene, ballSprite, playerSprite);
+        attachBallToPlayer(scene, ballSprite, playerSprite);
       }
       break; // Only one player can have the ball
     }
@@ -565,10 +525,10 @@ export function updateBallOwnership(scene, ballSprite, animations, playerSprites
 }
 
 
-// import { lockBallToPlayer, passBall } from "./ballManager.js";
+// import { attachBallToPlayer, passBall } from "./ballManager.js";
 
 // // Lock to player
-// lockBallToPlayer(ballSprite, playerSprites[playerId]);
+// attachBallToPlayer(ballSprite, playerSprites[playerId]);
 
 // // Animate pass
 // passBall({

--- a/FrontEnd/static/js/phaser/animation/ballTween.js
+++ b/FrontEnd/static/js/phaser/animation/ballTween.js
@@ -1,4 +1,5 @@
 import * as Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.60.0/dist/phaser.esm.js';
+import animationConfig from "./animation_config.js";
 
 const BALL_DEPTH = 1000;
 export const PASS_DEBUG = false;
@@ -22,6 +23,14 @@ export function attachBallToPlayer(scene, ballSprite, playerSprite, opts = {}) {
   if (typeof playerSprite.playerId !== 'undefined') {
     scene.ballAttachedToPlayerId = playerSprite.playerId;
     scene.ballLastKnownOwnerId = playerSprite.playerId;
+  } else if (scene.playerSprites) {
+    for (const [pid, sprite] of Object.entries(scene.playerSprites)) {
+      if (sprite === playerSprite) {
+        scene.ballAttachedToPlayerId = pid;
+        scene.ballLastKnownOwnerId = pid;
+        break;
+      }
+    }
   }
 }
 
@@ -166,7 +175,20 @@ export async function runPass(scene, cfg = {}) {
         resolveFn();
         return;
       }
-      await tweenBallTo(scene, ballSprite, end, { duration: usedDuration, easing: usedEasing });
+
+      const doTween = animationConfig.enableBallTween !== false;
+      if (doTween) {
+        scene.events?.emit('tweenStart', { fromId, toId, duration: usedDuration, easing: usedEasing });
+        await tweenBallTo(scene, ballSprite, end, { duration: usedDuration, easing: usedEasing });
+        scene.events?.emit('tweenEnd', { toId });
+      } else {
+        scene.events?.emit('tweenStart', { fromId, toId, skipped: true });
+        if (scene.tweens) scene.tweens.killTweensOf(ballSprite);
+        ballSprite.setPosition(end.x, end.y);
+        ballSprite.setVisible(true);
+        ballSprite.setDepth(BALL_DEPTH);
+        scene.events?.emit('tweenEnd', { toId, skipped: true });
+      }
       if (toSprite) {
         attachBallToPlayer(scene, ballSprite, toSprite);
         scene.ballDetached = false;

--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -2,7 +2,7 @@ import * as Phaser from "https://cdn.jsdelivr.net/npm/phaser@3.70.0/dist/phaser.
 import { animateStep } from "./animateStep.js";
 import { gridToPixels } from "../utils/gridToPixels.js";
 import {
-  lockBallToPlayer,
+  attachBallToPlayer,
   shootBall,
   SHOT_DEBUG,
   animateRebound,
@@ -172,18 +172,21 @@ async function runSideInboundSetup({ scene, ballSprite, playerSprites, turnData 
   const sfId = offenseIds["SF"];
   const pgId = offenseIds["PG"];
   if (sfSprite) {
-    lockBallToPlayer(scene, ballSprite, sfSprite);
+    attachBallToPlayer(scene, ballSprite, sfSprite);
     scene.ballAttachedToPlayerId = sfId;
     console.log("ballAttach(SF)");
 
     console.log(`[sideInbound][holdStart] sf:${sfId} pg:${pgId}`);
     await new Promise((resolve) => scene.time.delayedCall(1000, resolve));
 
+    scene.events?.once('passStart', () => console.log('passStart'));
+    scene.events?.once('tweenStart', () => console.log('tweenStart'));
+    scene.events?.once('tweenEnd', () => console.log('tweenEnd'));
+    scene.events?.once('passEnd', () => console.log('passEnd'));
+
     console.log(`[sideInbound][passStart] sf:${sfId} pg:${pgId}`);
-    if (animationConfig.enableBallTween && pgSprite) {
+    if (pgSprite) {
       await runPass(scene, { fromId: sfId, toId: pgId, duration, easing: ease });
-    } else if (pgSprite) {
-      lockBallToPlayer(scene, ballSprite, pgSprite);
     }
     console.log(`[sideInbound][passEnd] sf:${sfId} pg:${pgId}`);
     if (pgSprite) {
@@ -474,7 +477,7 @@ async function runInboundSetup({
   ]);
 
   console.log(`[inbound][ballAttach][${newOffenseSide}] sf:${sfId} pg:${pgId}`);
-  lockBallToPlayer(scene, ballSprite, sfSprite);
+  attachBallToPlayer(scene, ballSprite, sfSprite);
   scene.ballAttachedToPlayerId = sfId;
 
   console.log(`[inbound][holdStart][${newOffenseSide}] sf:${sfId} pg:${pgId}`);
@@ -485,19 +488,19 @@ async function runInboundSetup({
     scene.tweens.killTweensOf(pgSprite);
   }
 
+  scene.events?.once('passStart', () => console.log('passStart'));
+  scene.events?.once('tweenStart', () => console.log('tweenStart'));
+  scene.events?.once('tweenEnd', () => console.log('tweenEnd'));
+  scene.events?.once('passEnd', () => console.log('passEnd'));
+
   console.log(`[inbound][passStart][${newOffenseSide}] sf:${sfId} pg:${pgId}`);
-  if (animationConfig.enableBallTween) {
-    await runPass(scene, {
-      fromId: sfId,
-      toId: pgId,
-      duration: 500,
-      easing: "Sine.easeInOut"
-    });
-  } else {
-    lockBallToPlayer(scene, ballSprite, pgSprite);
-  }
+  await runPass(scene, {
+    fromId: sfId,
+    toId: pgId,
+    duration: 500,
+    easing: "Sine.easeInOut"
+  });
   console.log(`[inbound][passEnd][${newOffenseSide}] sf:${sfId} pg:${pgId}`);
-  lockBallToPlayer(scene, ballSprite, pgSprite);
   scene.ballAttachedToPlayerId = pgId;
   console.log(`[inbound][pgAttach][${newOffenseSide}] sf:${sfId} pg:${pgId}`);
 
@@ -538,7 +541,7 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
   }
 
   if (step0OwnerSprite) {
-    lockBallToPlayer(scene, ballSprite, step0OwnerSprite);
+    attachBallToPlayer(scene, ballSprite, step0OwnerSprite);
     currentBallOwnerRef.value = step0OwnerSprite;
   }
 
@@ -696,7 +699,7 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
         const shooterId = evt.shooterId;
         const rebounderSprite = playerSprites[shooterId];
         if (!rebounderSprite) continue;
-        lockBallToPlayer(scene, ballSprite, rebounderSprite);
+        attachBallToPlayer(scene, ballSprite, rebounderSprite);
         const rimCoords =
           rebounderSprite.team === "home" ? HOME_RIM_COORDS : AWAY_RIM_COORDS;
         const putbackResult = await animatePutbackAttempt(

--- a/FrontEnd/static/js/phaser/testScene.js
+++ b/FrontEnd/static/js/phaser/testScene.js
@@ -2,7 +2,7 @@
 import { loadPhaserPlayers } from './setup/loadPhaserPlayers.js';
 import { playTurnAnimation } from './animation/turnAnimation.js';
 import { onAction } from './animation/onAction.js';
-import { passBall, lockBallToPlayer } from './animation/ballManager.js';
+import { passBall, attachBallToPlayer } from './animation/ballManager.js';
 import { gridToPixels } from './utils/gridToPixels.js';
 
 
@@ -72,7 +72,7 @@ export function createTestScene(Phaser) {
     const passStep = allPlayers[0].movement[1];
     const receiveStep = allPlayers[1].movement[0];
 
-    lockBallToPlayer(this, this.ballSprite, this.playerSprites[playerId]);
+    attachBallToPlayer(this, this.ballSprite, this.playerSprites[playerId]);
 
     if (!this.playerSprites) {
       console.error("❌ playerSprites is undefined!");

--- a/tests/js/ballManagerStub.mjs
+++ b/tests/js/ballManagerStub.mjs
@@ -1,4 +1,4 @@
-export function lockBallToPlayer() {}
+export function attachBallToPlayer() {}
 export const calls = [];
 export const SHOT_DEBUG = false;
 export const REBOUND_DEBUG = false;


### PR DESCRIPTION
## Summary
- route all pass actions through `runPass` and remove legacy ball locking
- respect `animationConfig.enableBallTween` and emit `tweenStart`/`tweenEnd` events
- instrument pass flows for side inbounds and inbound setups

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a272b7f7148328a6829ab28d3a7011