### PR TITLE
Handle mid-turn possession flips in animations

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animateGameTurns.js
+++ b/FrontEnd/static/js/phaser/animation/animateGameTurns.js
@@ -18,12 +18,22 @@ export async function animateGameTurns({ //hasBallAtStep
   const turns = simData.turns || [];
   const allPlayers = simData.players || [];
 
+  function handlePossessionFlip(turn) {
+    if (turn.starting_possession_team_id !== turn.possession_team_id) {
+      scene.currentOffenseTeamId = turn.possession_team_id;
+      scene.events?.emit('possessionChange', { offenseTeamId: turn.possession_team_id });
+    }
+  }
+
   for (let i = 0; i < turns.length; i++) {
     scene.currentTurn = i;
     const turn = turns[i];
     turn.index = i;
     if (scene.skipToEnd) break;
     console.log(`🔁 Turn ${i + 1}`, turn);
+
+    scene.currentOffenseTeamId = turn.starting_possession_team_id;
+    handlePossessionFlip(turn);
 
     if (turn.result_type === "FREE_THROW") {
       await runFreeThrowSequence(scene, { playerSprites, ballSprite, turnData: turn, onUpdate });
@@ -157,18 +167,13 @@ export async function animateGameTurns({ //hasBallAtStep
         if (scene.__activePass) {
           console.warn('Active pass tween detected before steal; cancelling previous tween');
         }
+        handlePossessionFlip(turn);
         await runPass(scene, {
           fromId: ballHandlerId,
           toId: stealerId,
           duration: cfg.duration,
           easing: cfg.easing
         });
-        const defenderSprite = playerSprites[stealerId];
-        // runPass reattaches the ball after the tween resolves, so only emit
-        // possession change once that handoff has finished.
-        if (!scene.fastBreakInProgress && defenderSprite) {
-          scene.events?.emit?.('possessionChange', { offenseTeamId: defenderSprite.team_id });
-        }
       }
     }
 

--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -119,6 +119,7 @@ async function runSideInboundSetup({ scene, ballSprite, playerSprites, turnData 
   if (!turnData || scene?.skipToEnd || scene?.ftInProgress) return;
 
   const { ball_spot, oDestinations = {}, dDestinations = {}, possession_team_id } = turnData;
+  const offenseTeamId = scene.currentOffenseTeamId ?? possession_team_id;
 
   const width = scene.game.config.width;
   const height = scene.game.config.height;
@@ -137,7 +138,7 @@ async function runSideInboundSetup({ scene, ballSprite, playerSprites, turnData 
   for (const [id, sprite] of Object.entries(playerSprites)) {
     const info = scene.playerInfo?.[id];
     if (!info) continue;
-    if (String(sprite.team_id) === String(possession_team_id)) {
+    if (String(sprite.team_id) === String(offenseTeamId)) {
       offenseSprites[info.pos] = sprite;
       offenseIds[info.pos] = id;
     } else {
@@ -765,7 +766,7 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
     animations: turnData.animations,
     playerSprites,
     stepIndex: 0,
-    offenseTeamId: turnData.possession_team_id,
+    offenseTeamId: scene.currentOffenseTeamId ?? turnData.possession_team_id,
     currentBallOwnerRef
   });
 
@@ -778,7 +779,7 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
       animations: turnData.animations,
       playerSprites,
       stepIndex,
-      offenseTeamId: turnData.possession_team_id,
+      offenseTeamId: scene.currentOffenseTeamId ?? turnData.possession_team_id,
       currentBallOwnerRef
     });
 


### PR DESCRIPTION
## Summary
- centralize detection of possession flips with `handlePossessionFlip`
- emit `possessionChange` before animations and steals
- read `scene.currentOffenseTeamId` for dynamic offense state

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4ae8d20e08328af8c830d5f3a7047