### PR TITLE
feat: add free throw animation sequence

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animateGameTurns.js
+++ b/FrontEnd/static/js/phaser/animation/animateGameTurns.js
@@ -2,6 +2,7 @@ import { playTurnAnimation, runSideInboundSetup } from "./turnAnimation.js";
 import { onAction } from "./onAction.js";
 import { runPass } from "./ballManager.js";
 import animationConfig from "./animation_config.js";
+import runFreeThrowSequence from "./freeThrow.js";
 
 /**
  * Animate all turns from simData.turns using real backend structure.
@@ -22,6 +23,18 @@ export async function animateGameTurns({ //hasBallAtStep
     turn.index = i;
     if (scene.skipToEnd) break;
     console.log(`🔁 Turn ${i + 1}`, turn);
+
+    if (turn.result_type === "FREE_THROW") {
+      await runFreeThrowSequence(scene, { playerSprites, ballSprite, turnData: turn, onUpdate });
+      if (onUpdate) {
+        try {
+          onUpdate(turn);
+        } catch (err) {
+          console.error('Scoreboard update failed:', err);
+        }
+      }
+      continue;
+    }
 
     if (turn.result_type === "SIDE_INBOUND") {
       await runSideInboundSetup({ scene, ballSprite, playerSprites, turnData: turn });

--- a/FrontEnd/static/js/phaser/animation/animation_config.js
+++ b/FrontEnd/static/js/phaser/animation/animation_config.js
@@ -21,6 +21,13 @@ const defaults = {
     easing: 'Sine.easeInOut',
     arc: null,
   },
+  freeThrow: {
+    lineupMoveMs: 800,
+    shooterPrepMs: 400,
+    shotMs: 500,
+    arcHeight: 40,
+    rimHoldMs: 300,
+  },
 };
 
 const overrides =
@@ -32,6 +39,7 @@ export const animationConfig = {
   inbound: { ...defaults.inbound, ...(overrides.inbound || {}) },
   kickout: { ...defaults.kickout, ...(overrides.kickout || {}) },
   steal: { ...defaults.steal, ...(overrides.steal || {}) },
+  freeThrow: { ...defaults.freeThrow, ...(overrides.freeThrow || {}) },
 };
 
 export default animationConfig;

--- a/FrontEnd/static/js/phaser/animation/freeThrow.js
+++ b/FrontEnd/static/js/phaser/animation/freeThrow.js
@@ -1,0 +1,243 @@
+import { gridToPixels } from "../utils/gridToPixels.js";
+import animationConfig from "./animation_config.js";
+
+const positionList = ["PG", "SG", "SF", "PF", "C"];
+
+const HOME = {
+  shooterSpot: { x: 74, y: 25 },
+  offenseAlignList: [
+    { x: 56, y: 44 },
+    { x: 80, y: 32 },
+    { x: 86, y: 19 },
+    { x: 86, y: 32 },
+  ],
+  dDestinationDict: {
+    PG: { x: 54, y: 37 },
+    SG: { x: 83, y: 32 },
+    SF: { x: 83, y: 19 },
+    PF: { x: 89, y: 32 },
+    C: { x: 89, y: 19 },
+  },
+  rim: { x: 91, y: 25 },
+};
+
+const AWAY = {
+  shooterSpot: { x: 27, y: 25 },
+  offenseAlignList: [
+    { x: 45, y: 44 },
+    { x: 20, y: 32 },
+    { x: 14, y: 19 },
+    { x: 14, y: 32 },
+  ],
+  dDestinationDict: {
+    PG: { x: 47, y: 37 },
+    SG: { x: 17, y: 32 },
+    SF: { x: 17, y: 19 },
+    PF: { x: 11, y: 32 },
+    C: { x: 11, y: 19 },
+  },
+  rim: { x: 9, y: 25 },
+};
+
+export function buildDestinations(offenseIsHome, shooterPos) {
+  const cfg = offenseIsHome ? HOME : AWAY;
+  const shooterSpot = cfg.shooterSpot;
+  const oDestinationDict = {};
+  oDestinationDict[shooterPos] = shooterSpot;
+  const positionListMinusShooter = positionList.filter((p) => p !== shooterPos);
+  for (let i = 0; i < positionListMinusShooter.length; i++) {
+    const pos = positionListMinusShooter[i];
+    oDestinationDict[pos] = cfg.offenseAlignList[i];
+  }
+  return {
+    oDestinations: oDestinationDict,
+    dDestinations: cfg.dDestinationDict,
+    shooterSpot,
+    rim: cfg.rim,
+  };
+}
+
+function wait(scene, ms) {
+  if (!ms) return Promise.resolve();
+  return scene.time?.delayedCall
+    ? new Promise((res) => scene.time.delayedCall(ms, res))
+    : new Promise((res) => setTimeout(res, ms));
+}
+
+export async function runFreeThrowSequence(
+  scene,
+  {
+    playerSprites,
+    ballSprite,
+    turnData,
+    onUpdate,
+    helpers = {},
+  }
+) {
+  const attach =
+    helpers.attachBallToPlayer ||
+    (await import("./ballTween.js")).attachBallToPlayer;
+  const detach =
+    helpers.detachBall || (await import("./ballTween.js")).detachBall;
+  const tween =
+    helpers.tweenBallTo || (await import("./ballTween.js")).tweenBallTo;
+  const inboundSetup =
+    helpers.runInboundSetup || (await import("./turnAnimation.js")).runInboundSetup;
+  const rebound =
+    helpers.animateRebound || (await import("./ballManager.js")).animateRebound;
+
+  if (!scene || !playerSprites || !ballSprite || !turnData) return;
+
+  scene.ftInProgress = true;
+  scene.events?.emit("ft:start", {});
+  if (scene.tweens) {
+    for (const sprite of Object.values(playerSprites)) {
+      scene.tweens.killTweensOf(sprite);
+    }
+    scene.tweens.killTweensOf(ballSprite);
+  }
+
+  const offenseIsHome = (() => {
+    const shooterSprite = playerSprites[turnData.shooter_id];
+    if (shooterSprite?.team) return shooterSprite.team === "home";
+    if (turnData.offense_team_id && scene.simData) {
+      return turnData.offense_team_id === scene.simData.home_team_id;
+    }
+    return true;
+  })();
+
+  const { oDestinations, dDestinations, shooterSpot, rim } = buildDestinations(
+    offenseIsHome,
+    turnData.shooter_pos
+  );
+
+  const width = scene.game.config.width;
+  const height = scene.game.config.height;
+
+  const shooterSprite = playerSprites[turnData.shooter_id];
+
+  if (!turnData.no_lane) {
+    const promises = [];
+    for (const [id, sprite] of Object.entries(playerSprites)) {
+      const info = scene.playerInfo?.[id];
+      if (!info) continue;
+      const dest =
+        info.team_id === turnData.offense_team_id
+          ? oDestinations[info.pos]
+          : dDestinations[info.pos];
+      if (!dest) continue;
+      const px = gridToPixels(dest.x, dest.y, width, height);
+      promises.push(
+        new Promise((resolve) => {
+          scene.tweens.add({
+            targets: sprite,
+            x: px.x,
+            y: px.y,
+            duration: animationConfig.freeThrow.lineupMoveMs,
+            ease: "Linear",
+            onComplete: resolve,
+            onStop: resolve,
+          });
+        })
+      );
+    }
+    await Promise.all(promises);
+  } else if (shooterSprite) {
+    const spotPx = gridToPixels(shooterSpot.x, shooterSpot.y, width, height);
+    await new Promise((resolve) => {
+      scene.tweens.add({
+        targets: shooterSprite,
+        x: spotPx.x,
+        y: spotPx.y,
+        duration: animationConfig.freeThrow.lineupMoveMs,
+        ease: "Linear",
+        onComplete: resolve,
+        onStop: resolve,
+      });
+    });
+  }
+
+  if (shooterSprite) {
+    attach(scene, ballSprite, shooterSprite);
+  }
+  scene.events?.emit("ft:lineupComplete", {});
+
+  const attempts = turnData.attempts || [];
+  for (let i = 0; i < attempts.length; i++) {
+    const result = attempts[i];
+    scene.events?.emit("ft:attempt", { attempt: i + 1, total: attempts.length });
+    await wait(scene, animationConfig.freeThrow.shooterPrepMs);
+    detach(scene, ballSprite);
+    const rimPx = gridToPixels(rim.x, rim.y, width, height);
+    scene.events?.emit("ft:shotStart");
+    await tween(scene, ballSprite, rimPx, {
+      duration: animationConfig.freeThrow.shotMs,
+      easing: "Sine.easeInOut",
+      arc: { height: animationConfig.freeThrow.arcHeight },
+    });
+    scene.events?.emit(result === "MAKE" ? "ft:make" : "ft:miss");
+    await wait(scene, animationConfig.freeThrow.rimHoldMs);
+    scene.events?.emit("ft:rimHoldEnd");
+
+    const isLast = i === attempts.length - 1;
+    if (result === "MAKE") {
+      if (onUpdate) {
+        try {
+          onUpdate({ ...turnData, attempt: i, result });
+        } catch (err) {
+          console.error("Scoreboard update failed:", err);
+        }
+      }
+      if (isLast) {
+        const newOffenseSide = offenseIsHome ? "away" : "home";
+        await inboundSetup({
+          scene,
+          ballSprite,
+          playerSprites,
+          newOffenseSide,
+        });
+      } else if (shooterSprite) {
+        const spotPx = gridToPixels(
+          shooterSpot.x,
+          shooterSpot.y,
+          width,
+          height
+        );
+        await tween(scene, ballSprite, spotPx, {
+          duration: animationConfig.freeThrow.shotMs,
+          easing: "Sine.easeInOut",
+        });
+        attach(scene, ballSprite, shooterSprite);
+      }
+    } else {
+      if (isLast) {
+        await rebound({
+          scene,
+          ballSprite,
+          playerSprites,
+          animations: [],
+          rebounderId: null,
+          ballSpot: rim,
+        });
+      } else if (shooterSprite) {
+        const spotPx = gridToPixels(
+          shooterSpot.x,
+          shooterSpot.y,
+          width,
+          height
+        );
+        await tween(scene, ballSprite, spotPx, {
+          duration: animationConfig.freeThrow.shotMs,
+          easing: "Sine.easeInOut",
+        });
+        attach(scene, ballSprite, shooterSprite);
+      }
+    }
+    scene.events?.emit("ft:repeatOrExit");
+  }
+
+  scene.ftInProgress = false;
+  scene.events?.emit("ft:end");
+}
+
+export default runFreeThrowSequence;

--- a/tests/js/runFreeThrowSequence.mjs
+++ b/tests/js/runFreeThrowSequence.mjs
@@ -1,0 +1,122 @@
+import runFreeThrowSequence from '../../FrontEnd/static/js/phaser/animation/freeThrow.js';
+import { gridToPixels } from '../../FrontEnd/static/js/phaser/utils/gridToPixels.js';
+
+function makeScene() {
+  return {
+    tweens: {
+      add: ({ targets, x, y, onComplete, onStop }) => {
+        if (Array.isArray(targets)) {
+          targets.forEach(t => { t.x = x; t.y = y; });
+        } else if (targets) {
+          targets.x = x;
+          targets.y = y;
+        }
+        if (onComplete) onComplete();
+        return { stop: () => { if (onStop) onStop(); } };
+      },
+      killTweensOf: () => {},
+    },
+    time: { delayedCall: (ms, fn) => fn() },
+    game: { config: { width: 100, height: 50 } },
+    events: { emit: () => {} },
+    playerInfo: {},
+    simData: { home_team_id: 'HOME', away_team_id: 'AWAY' },
+  };
+}
+
+function createPlayers() {
+  const ids = ['pg','sg','sf','pf','c','pgA','sgA','sfA','pfA','cA'];
+  const sprites = {};
+  for (const id of ids) sprites[id] = { x:0, y:0 };
+  return sprites;
+}
+
+function createInfo() {
+  return {
+    pg: { pos:'PG', team_id:'HOME' },
+    sg: { pos:'SG', team_id:'HOME' },
+    sf: { pos:'SF', team_id:'HOME' },
+    pf: { pos:'PF', team_id:'HOME' },
+    c: { pos:'C', team_id:'HOME' },
+    pgA: { pos:'PG', team_id:'AWAY' },
+    sgA: { pos:'SG', team_id:'AWAY' },
+    sfA: { pos:'SF', team_id:'AWAY' },
+    pfA: { pos:'PF', team_id:'AWAY' },
+    cA: { pos:'C', team_id:'AWAY' },
+  };
+}
+
+function makeBall() {
+  return { setPosition(x,y){this.x=x;this.y=y;}, setVisible(){}, setDepth(){}, x:0,y:0 };
+}
+
+const sceneHome = makeScene();
+const playerSpritesHome = createPlayers();
+sceneHome.playerInfo = createInfo();
+const ballSpriteHome = makeBall();
+let inboundCalled = false;
+let reboundCalled = false;
+let arcHeight;
+await runFreeThrowSequence(sceneHome, {
+  playerSprites: playerSpritesHome,
+  ballSprite: ballSpriteHome,
+  turnData: {
+    result_type: 'FREE_THROW',
+    offense_team_id: 'HOME',
+    shooter_id: 'pg',
+    shooter_pos: 'PG',
+    attempts: ['MAKE']
+  },
+  helpers: {
+    tweenBallTo: (scene, ball, target, opts) => { arcHeight = opts.arc.height; ball.x = target.x; ball.y = target.y; return Promise.resolve(); },
+    runInboundSetup: () => { inboundCalled = true; return Promise.resolve(); },
+    animateRebound: () => { reboundCalled = true; return Promise.resolve(); },
+    attachBallToPlayer: () => {},
+    detachBall: () => {},
+  },
+});
+
+const pgDest = gridToPixels(74,25,100,50);
+const sgDest = gridToPixels(56,44,100,50);
+const dPgDest = gridToPixels(54,37,100,50);
+
+const homeResult = {
+  inboundCalled,
+  reboundCalled,
+  arcHeight,
+  pg: { x: playerSpritesHome.pg.x, y: playerSpritesHome.pg.y },
+  sg: { x: playerSpritesHome.sg.x, y: playerSpritesHome.sg.y },
+  pgA: { x: playerSpritesHome.pgA.x, y: playerSpritesHome.pgA.y }
+};
+
+const sceneAway = makeScene();
+const playerSpritesAway = createPlayers();
+sceneAway.playerInfo = createInfo();
+const ballSpriteAway = makeBall();
+let inboundCalled2 = false;
+let reboundCalled2 = false;
+await runFreeThrowSequence(sceneAway, {
+  playerSprites: playerSpritesAway,
+  ballSprite: ballSpriteAway,
+  turnData: {
+    result_type: 'FREE_THROW',
+    offense_team_id: 'AWAY',
+    shooter_id: 'pgA',
+    shooter_pos: 'PG',
+    attempts: ['MISS']
+  },
+  helpers: {
+    tweenBallTo: (scene, ball, target, opts) => Promise.resolve(),
+    runInboundSetup: () => { inboundCalled2 = true; return Promise.resolve(); },
+    animateRebound: () => { reboundCalled2 = true; return Promise.resolve(); },
+    attachBallToPlayer: () => {},
+    detachBall: () => {},
+  }
+});
+
+const awayResult = {
+  inboundCalled: inboundCalled2,
+  reboundCalled: reboundCalled2,
+};
+
+console.log(JSON.stringify({ home: homeResult, away: awayResult, expected: { pgDest, sgDest, dPgDest } }));


### PR DESCRIPTION
## Summary
- add free throw config values
- orchestrate free throw attempts with lineup, shot loop, and inbound/rebound handling
- wire free throw turns into main turn animator

## Testing
- `node tests/js/runFreeThrowSequence.mjs`
- `pytest` *(fails: ModuleNotFoundError: No module named 'bson')*

------
https://chatgpt.com/codex/tasks/task_e_68a33606a038832885eaf98aec50f99a