### PR TITLE
Limit hero section image height for better responsiveness

### DIFF
--- a/FrontEnd/static/homepage.css
+++ b/FrontEnd/static/homepage.css
@@ -93,6 +93,8 @@ body {
   max-width: 100%;
   height: auto;
   display: block;
+  max-height: 40vh;
+  object-fit: contain;
 }
 
 /* Feature Cards */
@@ -115,6 +117,12 @@ body {
 @media (min-width: 900px) {
   .features {
     grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-height: 900px) {
+  .hero img {
+    max-height: 35vh;
   }
 }
 


### PR DESCRIPTION
## Summary
- limit hero image height and preserve aspect ratio
- reduce hero image height on shorter viewports

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a374f238408328b28ca3b32d1d16ad