### PR TITLE
Centralize court coordinate constants

### DIFF
--- a/BackEnd/constants.py
+++ b/BackEnd/constants.py
@@ -115,8 +115,13 @@ HCO_STRING_SPOTS = {
 }
 
 # Shared court coordinates
-RIM_COORDS = {"x": 91, "y": 25}
-TOP_KEY_COORDS = HCO_STRING_SPOTS["key"]
+HOME_RIM_COORDS = {"x": 91, "y": 25}
+AWAY_RIM_COORDS = {"x": 9, "y": 25}
+HOME_TOP_KEY = {"x": 64, "y": 25}
+AWAY_TOP_KEY = {"x": 36, "y": 25}
+
+RIM_COORDS = HOME_RIM_COORDS
+TOP_KEY_COORDS = HOME_TOP_KEY
 
 ACTIONS = {
     "HANDLE": "handle_ball",

--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -3,6 +3,7 @@ import { generateBallTween } from "./generateBallTween.js";
 import { gridToPixels } from "../utils/gridToPixels.js";
 import { runInboundSetup as baseRunInboundSetup } from "./turnAnimation.js";
 import animationConfig from "./animation_config.js";
+import { HOME_RIM_COORDS, AWAY_RIM_COORDS } from "./courtConstants.js";
 import {
   attachBallToPlayer as baseAttachBallToPlayer,
   detachBall,
@@ -62,10 +63,6 @@ export { attachBallToPlayer, detachBall, tweenBallTo, runPass, runInboundSetup }
 export const SHOT_DEBUG = false;
 export const REBOUND_DEBUG = false;
 export const INBOUND_DEBUG = false;
-
-// Hoop locations in grid coordinates for each team
-const HOME_RIM_COORDS = { x: 91, y: 25 };
-const AWAY_RIM_COORDS = { x: 9, y: 25 };
 
 
 

--- a/FrontEnd/static/js/phaser/animation/courtConstants.js
+++ b/FrontEnd/static/js/phaser/animation/courtConstants.js
@@ -1,0 +1,5 @@
+export const HOME_RIM_COORDS = { x: 91, y: 25 };
+export const AWAY_RIM_COORDS = { x: 9, y: 25 };
+
+export const HOME_TOP_KEY = { x: 64, y: 25 };
+export const AWAY_TOP_KEY = { x: 36, y: 25 };

--- a/FrontEnd/static/js/phaser/animation/fastBreak.js
+++ b/FrontEnd/static/js/phaser/animation/fastBreak.js
@@ -13,5 +13,6 @@ export function runFastBreakSequenceWrapper(
 }
 
 export { runFastBreakSequence } from "./turnAnimation.js";
+export { HOME_RIM_COORDS, AWAY_RIM_COORDS, HOME_TOP_KEY, AWAY_TOP_KEY } from "./courtConstants.js";
 export default runFastBreakSequenceWrapper;
 

--- a/FrontEnd/static/js/phaser/animation/freeThrow.js
+++ b/FrontEnd/static/js/phaser/animation/freeThrow.js
@@ -1,5 +1,6 @@
 import { gridToPixels } from "../utils/gridToPixels.js";
 import animationConfig from "./animation_config.js";
+import { HOME_RIM_COORDS, AWAY_RIM_COORDS } from "./courtConstants.js";
 
 const positionList = ["PG", "SG", "SF", "PF", "C"];
 
@@ -18,7 +19,7 @@ const HOME = {
     PF: { x: 89, y: 32 },
     C: { x: 89, y: 19 },
   },
-  rim: { x: 91, y: 25 },
+  rim: HOME_RIM_COORDS,
 };
 
 const AWAY = {
@@ -36,7 +37,7 @@ const AWAY = {
     PF: { x: 11, y: 32 },
     C: { x: 11, y: 19 },
   },
-  rim: { x: 9, y: 25 },
+  rim: AWAY_RIM_COORDS,
 };
 
 export function buildDestinations(offenseIsHome, shooterPos) {

--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -11,13 +11,12 @@ import {
 } from "./ballManager.js";
 import { tweenBallTo, runPass, PASS_DEBUG } from "./ballTween.js";
 import animationConfig from "./animation_config.js";
+import { HOME_RIM_COORDS, AWAY_RIM_COORDS } from "./courtConstants.js";
 
 // Cap the time spent on any single movement step. Large timestamp gaps can
 // otherwise produce multi‑second tweens that appear as animation stalls.
 const MAX_STEP_DURATION = 1000; // ms
 
-const HOME_RIM_COORDS = { x: 91, y: 25 };
-const AWAY_RIM_COORDS = { x: 9, y: 25 };
 
 /**
  * Centralized ball ownership logic


### PR DESCRIPTION
## Summary
- add `courtConstants.js` exporting rim and top key coordinates for both teams
- update front-end animation modules to import shared court constants
- mirror rim and top key constants in backend

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4cd5b8e1883289a413c703b08e840