### PR TITLE
Handle fast break animations

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animateGameTurns.js
+++ b/FrontEnd/static/js/phaser/animation/animateGameTurns.js
@@ -3,6 +3,7 @@ import { onAction } from "./onAction.js";
 import { runPass } from "./ballManager.js";
 import animationConfig from "./animation_config.js";
 import runFreeThrowSequence from "./freeThrow.js";
+import runFastBreakSequence from "./fastBreak.js";
 
 /**
  * Animate all turns from simData.turns using real backend structure.
@@ -38,6 +39,18 @@ export async function animateGameTurns({ //hasBallAtStep
 
     if (turn.result_type === "SIDE_INBOUND") {
       await runSideInboundSetup({ scene, ballSprite, playerSprites, turnData: turn });
+      if (onUpdate) {
+        try {
+          onUpdate(turn);
+        } catch (err) {
+          console.error('Scoreboard update failed:', err);
+        }
+      }
+      continue;
+    }
+
+    if (turn.fast_break === true || turn.result_type === "FAST_BREAK") {
+      await runFastBreakSequence(scene, { playerSprites, ballSprite, turnData: turn, onUpdate });
       if (onUpdate) {
         try {
           onUpdate(turn);

--- a/FrontEnd/static/js/phaser/animation/fastBreak.js
+++ b/FrontEnd/static/js/phaser/animation/fastBreak.js
@@ -1,0 +1,11 @@
+export async function runFastBreakSequence(
+  scene,
+  { playerSprites, ballSprite, turnData, onUpdate }
+) {
+  // Placeholder fast break animation handler.
+  // Implementation will animate fast break sequences between turns.
+  // Currently, this is a no-op to allow wiring and future expansion.
+  return;
+}
+
+export default runFastBreakSequence;


### PR DESCRIPTION
## Summary
- Detect fast-break turns and invoke new fast break animation sequence instead of default turn animation
- Stub out fast break animation handler for future implementation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a34dfd838483289ee65ac999638432