### PR TITLE
Handle duplicate runPass calls

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballTween.js
+++ b/FrontEnd/static/js/phaser/animation/ballTween.js
@@ -121,7 +121,8 @@ export async function runPass(scene, cfg = {}) {
   const key = `${fromId ?? ''}-${toId ?? ''}`;
 
   if (scene.__activePass && scene.__activePass.key === key && scene.__activePass.frame === frame) {
-    return scene.__activePass.promise;
+    console.log('duplicate runPass ignored', { fromId, toId, frame });
+    return Promise.resolve();
   }
 
   if (scene.__activePass) {


### PR DESCRIPTION
## Summary
- log and ignore duplicate `runPass` calls within the same frame and return a resolved promise

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a30f2302fc8328aab92d85087f506e