### PR TITLE
Fix hero headline line breaks

### DIFF
--- a/FrontEnd/static/homepage.css
+++ b/FrontEnd/static/homepage.css
@@ -85,6 +85,9 @@ body {
   line-height: 1.1;
   margin: 0 0 var(--spacing-sm);
 }
+.hero-text h1 .headline-line {
+  display: block;
+}
 .hero-text p {
   font-size: 1.125rem;
   margin: 0;

--- a/FrontEnd/static/homepage.html
+++ b/FrontEnd/static/homepage.html
@@ -37,7 +37,11 @@
 
   <section class="hero">
     <div class="hero-text">
-      <h1>A New Kind Of Basketball Sim — Built For Coaches, Not Button Mashers</h1>
+      <h1>
+        <span class="headline-line">A New Kind Of Basketball Sim —</span>
+        <span class="headline-line">Built For Coaches,</span>
+        <span class="headline-line">Not Button Mashers</span>
+      </h1>
       <p>Geeked-Out Basketball is built for sim gamers who crave strategy, not stick skills.</p>
     </div>
     <img src="./images/GOB_iconic_image.jpg" alt="Illustration of a coach holding a basketball" />


### PR DESCRIPTION
## Summary
- Force homepage hero headline to break into three specific lines
- Style new headline segments to stack properly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a37cf2b95c8328b57f51c160b201ab