### PR TITLE
Handle steal animations and add steal action effect

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animateGameTurns.js
+++ b/FrontEnd/static/js/phaser/animation/animateGameTurns.js
@@ -1,6 +1,6 @@
 import { playTurnAnimation, runSideInboundSetup } from "./turnAnimation.js";
 import { onAction } from "./onAction.js";
-import { runPass } from "./ballManager.js";
+import { runPass, attachBallToPlayer } from "./ballManager.js";
 import animationConfig from "./animation_config.js";
 
 /**
@@ -106,6 +106,31 @@ export async function animateGameTurns({ //hasBallAtStep
         // }
       }
     });
+
+    const stealEvent = turn.events?.find(e => e.event_type === "STEAL");
+    if (turn.result_type === "STEAL" || stealEvent) {
+      const ballHandlerId = playerMap[turn.ball_handler] ?? turn.ball_handler;
+      const stealerRaw =
+        turn.stealerId ||
+        turn.stealer_id ||
+        stealEvent?.stealerId ||
+        stealEvent?.stealer_id;
+      const stealerId = stealerRaw ?? playerMap[turn.stealer_name];
+      if (ballHandlerId != null && stealerId != null) {
+        const cfg = animationConfig.steal || {};
+        await runPass(scene, {
+          fromId: ballHandlerId,
+          toId: stealerId,
+          duration: cfg.duration,
+          easing: cfg.easing
+        });
+        const defenderSprite = playerSprites[stealerId];
+        if (defenderSprite) {
+          attachBallToPlayer(scene, ballSprite, defenderSprite);
+          scene.events?.emit?.('possessionChange', { offenseTeamId: defenderSprite.team_id });
+        }
+      }
+    }
 
     if (onUpdate) {
       try {

--- a/FrontEnd/static/js/phaser/animation/animation_config.js
+++ b/FrontEnd/static/js/phaser/animation/animation_config.js
@@ -16,6 +16,11 @@ const defaults = {
     easing: 'Sine.easeInOut',
     arc: null,
   },
+  steal: {
+    duration: 150,
+    easing: 'Sine.easeInOut',
+    arc: null,
+  },
 };
 
 const overrides =
@@ -26,6 +31,7 @@ export const animationConfig = {
   pass: { ...defaults.pass, ...(overrides.pass || {}) },
   inbound: { ...defaults.inbound, ...(overrides.inbound || {}) },
   kickout: { ...defaults.kickout, ...(overrides.kickout || {}) },
+  steal: { ...defaults.steal, ...(overrides.steal || {}) },
 };
 
 export default animationConfig;

--- a/FrontEnd/static/js/phaser/animation/onAction.js
+++ b/FrontEnd/static/js/phaser/animation/onAction.js
@@ -58,7 +58,18 @@ export function onAction(action, sprite, timestamp) {
           ease: "Back.easeOut"
         });
         break;
-  
+
+      case "steal":
+        // Brief flash to highlight defender
+        scene.tweens.add({
+          targets: sprite,
+          alpha: 0.5,
+          duration: 100,
+          yoyo: true,
+          ease: "Sine.easeInOut"
+        });
+        break;
+
       default:
         // No effect for unrecognized actions
         break;


### PR DESCRIPTION
## Summary
- Animate ball transfer on steals by passing from the ball handler to the stealer and reattaching the ball to the defender
- Add `steal` tween configuration
- Provide a brief visual effect when a steal action occurs

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node tests/js/runReboundAnimation.mjs` *(fails: ERR_UNSUPPORTED_ESM_URL_SCHEME)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a302c3a7e0832898ecdbeeeca0b829