### PR TITLE
Add optional pass debug logging

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animateStep.js
+++ b/FrontEnd/static/js/phaser/animation/animateStep.js
@@ -10,6 +10,8 @@ import { gridToPixels } from "../utils/gridToPixels.js";
  * @param {number} duration - Milliseconds for tween duration
  * @returns {Promise} resolves when tween completes
  */
+import { PASS_DEBUG } from "./ballTween.js";
+
 export function animateStep({ scene, sprite, step, duration, ballSprite, currentBallOwnerRef, onAction }) {
   if (scene.skipToEnd) return Promise.resolve();
   return new Promise((resolve) => {
@@ -30,6 +32,9 @@ export function animateStep({ scene, sprite, step, duration, ballSprite, current
       ease: "Linear",
       onStart: async () => {
         if (step.action && onAction) {
+          if (PASS_DEBUG && step.action === 'pass') {
+            console.log('passStart', { fromId: sprite?.playerId, timestamp: step.timestamp });
+          }
           startPromise = onAction(step.action, sprite, step.timestamp);
           await startPromise;
         }

--- a/FrontEnd/static/js/phaser/animation/ballTween.js
+++ b/FrontEnd/static/js/phaser/animation/ballTween.js
@@ -121,7 +121,7 @@ export async function runPass(scene, cfg = {}) {
   const key = `${fromId ?? ''}-${toId ?? ''}`;
 
   if (scene.__activePass && scene.__activePass.key === key && scene.__activePass.frame === frame) {
-    console.log('duplicate runPass ignored', { fromId, toId, frame });
+    if (PASS_DEBUG) console.log('duplicate runPass ignored', { fromId, toId, frame });
     return Promise.resolve();
   }
 
@@ -155,7 +155,7 @@ export async function runPass(scene, cfg = {}) {
   (async () => {
     try {
       scene.events?.emit('passStart', { fromId, toId, duration: usedDuration, easing: usedEasing });
-      console.log('passStart', { fromId, toId, duration: usedDuration, easing: usedEasing });
+      if (PASS_DEBUG) console.log('passStart', { fromId, toId, duration: usedDuration, easing: usedEasing });
 
       if (fromSprite) {
         attachBallToPlayer(scene, ballSprite, fromSprite);
@@ -172,7 +172,7 @@ export async function runPass(scene, cfg = {}) {
       detachBall(scene, ballSprite);
       scene.ballDetached = true;
       scene.events?.emit('ballDetached');
-      console.log('ballDetached');
+      if (PASS_DEBUG) console.log('detach(A)', { fromId });
 
       const end = endCoords || (toSprite ? { x: toSprite.x, y: toSprite.y } : null);
       if (!end) {
@@ -183,29 +183,29 @@ export async function runPass(scene, cfg = {}) {
       const doTween = animationConfig.enableBallTween !== false;
       if (doTween) {
         scene.events?.emit('tweenStart', { fromId, toId, duration: usedDuration, easing: usedEasing });
-        console.log('tweenStart', { fromId, toId, duration: usedDuration, easing: usedEasing });
+        if (PASS_DEBUG) console.log('tweenStart', { fromId, toId, duration: usedDuration, easing: usedEasing });
         await tweenBallTo(scene, ballSprite, end, { duration: usedDuration, easing: usedEasing });
         scene.events?.emit('tweenEnd', { toId });
-        console.log('tweenEnd', { toId });
+        if (PASS_DEBUG) console.log('tweenEnd', { toId });
       } else {
         scene.events?.emit('tweenStart', { fromId, toId, skipped: true });
-        console.log('tweenStart', { fromId, toId, skipped: true });
+        if (PASS_DEBUG) console.log('tweenStart', { fromId, toId, skipped: true });
         if (scene.tweens) scene.tweens.killTweensOf(ballSprite);
         ballSprite.setPosition(end.x, end.y);
         ballSprite.setVisible(true);
         ballSprite.setDepth(BALL_DEPTH);
         scene.events?.emit('tweenEnd', { toId, skipped: true });
-        console.log('tweenEnd', { toId, skipped: true });
+        if (PASS_DEBUG) console.log('tweenEnd', { toId, skipped: true });
       }
       if (toSprite) {
         attachBallToPlayer(scene, ballSprite, toSprite);
         scene.ballDetached = false;
         scene.events?.emit('ballAttached', { toId });
-        console.log('ballAttached', { toId });
+        if (PASS_DEBUG) console.log('attach(B)', { toId });
       }
 
       scene.events?.emit('passEnd', { toId });
-      console.log('passEnd', { toId });
+      if (PASS_DEBUG) console.log('passEnd', { toId });
       resolveFn();
     } catch (err) {
       const lastId = scene.ballLastKnownOwnerId;

--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -9,7 +9,7 @@ import {
   animatePutbackAttempt,
   animateKickoutReset
 } from "./ballManager.js";
-import { tweenBallTo, runPass } from "./ballTween.js";
+import { tweenBallTo, runPass, PASS_DEBUG } from "./ballTween.js";
 import animationConfig from "./animation_config.js";
 
 // Cap the time spent on any single movement step. Large timestamp gaps can
@@ -29,7 +29,7 @@ function updateBallOwnership({ scene, ballSprite, animations, playerSprites, ste
   if (scene.passInFlight) return;
 
   if (scene.ballDetached) {
-    console.log('ownershipSkipped', { stepIndex });
+    if (PASS_DEBUG) console.log('ownershipSkipped', { stepIndex });
     return;
   }
 
@@ -40,7 +40,7 @@ function updateBallOwnership({ scene, ballSprite, animations, playerSprites, ste
       ballSprite.setPosition(pendingSprite.x, pendingSprite.y);
       ballSprite.setVisible(true);
       if (currentBallOwnerRef) currentBallOwnerRef.value = pendingSprite;
-      console.log('ownershipApplied', { playerId: pendingId, stepIndex });
+      if (PASS_DEBUG) console.log('ownershipUpdate', { target: pendingId, stepIndex });
     }
     scene.pendingBallOwnerId = null;
     return;
@@ -59,7 +59,7 @@ function updateBallOwnership({ scene, ballSprite, animations, playerSprites, ste
       ballSprite.setPosition(sprite.x, sprite.y);
       ballSprite.setVisible(true);
       if (currentBallOwnerRef) currentBallOwnerRef.value = sprite;
-      console.log('ownershipApplied', { playerId: anim.playerId, stepIndex });
+      if (PASS_DEBUG) console.log('ownershipUpdate', { target: anim.playerId, stepIndex });
       break;
     }
 


### PR DESCRIPTION
## Summary
- Add PASS_DEBUG-gated logging for pass lifecycle: start, detach, tween start/end, attach, and completion
- Track ball ownership updates with optional debug logs
- Expose pass start logging in animateStep for step-based actions

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3106114c483289ab0cbc1cde1992b