### PR TITLE
Track ball owner on scene

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballTween.js
+++ b/FrontEnd/static/js/phaser/animation/ballTween.js
@@ -199,6 +199,11 @@ export async function runPass(scene, cfg = {}) {
       }
       if (toSprite) {
         attachBallToPlayer(scene, ballSprite, toSprite);
+        // Update the global ball owner reference so other systems know who
+        // currently has possession after the pass completes.
+        if (scene.currentBallOwnerRef) {
+          scene.currentBallOwnerRef.value = toSprite;
+        }
         scene.ballDetached = false;
         scene.events?.emit('ballAttached', { toId });
         if (PASS_DEBUG) console.log('attach(B)', { toId });

--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -526,6 +526,9 @@ async function runInboundSetup({
  */
 export async function playTurnAnimation({ scene, simData, playerSprites, turnData, ballSprite, onAction }) {
   const currentBallOwnerRef = { value: null };
+  // Store a reference on the scene so other modules (e.g., runPass)
+  // can update ball ownership consistently.
+  scene.currentBallOwnerRef = currentBallOwnerRef;
   const maxSteps = Math.max(
     ...turnData.animations.map(anim => anim.movement.length)
   );


### PR DESCRIPTION
## Summary
- expose currentBallOwnerRef on the Phaser scene for easier access
- update runPass to refresh scene.currentBallOwnerRef when a pass finishes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a31f143adc8328a4efd4ab2c9804e6