### PR TITLE
feat: track franchise player stat blocks

### DIFF
--- a/BackEnd/models/franchise_manager.py
+++ b/BackEnd/models/franchise_manager.py
@@ -89,28 +89,31 @@ class FranchiseManager:
         if self.franchise_id:
             existing = (
                 self.db.franchises.find_one(
-                    {"_id": self.franchise_id}, {"player_stats": 1}
+                    {"_id": self.franchise_id}, {"players": 1}
                 )
                 or {}
             )
-        prev_stats = existing.get("player_stats", {})
-        player_stats: dict[str, dict] = {}
+        prev_stats = existing.get("players", {})
+        players_map: dict[str, dict] = {}
         players = self.db.players.find(
             {}, {"first_name": 1, "last_name": 1, "team": 1}
         )
         for p in players:
             pid = str(p.get("_id"))
             career = prev_stats.get(pid, {}).get("career", zero_stats.copy())
-            player_stats[pid] = {
+            meta = {
                 "first_name": p.get("first_name", ""),
                 "last_name": p.get("last_name", ""),
                 "team": p.get("team", ""),
+            }
+            players_map[pid] = {
+                "meta": meta,
                 "season": zero_stats.copy(),
                 "career": career,
             }
 
         self.save_season_state(
-            extra_state={"player_stats": player_stats, "applied_games": []}
+            extra_state={"players": players_map, "applied_games": []}
         )
 
     def reset_stats(self):

--- a/BackEnd/utils/stat_updater.py
+++ b/BackEnd/utils/stat_updater.py
@@ -2,7 +2,49 @@ from typing import Any, Dict
 
 from bson import ObjectId
 
+from BackEnd.constants import BOX_SCORE_KEYS
 from BackEnd.db import db, players_collection, tournaments_collection, games_collection
+
+
+def init_franchise_player_stats(franchise_id: str | ObjectId, roster: list[dict]) -> None:
+    """Seed a franchise document with zeroed player stat containers.
+
+    Args:
+        franchise_id: The ``_id`` of the franchise document to update. Can be
+            a ``str`` or :class:`~bson.objectid.ObjectId`.
+        roster: Iterable of player documents. Each entry should contain at
+            least ``_id``, ``first_name``, ``last_name`` and ``team`` fields.
+
+    The function populates ``players.<player_id>`` with ``meta``, ``season`` and
+    ``career`` blocks. All stat fields start at zero. Player documents in the
+    ``players`` collection are left untouched.
+    """
+
+    try:
+        fid = ObjectId(franchise_id)
+    except Exception:
+        fid = franchise_id
+
+    zero_stats = {k: 0 for k in BOX_SCORE_KEYS}
+    update: Dict[str, Any] = {}
+
+    for player in roster:
+        pid = str(player.get("_id"))
+        if not pid:
+            continue
+        meta = {
+            "first_name": player.get("first_name", ""),
+            "last_name": player.get("last_name", ""),
+            "team": player.get("team", ""),
+        }
+        update[f"players.{pid}"] = {
+            "meta": meta,
+            "season": zero_stats.copy(),
+            "career": zero_stats.copy(),
+        }
+
+    if update:
+        db.franchises.update_one({"_id": fid}, {"$set": update})
 
 
 def apply_stats_from_summary(summary: Dict[str, Any], game_id: str, tournament_id: str | None = None) -> None:
@@ -267,11 +309,11 @@ def finalize_game(
             for stat, val in stat_block.items():
                 if stat == "name" or not isinstance(val, (int, float)):
                     continue
-                inc_doc[f"player_stats.{pid}.season.{stat}"] = inc_doc.get(
-                    f"player_stats.{pid}.season.{stat}", 0
+                inc_doc[f"players.{pid}.season.{stat}"] = inc_doc.get(
+                    f"players.{pid}.season.{stat}", 0
                 ) + val
-                inc_doc[f"player_stats.{pid}.career.{stat}"] = inc_doc.get(
-                    f"player_stats.{pid}.career.{stat}", 0
+                inc_doc[f"players.{pid}.career.{stat}"] = inc_doc.get(
+                    f"players.{pid}.career.{stat}", 0
                 ) + val
 
         update: Dict[str, Any] = {"$addToSet": {"applied_games": game_id}}

--- a/tests/test_init_franchise_player_stats.py
+++ b/tests/test_init_franchise_player_stats.py
@@ -1,0 +1,55 @@
+from BackEnd.constants import BOX_SCORE_KEYS
+from BackEnd.db import db, players_collection
+from BackEnd.utils.stat_updater import init_franchise_player_stats
+
+
+def setup_db():
+    db.franchises.delete_many({})
+    players_collection.delete_many({})
+
+
+def test_init_franchise_player_stats_seeds_zero_blocks():
+    setup_db()
+
+    players_collection.insert_many(
+        [
+            {
+                "_id": "p1",
+                "first_name": "A",
+                "last_name": "One",
+                "team": "Team0",
+                "stats": {"season": {"PTS": 5}, "career": {"PTS": 10}},
+            },
+            {
+                "_id": "p2",
+                "first_name": "B",
+                "last_name": "Two",
+                "team": "Team1",
+                "stats": {"season": {"PTS": 7}, "career": {"PTS": 14}},
+            },
+        ]
+    )
+
+    roster = list(
+        players_collection.find({}, {"first_name": 1, "last_name": 1, "team": 1})
+    )
+    fid = db.franchises.insert_one({}).inserted_id
+
+    init_franchise_player_stats(fid, roster)
+
+    franchise = db.franchises.find_one({"_id": fid}) or {}
+    players = franchise.get("players", {})
+
+    assert set(players.keys()) == {"p1", "p2"}
+    zero_stats = {k: 0 for k in BOX_SCORE_KEYS}
+
+    for pid, pdata in players.items():
+        meta = pdata.get("meta", {})
+        assert meta.get("first_name")
+        assert meta.get("last_name")
+        assert pdata.get("season") == zero_stats
+        assert pdata.get("career") == zero_stats
+
+    p1_doc = players_collection.find_one({"_id": "p1"})
+    assert p1_doc["stats"]["season"]["PTS"] == 5
+    assert p1_doc["stats"]["career"]["PTS"] == 10


### PR DESCRIPTION
## Summary
- structure franchise documents with nested player meta/season/career fields
- add `init_franchise_player_stats` helper to seed zeroed blocks
- update stat updater to write to new franchise player paths
- cover zero-initialization with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4cdf6e664832883c3f3e206abde13