### PR TITLE
Guard movements during free throws

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -33,6 +33,7 @@ export function passBall({
   fromTimestamp,
   toTimestamp
 }) {
+  if (scene?.ftInProgress) return;
   generateBallTween({
     scene,
     ballSprite,
@@ -53,6 +54,7 @@ export function animateInboundPass(
   startTs,
   endTs
 ) {
+  if (scene?.ftInProgress) return;
   generateBallTween({
     scene,
     ballSprite,
@@ -89,6 +91,7 @@ export function shootBall({
   turnIndex
 }) {
   if (!scene || !ballSprite) return Promise.resolve();
+  if (scene?.ftInProgress) return Promise.resolve();
 
   const isHomeTeam = shooterTeamId === homeTeamId;
 
@@ -199,6 +202,7 @@ export function animatePutbackAttempt(
   result
 ) {
   if (!scene || !ballSprite) return Promise.resolve();
+  if (scene?.ftInProgress) return Promise.resolve();
   const shooterSprite = scene.playerSprites?.[shooterId];
   if (!shooterSprite) return Promise.resolve();
 
@@ -298,6 +302,7 @@ export function animateRebound({
   ballSpot
 }) {
   if (!scene || !ballSprite || !ballSpot) return Promise.resolve();
+  if (scene?.ftInProgress) return Promise.resolve();
 
   const promises = [];
   const finalPositions = [];
@@ -442,6 +447,7 @@ export function animateKickoutReset(
   duration
 ) {
   if (!scene || !ballSprite) return Promise.resolve();
+  if (scene?.ftInProgress) return Promise.resolve();
 
   const rebounderSprite = scene.playerSprites?.[rebounderId];
   const pgSprite = scene.playerSprites?.[pgId];

--- a/FrontEnd/static/js/phaser/animation/freeThrow.js
+++ b/FrontEnd/static/js/phaser/animation/freeThrow.js
@@ -89,7 +89,6 @@ export async function runFreeThrowSequence(
   if (!scene || !playerSprites || !ballSprite || !turnData) return;
 
   scene.ftInProgress = true;
-  scene.events?.emit("ft:start", {});
   if (scene.tweens) {
     for (const sprite of Object.values(playerSprites)) {
       scene.tweens.killTweensOf(sprite);
@@ -110,6 +109,13 @@ export async function runFreeThrowSequence(
     offenseIsHome,
     turnData.shooter_pos
   );
+
+  scene.events?.emit("ft:start", {
+    team: offenseIsHome ? "home" : "away",
+    shooter: turnData.shooter_id,
+    oDestinations,
+    dDestinations,
+  });
 
   const width = scene.game.config.width;
   const height = scene.game.config.height;
@@ -135,8 +141,28 @@ export async function runFreeThrowSequence(
             y: px.y,
             duration: animationConfig.freeThrow.lineupMoveMs,
             ease: "Linear",
-            onComplete: resolve,
-            onStop: resolve,
+            onStart: () =>
+              scene.events?.emit("ft:tweenStart", {
+                playerId: id,
+                x: px.x,
+                y: px.y,
+              }),
+            onComplete: () => {
+              scene.events?.emit("ft:tweenEnd", {
+                playerId: id,
+                x: px.x,
+                y: px.y,
+              });
+              resolve();
+            },
+            onStop: () => {
+              scene.events?.emit("ft:tweenEnd", {
+                playerId: id,
+                x: px.x,
+                y: px.y,
+              });
+              resolve();
+            },
           });
         })
       );
@@ -151,8 +177,28 @@ export async function runFreeThrowSequence(
         y: spotPx.y,
         duration: animationConfig.freeThrow.lineupMoveMs,
         ease: "Linear",
-        onComplete: resolve,
-        onStop: resolve,
+        onStart: () =>
+          scene.events?.emit("ft:tweenStart", {
+            playerId: turnData.shooter_id,
+            x: spotPx.x,
+            y: spotPx.y,
+          }),
+        onComplete: () => {
+          scene.events?.emit("ft:tweenEnd", {
+            playerId: turnData.shooter_id,
+            x: spotPx.x,
+            y: spotPx.y,
+          });
+          resolve();
+        },
+        onStop: () => {
+          scene.events?.emit("ft:tweenEnd", {
+            playerId: turnData.shooter_id,
+            x: spotPx.x,
+            y: spotPx.y,
+          });
+          resolve();
+        },
       });
     });
   }
@@ -189,6 +235,7 @@ export async function runFreeThrowSequence(
         }
       }
       if (isLast) {
+        scene.ftInProgress = false;
         const newOffenseSide = offenseIsHome ? "away" : "home";
         await inboundSetup({
           scene,
@@ -211,6 +258,7 @@ export async function runFreeThrowSequence(
       }
     } else {
       if (isLast) {
+        scene.ftInProgress = false;
         await rebound({
           scene,
           ballSprite,

--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -116,7 +116,7 @@ async function runSetupTween({ scene, ballSprite, animations, playerSprites, cur
 
 // Setup sideline inbound play
 async function runSideInboundSetup({ scene, ballSprite, playerSprites, turnData }) {
-  if (!turnData || scene?.skipToEnd) return;
+  if (!turnData || scene?.skipToEnd || scene?.ftInProgress) return;
 
   const { ball_spot, oDestinations = {}, dDestinations = {}, possession_team_id } = turnData;
 
@@ -219,6 +219,7 @@ async function runInboundSetup({
   homeTeamId,
   awayTeamId
 }) {
+  if (scene?.ftInProgress) return;
   scene.isInboundSetup = true;
   if (!scene.ballSprite) scene.ballSprite = ballSprite;
   const isAwayOffense = newOffenseSide === "away";


### PR DESCRIPTION
## Summary
- Broadcast FT start data and emit tween start/end events for each player lineup move
- Block ball and player movement helpers while `ftInProgress` is true
- Skip inbound and sideline setups when a free throw is active

## Testing
- `node tests/js/runFreeThrowSequence.mjs`
- `pytest tests/test_free_throw_logic.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a37b6759d4832892fe63216ed3903e