### PR TITLE
Handle pass state in ball ownership

### DIFF
--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -26,8 +26,23 @@ const AWAY_RIM_COORDS = { x: 9, y: 25 };
 function updateBallOwnership({ scene, ballSprite, animations, playerSprites, stepIndex, offenseTeamId, currentBallOwnerRef }) {
   if (scene?.skipToEnd) return;
 
+  if (scene.passInFlight) return;
+
   if (scene.ballDetached) {
     console.log('ownershipSkipped', { stepIndex });
+    return;
+  }
+
+  if (scene.pendingBallOwnerId != null) {
+    const pendingId = scene.pendingBallOwnerId;
+    const pendingSprite = playerSprites[pendingId];
+    if (pendingSprite && ballSprite?.setPosition) {
+      ballSprite.setPosition(pendingSprite.x, pendingSprite.y);
+      ballSprite.setVisible(true);
+      if (currentBallOwnerRef) currentBallOwnerRef.value = pendingSprite;
+      console.log('ownershipApplied', { playerId: pendingId, stepIndex });
+    }
+    scene.pendingBallOwnerId = null;
     return;
   }
 


### PR DESCRIPTION
## Summary
- Avoid ball ownership updates while a pass is in flight
- Attach ball to pending owner after a pass completes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a30c25d99483288f713abf928d2411