### PR TITLE
refactor: route passes through runPass

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animateGameTurns.js
+++ b/FrontEnd/static/js/phaser/animation/animateGameTurns.js
@@ -1,6 +1,6 @@
 import { playTurnAnimation, runSideInboundSetup } from "./turnAnimation.js";
 import { onAction } from "./onAction.js";
-import { runPass, attachBallToPlayer } from "./ballManager.js";
+import { runPass } from "./ballManager.js";
 import animationConfig from "./animation_config.js";
 
 /**
@@ -60,23 +60,6 @@ export async function animateGameTurns({ //hasBallAtStep
 
         const anim = animations.find(a => a.playerId === playerId);
         const movement = anim?.movement || [];
-
-        if (action === "handle_ball" && anim?.hasBallAtStep?.length) {
-          const stepIndex = movement.findIndex(m => m.timestamp === timestamp);
-          const ownsBall = anim.hasBallAtStep?.[stepIndex];
-
-          if (ownsBall && !scene.ballDetached) {
-            console.log('🔗 attaching ball to player', { playerId, stepIndex });
-            attachBallToPlayer(scene, ballSprite, sprite);
-          } else {
-            console.log('⚠️ attachBallToPlayer skipped', {
-              playerId,
-              stepIndex,
-              ownsBall,
-              ballDetached: scene.ballDetached
-            });
-          }
-        }
 
         if (action === "pass") {
           const passStep = movement.find(m => m.action === "pass");

--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -484,11 +484,7 @@ export function animateKickoutReset(
   scene.events?.once('tweenStart', () => console.log('tweenStart'));
   scene.events?.once('tweenEnd', () => console.log('tweenEnd'));
 
-  return runPass(scene, opts).then(() => {
-    if (!pgSprite.playerId) {
-      scene.ballAttachedToPlayerId = pgId;
-    }
-  });
+  return runPass(scene, opts);
 }
 
 /**

--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -117,6 +117,7 @@ async function runSideInboundSetup({ scene, ballSprite, playerSprites, turnData 
   const offenseIds = {};
 
   if (scene.tweens) scene.tweens.killTweensOf(ballSprite);
+  if (!scene.ballSprite) scene.ballSprite = ballSprite;
 
   for (const [id, sprite] of Object.entries(playerSprites)) {
     const info = scene.playerInfo?.[id];
@@ -173,7 +174,6 @@ async function runSideInboundSetup({ scene, ballSprite, playerSprites, turnData 
   const pgId = offenseIds["PG"];
   if (sfSprite) {
     attachBallToPlayer(scene, ballSprite, sfSprite);
-    scene.ballAttachedToPlayerId = sfId;
     console.log("ballAttach(SF)");
 
     console.log(`[sideInbound][holdStart] sf:${sfId} pg:${pgId}`);
@@ -190,7 +190,6 @@ async function runSideInboundSetup({ scene, ballSprite, playerSprites, turnData 
     }
     console.log(`[sideInbound][passEnd] sf:${sfId} pg:${pgId}`);
     if (pgSprite) {
-      scene.ballAttachedToPlayerId = pgId;
       console.log(`[sideInbound][pgAttach] sf:${sfId} pg:${pgId}`);
     }
   }
@@ -206,6 +205,7 @@ async function runInboundSetup({
   awayTeamId
 }) {
   scene.isInboundSetup = true;
+  if (!scene.ballSprite) scene.ballSprite = ballSprite;
   const isAwayOffense = newOffenseSide === "away";
 
   // Derive missing team IDs from sprite metadata
@@ -478,7 +478,6 @@ async function runInboundSetup({
 
   console.log(`[inbound][ballAttach][${newOffenseSide}] sf:${sfId} pg:${pgId}`);
   attachBallToPlayer(scene, ballSprite, sfSprite);
-  scene.ballAttachedToPlayerId = sfId;
 
   console.log(`[inbound][holdStart][${newOffenseSide}] sf:${sfId} pg:${pgId}`);
   await new Promise((resolve) => scene.time.delayedCall(1000, resolve));
@@ -501,7 +500,6 @@ async function runInboundSetup({
     easing: "Sine.easeInOut"
   });
   console.log(`[inbound][passEnd][${newOffenseSide}] sf:${sfId} pg:${pgId}`);
-  scene.ballAttachedToPlayerId = pgId;
   console.log(`[inbound][pgAttach][${newOffenseSide}] sf:${sfId} pg:${pgId}`);
 
   scene.isInboundSetup = false;


### PR DESCRIPTION
## Summary
- remove direct attachBallToPlayer calls from animateGameTurns receive flow
- rely on runPass for inbound and kickout passes
- ensure inbound helpers expose ball sprite on scene

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2fccc2d888328958b62b735ed4b48