### PR TITLE
Add debug logs for rebound possession and ball attachments

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animateGameTurns.js
+++ b/FrontEnd/static/js/phaser/animation/animateGameTurns.js
@@ -1,6 +1,6 @@
 import { playTurnAnimation, runSideInboundSetup } from "./turnAnimation.js";
 import { onAction } from "./onAction.js";
-import { runPass } from "./ballManager.js";
+import { runPass, REBOUND_DEBUG } from "./ballManager.js";
 import animationConfig from "./animation_config.js";
 import runFreeThrowSequence from "./freeThrow.js";
 import runFastBreakSequence from "./fastBreak.js";
@@ -18,8 +18,12 @@ export async function animateGameTurns({ //hasBallAtStep
   const turns = simData.turns || [];
   const allPlayers = simData.players || [];
 
-  const handlePossessionFlip = () => {
+  const handlePossessionFlip = (payload = {}) => {
     scene.possessionFlipInProgress = true;
+    scene.offenseTeamId = payload.offenseTeamId;
+    if (REBOUND_DEBUG) {
+      console.log("reb:flip", { newPossession: payload.offenseTeamId });
+    }
     scene.time.delayedCall(0, () => (scene.possessionFlipInProgress = false));
   };
   scene.events?.on?.('possessionChange', handlePossessionFlip);

--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -12,6 +12,36 @@ import {
 
 function attachBallToPlayer(scene, ballSprite, playerSprite, opts = {}) {
   if (scene.possessionFlipInProgress) return;
+
+  let targetId = playerSprite?.playerId;
+  if (targetId == null && scene?.playerSprites) {
+    for (const [pid, sprite] of Object.entries(scene.playerSprites)) {
+      if (sprite === playerSprite) {
+        targetId = pid;
+        break;
+      }
+    }
+  }
+
+  if (REBOUND_DEBUG) {
+    if (
+      scene?.currentBallOwnerRef &&
+      scene.currentBallOwnerRef.value &&
+      scene.currentBallOwnerRef.value !== playerSprite
+    ) {
+      const refId = scene.currentBallOwnerRef.value?.playerId;
+      console.warn("ball:owner mismatch", {
+        ref: refId,
+        target: targetId
+      });
+    }
+    console.log(`ball:attach -> ${targetId}`);
+  }
+
+  if (scene?.currentBallOwnerRef) {
+    scene.currentBallOwnerRef.value = playerSprite;
+  }
+
   return baseAttachBallToPlayer(scene, ballSprite, playerSprite, opts);
 }
 
@@ -336,7 +366,14 @@ export function animateRebound({
   ballSprite.setVisible(true);
 
   const rebounderSprite = playerSprites[rebounderId];
+  if (REBOUND_DEBUG) {
+    const team = rebounderSprite?.team_id ?? rebounderSprite?.team;
+    console.log("reb:event", { team, playerId: rebounderId });
+  }
   if (rebounderSprite) {
+    const teamId = rebounderSprite.team_id;
+    scene.offenseTeamId = teamId;
+    scene.events?.emit?.("possessionChange", { offenseTeamId: teamId });
     finalPositions.push({ playerId: rebounderId, grid: { ...ballSpot } });
     promises.push(
       new Promise((resolve) => {

--- a/FrontEnd/static/js/phaser/animation/ballTween.js
+++ b/FrontEnd/static/js/phaser/animation/ballTween.js
@@ -46,7 +46,6 @@ export function attachBallToPlayer(scene, ballSprite, playerSprite, opts = {}) {
     scene.ballAttachedToPlayerId = targetId;
     scene.ballLastKnownOwnerId = targetId;
   }
-  console.log('ball:attach', targetId);
 }
 
 /**


### PR DESCRIPTION
## Summary
- add optional debug logging for rebound events and ball ownership
- warn on currentBallOwnerRef mismatches when attaching the ball
- track and log possession flips with new offense team id

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4cab16e008328ba5030639b2ad743