### PR TITLE
Fix defensive rebound possession flip and add guard to ball attachment

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballTween.js
+++ b/FrontEnd/static/js/phaser/animation/ballTween.js
@@ -14,24 +14,39 @@ export const PASS_DEBUG = false;
  */
 export function attachBallToPlayer(scene, ballSprite, playerSprite, opts = {}) {
   if (!scene || !ballSprite || !playerSprite) return;
+
+  let targetId = playerSprite.playerId;
+  if (targetId == null && scene.playerSprites) {
+    for (const [pid, sprite] of Object.entries(scene.playerSprites)) {
+      if (sprite === playerSprite) {
+        targetId = pid;
+        break;
+      }
+    }
+  }
+
+  const targetTeamId = playerSprite.team_id;
+  if (
+    scene.possessionFlipInProgress &&
+    scene.offenseTeamId != null &&
+    String(targetTeamId) !== String(scene.offenseTeamId)
+  ) {
+    const from = scene.ballAttachedToPlayerId;
+    console.warn('overwrite', { from, to: targetId, reason: 'possessionFlipInProgress' });
+    return;
+  }
+
   scene.ballDetached = false;
   const depth = opts.depth ?? (playerSprite.depth != null ? playerSprite.depth + 1 : BALL_DEPTH);
   if (scene.tweens) scene.tweens.killTweensOf(ballSprite);
   ballSprite.setPosition(playerSprite.x, playerSprite.y);
   ballSprite.setVisible(true);
   ballSprite.setDepth(depth);
-  if (typeof playerSprite.playerId !== 'undefined') {
-    scene.ballAttachedToPlayerId = playerSprite.playerId;
-    scene.ballLastKnownOwnerId = playerSprite.playerId;
-  } else if (scene.playerSprites) {
-    for (const [pid, sprite] of Object.entries(scene.playerSprites)) {
-      if (sprite === playerSprite) {
-        scene.ballAttachedToPlayerId = pid;
-        scene.ballLastKnownOwnerId = pid;
-        break;
-      }
-    }
+  if (targetId != null) {
+    scene.ballAttachedToPlayerId = targetId;
+    scene.ballLastKnownOwnerId = targetId;
   }
+  console.log('ball:attach', targetId);
 }
 
 /**

--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -722,6 +722,8 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
     if (awayTeamId) simData.away_team_id = awayTeamId;
   }
 
+  scene.offenseTeamId = turnData.possession_team_id;
+
   // Determine which player owns the ball at step 0
   let step0OwnerSprite = null;
   for (const anim of turnData.animations) {
@@ -765,7 +767,7 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
     animations: turnData.animations,
     playerSprites,
     stepIndex: 0,
-    offenseTeamId: turnData.possession_team_id,
+    offenseTeamId: scene.offenseTeamId,
     currentBallOwnerRef
   });
 
@@ -778,7 +780,7 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
       animations: turnData.animations,
       playerSprites,
       stepIndex,
-      offenseTeamId: turnData.possession_team_id,
+      offenseTeamId: scene.offenseTeamId,
       currentBallOwnerRef
     });
 
@@ -869,6 +871,8 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
           }
         }
         if (rebounderId) {
+          const rebounderSprite = playerSprites[rebounderId];
+          console.log('reb:event', { team: rebounderSprite?.team_id, playerId: rebounderId });
           await animateRebound({
             scene,
             ballSprite,
@@ -877,6 +881,18 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
             rebounderId,
             ballSpot
           });
+          if (rebounderSprite) {
+            scene.offenseTeamId = rebounderSprite.team_id;
+            scene.possessionFlipInProgress = true;
+            scene.events?.emit?.('possessionChange', { offenseTeamId: rebounderSprite.team_id });
+            console.log('reb:flip', { newPossession: rebounderSprite.team_id });
+            console.log('ui:possIndicator', { team: rebounderSprite.team_id });
+            if (scene.time?.delayedCall) {
+              scene.time.delayedCall(0, () => { scene.possessionFlipInProgress = false; });
+            } else {
+              setTimeout(() => { scene.possessionFlipInProgress = false; }, 0);
+            }
+          }
         }
       }
       break;
@@ -903,14 +919,29 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
           evt.result
         );
         if (evt.result === "MISS" && evt.rebound) {
+          const rbId = evt.rebound.rebounderId;
+          const rbSprite = playerSprites[rbId];
+          console.log('reb:event', { team: rbSprite?.team_id, playerId: rbId });
           await animateRebound({
             scene,
             ballSprite,
             playerSprites,
             animations: evt.rebound.animations || turnData.animations,
-            rebounderId: evt.rebound.rebounderId,
+            rebounderId: rbId,
             ballSpot: putbackResult?.grid || evt.rebound.ballSpot
           });
+          if (rbSprite) {
+            scene.offenseTeamId = rbSprite.team_id;
+            scene.possessionFlipInProgress = true;
+            scene.events?.emit?.('possessionChange', { offenseTeamId: rbSprite.team_id });
+            console.log('reb:flip', { newPossession: rbSprite.team_id });
+            console.log('ui:possIndicator', { team: rbSprite.team_id });
+            if (scene.time?.delayedCall) {
+              scene.time.delayedCall(0, () => { scene.possessionFlipInProgress = false; });
+            } else {
+              setTimeout(() => { scene.possessionFlipInProgress = false; }, 0);
+            }
+          }
         }
       } else if (evt.event_type === "KICKOUT_RESET") {
         await animateKickoutReset(

--- a/tests/js/runDefensiveReboundFlip.mjs
+++ b/tests/js/runDefensiveReboundFlip.mjs
@@ -1,0 +1,52 @@
+import { playTurnAnimation } from '../../FrontEnd/static/js/phaser/animation/turnAnimation.js';
+
+function makeScene() {
+  const log = {};
+  return {
+    tweens: {
+      add: ({ onUpdate, onComplete, onStop }) => {
+        if (onUpdate) onUpdate();
+        if (onComplete) onComplete();
+        return { stop: () => { if (onStop) onStop(); } };
+      },
+      killTweensOf: () => {}
+    },
+    time: { delayedCall: (ms, fn) => fn() },
+    events: { emit: (evt, payload) => { if (evt === 'possessionChange') log.event = payload.offenseTeamId; } },
+    game: { config: { width: 100, height: 50 }, loop: { frame: 0 } },
+    playerSprites: {
+      pg: { x: 0, y: 0, team: 'home', team_id: 'HOME' },
+      pgA: { x: 0, y: 0, team: 'away', team_id: 'AWAY' }
+    },
+    playerInfo: {
+      pg: { pos: 'PG', team_id: 'HOME', name: 'PG' },
+      pgA: { pos: 'PG', team_id: 'AWAY', name: 'PG A' }
+    },
+    nameToId: { 'PG': 'pg', 'PG A': 'pgA' },
+    possessionLog: log
+  };
+}
+
+const scene = makeScene();
+const ballSprite = { setPosition(){}, setVisible(){}, setDepth(){} };
+const simData = { home_team_id: 'HOME', away_team_id: 'AWAY', players: [] };
+const turnData = {
+  starting_possession_team_id: 'HOME',
+  possession_team_id: 'HOME',
+  result_type: 'MISS',
+  ball_handler: 'PG A',
+  animations: [
+    {
+      playerId: 'pg',
+      movement: [
+        { timestamp: 0, action: 'handle', coords: { x: 0, y: 0 } },
+        { timestamp: 1, action: 'shoot', coords: { x: 0, y: 0 } }
+      ],
+      hasBallAtStep: [true, false]
+    }
+  ]
+};
+
+await playTurnAnimation({ scene, simData, playerSprites: scene.playerSprites, turnData, ballSprite });
+
+console.log(JSON.stringify({ newOffense: scene.offenseTeamId, eventOffense: scene.possessionLog.event, attached: scene.ballAttachedToPlayerId }));

--- a/tests/test_rebound_possession_flip.py
+++ b/tests/test_rebound_possession_flip.py
@@ -1,0 +1,16 @@
+import json
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+def run_node(loader, script):
+    cmd = ["node", "--loader", str(ROOT / loader), str(ROOT / script)]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return json.loads(completed.stdout.strip().splitlines()[-1])
+
+def test_defensive_rebound_flips_possession():
+    result = run_node("tests/js/httpsLoaderNoStubBall.mjs", "tests/js/runDefensiveReboundFlip.mjs")
+    assert result["attached"] == "pgA"
+    assert result["newOffense"] == "AWAY"
+    assert result["eventOffense"] == "AWAY"


### PR DESCRIPTION
## Summary
- centralize defensive rebound handling to flip possession and update UI state
- guard ball attachments during possession change to avoid late overwrites
- add regression test for rebound possession flip

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4ad26ddd88328b568e724348b91ad