### PR TITLE
Handle possession flips during animations

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animateGameTurns.js
+++ b/FrontEnd/static/js/phaser/animation/animateGameTurns.js
@@ -20,11 +20,7 @@ export async function animateGameTurns({ //hasBallAtStep
 
   const handlePossessionFlip = () => {
     scene.possessionFlipInProgress = true;
-    if (scene.time?.delayedCall) {
-      scene.time.delayedCall(0, () => (scene.possessionFlipInProgress = false));
-    } else {
-      setTimeout(() => (scene.possessionFlipInProgress = false), 0);
-    }
+    scene.time.delayedCall(0, () => (scene.possessionFlipInProgress = false));
   };
   scene.events?.on?.('possessionChange', handlePossessionFlip);
 

--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -11,18 +11,18 @@ import {
 } from "./ballTween.js";
 
 function attachBallToPlayer(scene, ballSprite, playerSprite, opts = {}) {
-  if (scene?.possessionFlipInProgress) return;
+  if (scene.possessionFlipInProgress) return;
   return baseAttachBallToPlayer(scene, ballSprite, playerSprite, opts);
 }
 
 function runInboundSetup(opts) {
-  const scene = opts?.scene;
-  if (scene?.possessionFlipInProgress) return Promise.resolve();
+  const scene = opts.scene;
+  if (scene.possessionFlipInProgress) return Promise.resolve();
   return baseRunInboundSetup(opts);
 }
 
 function runPass(scene, cfg = {}) {
-  if (scene?.possessionFlipInProgress) return Promise.resolve();
+  if (scene.possessionFlipInProgress) return Promise.resolve();
   return baseRunPass(scene, cfg);
 }
 


### PR DESCRIPTION
## Summary
- mark and clear possession flip progress when a possession change event fires
- guard ball actions (runPass, runInboundSetup, attachBallToPlayer) while a possession flip is in progress

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest -q` *(fails: KeyError: 'newOffense')*

------
https://chatgpt.com/codex/tasks/task_e_68a4c73d75b48328a8ed5f5d1803b70c