### PR TITLE
Prevent ball actions during possession flip

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animateGameTurns.js
+++ b/FrontEnd/static/js/phaser/animation/animateGameTurns.js
@@ -18,6 +18,16 @@ export async function animateGameTurns({ //hasBallAtStep
   const turns = simData.turns || [];
   const allPlayers = simData.players || [];
 
+  const handlePossessionFlip = () => {
+    scene.possessionFlipInProgress = true;
+    if (scene.time?.delayedCall) {
+      scene.time.delayedCall(0, () => (scene.possessionFlipInProgress = false));
+    } else {
+      setTimeout(() => (scene.possessionFlipInProgress = false), 0);
+    }
+  };
+  scene.events?.on?.('possessionChange', handlePossessionFlip);
+
   for (let i = 0; i < turns.length; i++) {
     scene.currentTurn = i;
     const turn = turns[i];
@@ -191,5 +201,7 @@ export async function animateGameTurns({ //hasBallAtStep
       break;
     }
   }
+
+  scene.events?.off?.('possessionChange', handlePossessionFlip);
 }
 

--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -1,15 +1,32 @@
 import * as Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.60.0/dist/phaser.esm.js';
 import { generateBallTween } from "./generateBallTween.js";
 import { gridToPixels } from "../utils/gridToPixels.js";
-import { runInboundSetup } from "./turnAnimation.js";
+import { runInboundSetup as baseRunInboundSetup } from "./turnAnimation.js";
 import animationConfig from "./animation_config.js";
 import {
-  attachBallToPlayer,
+  attachBallToPlayer as baseAttachBallToPlayer,
   detachBall,
   tweenBallTo,
-  runPass
+  runPass as baseRunPass
 } from "./ballTween.js";
-export { attachBallToPlayer, detachBall, tweenBallTo, runPass };
+
+function attachBallToPlayer(scene, ballSprite, playerSprite, opts = {}) {
+  if (scene?.possessionFlipInProgress) return;
+  return baseAttachBallToPlayer(scene, ballSprite, playerSprite, opts);
+}
+
+function runInboundSetup(opts) {
+  const scene = opts?.scene;
+  if (scene?.possessionFlipInProgress) return Promise.resolve();
+  return baseRunInboundSetup(opts);
+}
+
+function runPass(scene, cfg = {}) {
+  if (scene?.possessionFlipInProgress) return Promise.resolve();
+  return baseRunPass(scene, cfg);
+}
+
+export { attachBallToPlayer, detachBall, tweenBallTo, runPass, runInboundSetup };
 
 // Debug flags for logging shot / rebound details
 export const SHOT_DEBUG = false;


### PR DESCRIPTION
## Summary
- Track possession flips with a temporary `possessionFlipInProgress` flag
- Skip pass, inbound setup, and ball attachment when a flip is underway

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4affab6ec8328a062fecb5173f4f3