### PR TITLE
Improve debug logging for ball control events

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animateGameTurns.js
+++ b/FrontEnd/static/js/phaser/animation/animateGameTurns.js
@@ -64,11 +64,10 @@ export async function animateGameTurns({ //hasBallAtStep
         if (action === "handle_ball" && anim?.hasBallAtStep?.length) {
           const stepIndex = movement.findIndex(m => m.timestamp === timestamp);
           const ownsBall = anim.hasBallAtStep?.[stepIndex];
+          const logMsg = ownsBall && !scene.ballDetached ? 'handleBallAttach' : 'handleBallIgnored';
+          console.log(logMsg, { playerId, stepIndex, ownsBall, ballDetached: scene.ballDetached });
           if (ownsBall && !scene.ballDetached) {
-            console.log('handleBallAttach', { playerId, stepIndex });
             attachBallToPlayer(scene, ballSprite, sprite);
-          } else {
-            console.log('handleBallIgnored', { playerId, stepIndex, ownsBall, ballDetached: scene.ballDetached });
           }
         }
 

--- a/FrontEnd/static/js/phaser/animation/ballTween.js
+++ b/FrontEnd/static/js/phaser/animation/ballTween.js
@@ -151,8 +151,7 @@ export async function runPass(scene, cfg = {}) {
   (async () => {
     try {
       scene.events?.emit('passStart', { fromId, toId, duration: usedDuration, easing: usedEasing });
-      if (PASS_DEBUG)
-        console.log(`passStart(${fromId}→${toId})`, { duration: usedDuration, easing: usedEasing });
+      console.log('passStart', { fromId, toId, duration: usedDuration, easing: usedEasing });
 
       if (fromSprite) {
         attachBallToPlayer(scene, ballSprite, fromSprite);
@@ -168,7 +167,7 @@ export async function runPass(scene, cfg = {}) {
 
       detachBall(scene, ballSprite);
       scene.events?.emit('ballDetached');
-      if (PASS_DEBUG) console.log('ballDetached');
+      console.log('ballDetached');
 
       const end = endCoords || (toSprite ? { x: toSprite.x, y: toSprite.y } : null);
       if (!end) {
@@ -179,25 +178,29 @@ export async function runPass(scene, cfg = {}) {
       const doTween = animationConfig.enableBallTween !== false;
       if (doTween) {
         scene.events?.emit('tweenStart', { fromId, toId, duration: usedDuration, easing: usedEasing });
+        console.log('tweenStart', { fromId, toId, duration: usedDuration, easing: usedEasing });
         await tweenBallTo(scene, ballSprite, end, { duration: usedDuration, easing: usedEasing });
         scene.events?.emit('tweenEnd', { toId });
+        console.log('tweenEnd', { toId });
       } else {
         scene.events?.emit('tweenStart', { fromId, toId, skipped: true });
+        console.log('tweenStart', { fromId, toId, skipped: true });
         if (scene.tweens) scene.tweens.killTweensOf(ballSprite);
         ballSprite.setPosition(end.x, end.y);
         ballSprite.setVisible(true);
         ballSprite.setDepth(BALL_DEPTH);
         scene.events?.emit('tweenEnd', { toId, skipped: true });
+        console.log('tweenEnd', { toId, skipped: true });
       }
       if (toSprite) {
         attachBallToPlayer(scene, ballSprite, toSprite);
         scene.ballDetached = false;
         scene.events?.emit('ballAttached', { toId });
-        if (PASS_DEBUG) console.log(`ballAttached(${toId})`);
+        console.log('ballAttached', { toId });
       }
 
       scene.events?.emit('passEnd', { toId });
-      if (PASS_DEBUG) console.log(`passEnd(${toId})`);
+      console.log('passEnd', { toId });
       resolveFn();
     } catch (err) {
       const lastId = scene.ballLastKnownOwnerId;

--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -32,7 +32,7 @@ function updateBallOwnership({ scene, ballSprite, animations, playerSprites, ste
   if (passHappening) return;
 
   if (scene.ballDetached) {
-    console.log('ownershipSkipped');
+    console.log('ownershipSkipped', { stepIndex });
     return;
   }
 
@@ -44,7 +44,7 @@ function updateBallOwnership({ scene, ballSprite, animations, playerSprites, ste
       ballSprite.setPosition(sprite.x, sprite.y);
       ballSprite.setVisible(true);
       if (currentBallOwnerRef) currentBallOwnerRef.value = sprite;
-      console.log('ownershipApplied');
+      console.log('ownershipApplied', { playerId: anim.playerId, stepIndex });
       break;
     }
 


### PR DESCRIPTION
## Summary
- log key pass events in `runPass` such as passStart and ballDetached
- consolidate handle_ball logging to consistently output attach vs ignore
- include step details when ball ownership is applied or skipped

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a279ff874083289b95f948688b43bd