### PR TITLE
Enable ball tween by default and cover runPass flag

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animation_config.js
+++ b/FrontEnd/static/js/phaser/animation/animation_config.js
@@ -1,5 +1,6 @@
 const defaults = {
-  enableBallTween: false,
+  // Enable ball tweening by default; tests can override via global animation_config
+  enableBallTween: true,
   pass: {
     duration: 150,
     easing: 'Sine.easeInOut',

--- a/tests/js/runPassTweenFlag.mjs
+++ b/tests/js/runPassTweenFlag.mjs
@@ -1,0 +1,47 @@
+const enable = process.argv.includes('--enable');
+
+globalThis.animation_config = { enableBallTween: enable };
+
+const { runPass } = await import('../../FrontEnd/static/js/phaser/animation/ballTween.js');
+
+let tweenCalled = false;
+
+const ballSprite = {
+  x: 0,
+  y: 0,
+  setPosition(x, y) {
+    this.x = x;
+    this.y = y;
+  },
+  setVisible() {},
+  setDepth() {},
+};
+
+const scene = {
+  tweens: {
+    add: (cfg) => {
+      tweenCalled = true;
+      if (cfg.targets === ballSprite) {
+        ballSprite.x = cfg.x;
+        ballSprite.y = cfg.y;
+      }
+      cfg.onComplete?.();
+      return { once: () => {}, stop: () => {} };
+    },
+    killTweensOf: () => {},
+  },
+  game: { loop: { frame: 0 }, config: { width: 100, height: 100 } },
+  events: { emit: () => {} },
+  ballSprite,
+};
+
+await runPass(scene, {
+  startCoords: { x: 0, y: 0 },
+  endCoords: { x: 10, y: 20 },
+  duration: 10,
+  easing: 'Linear',
+});
+
+console.log(
+  JSON.stringify({ tweenCalled, x: ballSprite.x, y: ballSprite.y })
+);

--- a/tests/test_run_pass_tween_flag.py
+++ b/tests/test_run_pass_tween_flag.py
@@ -1,0 +1,26 @@
+import json
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def run_case(enable: bool):
+    cmd = [
+        "node",
+        "--loader",
+        str(ROOT / "tests/js/httpsLoaderNoStubBall.mjs"),
+        str(ROOT / "tests/js/runPassTweenFlag.mjs"),
+    ]
+    if enable:
+        cmd.append("--enable")
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return json.loads(completed.stdout.strip().splitlines()[-1])
+
+
+def test_run_pass_respects_flag():
+    off = run_case(False)
+    assert off["tweenCalled"] is False
+    assert off["x"] == 10 and off["y"] == 20
+    on = run_case(True)
+    assert on["tweenCalled"] is True


### PR DESCRIPTION
## Summary
- Enable ball tweening by default while allowing global overrides
- Add tests verifying runPass skips tween when the flag is disabled

## Testing
- `pytest tests/test_generate_ball_tween_flag.py tests/test_run_pass_tween_flag.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2ff8545908328914cce1828fd4051