### PR TITLE
Handle ball detachment during passes

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballTween.js
+++ b/FrontEnd/static/js/phaser/animation/ballTween.js
@@ -166,6 +166,7 @@ export async function runPass(scene, cfg = {}) {
       }
 
       detachBall(scene, ballSprite);
+      scene.ballDetached = true;
       scene.events?.emit('ballDetached');
       console.log('ballDetached');
 

--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -26,15 +26,15 @@ const AWAY_RIM_COORDS = { x: 9, y: 25 };
 function updateBallOwnership({ scene, ballSprite, animations, playerSprites, stepIndex, offenseTeamId, currentBallOwnerRef }) {
   if (scene?.skipToEnd) return;
 
-  const passHappening = animations.some(
-    anim => anim.movement?.[stepIndex]?.action === "pass"
-  );
-  if (passHappening) return;
-
   if (scene.ballDetached) {
     console.log('ownershipSkipped', { stepIndex });
     return;
   }
+
+  const passHappening = animations.some(
+    anim => anim.movement?.[stepIndex]?.action === "pass"
+  );
+  if (passHappening) return;
 
   for (const anim of animations) {
     if (scene.skipToEnd) break;


### PR DESCRIPTION
## Summary
- Skip ball ownership updates when ball is detached
- Track ball detachment during passes and reset when attached to receiver

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a27f69c19083288cb57ac72a9d7674