### PR TITLE
Show latest turn first in game log

### DIFF
--- a/FrontEnd/app.js
+++ b/FrontEnd/app.js
@@ -33,7 +33,8 @@ async function simulateGame() {
     logContainer.innerHTML = ""; // clear previous
     text_log.forEach((turn, i) => {
       const text = turn.text || JSON.stringify(turn); // fallback in case text is missing
-      logContainer.innerHTML += `Turn ${i + 1}: ${text}\n`;
+      // Prepend so the most recent turn appears first
+      logContainer.innerHTML = `Turn ${i + 1}: ${text}\n` + logContainer.innerHTML;
     });
 
 


### PR DESCRIPTION
## Summary
- Display newest turn at top of gameplay log by prepending entries

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a31ff176508328b3ea29215609814a