### PR TITLE
Add fast break animation defaults with override merging

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animation_config.js
+++ b/FrontEnd/static/js/phaser/animation/animation_config.js
@@ -29,8 +29,12 @@ const defaults = {
     rimHoldMs: 300,
   },
   fastBreak: {
-    sprintDuration: 800,
-    arcHeight: 50,
+    sprintSpeed: 1.5, // multiplier
+    laneSpacing: 6,
+    passMs: 250,
+    shotMs: 500,
+    arcHeight: 60,
+    rimHoldMs: 800,
   },
 };
 


### PR DESCRIPTION
## Summary
- add detailed fastBreak animation defaults
- support overriding fastBreak settings via global animation_config

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a35ffd6d188328b2cd4bd095f71efb