### PR TITLE
Preserve pending ball owner for ownership update

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballTween.js
+++ b/FrontEnd/static/js/phaser/animation/ballTween.js
@@ -218,7 +218,7 @@ export async function runPass(scene, cfg = {}) {
       if (scene.__activePass && scene.__activePass.key === key && scene.__activePass.frame === frame) {
         scene.__activePass = null;
         scene.passInFlight = false;
-        scene.pendingBallOwnerId = null;
+        // Allow pendingBallOwnerId to persist so updateBallOwnership can consume it
       }
     }
   })();


### PR DESCRIPTION
## Summary
- Retain `pendingBallOwnerId` after pass completion so `updateBallOwnership` can set the new owner

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a31b35afc4832886cc86f26b10140d