### PR TITLE
Track pass animation flags with cleanup

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballTween.js
+++ b/FrontEnd/static/js/phaser/animation/ballTween.js
@@ -148,6 +148,9 @@ export async function runPass(scene, cfg = {}) {
   });
   scene.__activePass = { key, frame, promise, reject: rejectFn };
 
+  scene.passInFlight = true;
+  scene.pendingBallOwnerId = toId;
+
   (async () => {
     try {
       scene.events?.emit('passStart', { fromId, toId, duration: usedDuration, easing: usedEasing });
@@ -213,6 +216,8 @@ export async function runPass(scene, cfg = {}) {
     } finally {
       if (scene.__activePass && scene.__activePass.key === key && scene.__activePass.frame === frame) {
         scene.__activePass = null;
+        scene.passInFlight = false;
+        scene.pendingBallOwnerId = null;
       }
     }
   })();


### PR DESCRIPTION
## Summary
- mark pass in flight and pending owner at animation start
- clear pass and pending owner flags after pass ends or errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a30a2f0a90832887b7bc560267137b