### PR TITLE
Prepend game log entries with DOM elements

### DIFF
--- a/FrontEnd/app.js
+++ b/FrontEnd/app.js
@@ -29,13 +29,14 @@ async function simulateGame() {
     const data = await response.json();
     console.log("📦 Full response from backend:", data);
     
-    const text_log = data.text_log || [];
+    const turns = data.text_log || [];
     logContainer.innerHTML = ""; // clear previous
-    text_log.forEach((turn, i) => {
-      const text = turn.text || JSON.stringify(turn); // fallback in case text is missing
-      // Prepend so the most recent turn appears first
-      logContainer.innerHTML = `Turn ${i + 1}: ${text}\n` + logContainer.innerHTML;
+    turns.forEach((turn, idx) => {
+      const line = document.createElement('div');
+      line.textContent = `Turn ${idx + 1}: ${turn.text || JSON.stringify(turn)}`;
+      logContainer.prepend(line); // newest at top
     });
+    logContainer.scrollTop = 0; // ensure view starts at top
 
 
     // text_log.forEach((turn, i) => {


### PR DESCRIPTION
## Summary
- Build the game log using DOM elements instead of string concatenation
- Ensure newest turns appear first and reset scroll position

## Testing
- `pre-commit run --files FrontEnd/app.js FrontEnd/index_legacy.html` *(fails: .pre-commit-config.yaml is not a file)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a325027b4483288547b2c5d4f03000