### PR TITLE
Ensure async onStart completes before tween resolves

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animateStep.js
+++ b/FrontEnd/static/js/phaser/animation/animateStep.js
@@ -20,15 +20,18 @@ export function animateStep({ scene, sprite, step, duration, ballSprite, current
       scene.game.config.height
     );
 
+    let startPromise = Promise.resolve();
+
     const tween = scene.tweens.add({
       targets: [sprite],
       x: targetX,
       y: targetY,
       duration,
       ease: "Linear",
-      onStart: () => {
+      onStart: async () => {
         if (step.action && onAction) {
-          onAction(step.action, sprite, step.timestamp);
+          startPromise = onAction(step.action, sprite, step.timestamp);
+          await startPromise;
         }
       },
       onUpdate: () => {
@@ -36,8 +39,14 @@ export function animateStep({ scene, sprite, step, duration, ballSprite, current
           ballSprite.setPosition(sprite.x, sprite.y);
         }
       },
-      onComplete: resolve,
-      onStop: resolve
+      onComplete: async () => {
+        await startPromise;
+        resolve();
+      },
+      onStop: async () => {
+        await startPromise;
+        resolve();
+      }
     });
 
     if (scene.skipToEnd) {


### PR DESCRIPTION
## Summary
- Handle async actions during step animation start and wait for them before completing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a30d390ed08328af17beebf2847a3d