### PR TITLE
Prevent ball reattach during pass tween

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animateStep.js
+++ b/FrontEnd/static/js/phaser/animation/animateStep.js
@@ -40,7 +40,11 @@ export function animateStep({ scene, sprite, step, duration, ballSprite, current
         }
       },
       onUpdate: () => {
-        if (currentBallOwnerRef?.value === sprite && ballSprite?.setPosition) {
+        if (
+          currentBallOwnerRef?.value === sprite &&
+          ballSprite?.setPosition &&
+          !scene.pendingBallOwnerId
+        ) {
           ballSprite.setPosition(sprite.x, sprite.y);
         }
       },


### PR DESCRIPTION
## Summary
- prevent passer's tween from resetting ball position while a new owner is pending

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a31d8ec0288328be00e1cda1cc61ad