### PR TITLE
Raise HTTPException when user matchup missing

### DIFF
--- a/BackEnd/api/tournament_routes.py
+++ b/BackEnd/api/tournament_routes.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel
+import logging
 from BackEnd.db import (
     tournaments_collection,
     teams_collection,
@@ -16,6 +17,7 @@ from BackEnd.utils import stat_updater
 from bson import ObjectId
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 class StartTournamentRequest(BaseModel):
@@ -168,8 +170,21 @@ def simulate_round(request: SimulateRequest):
         if user_matchup:
             return user_matchup
 
-        return {"error": "User matchup not found"}
+        current_round = (
+            manager.tournament.get("current_round")
+            if getattr(manager, "tournament", None)
+            else None
+        )
+        logger.error(
+            "User matchup not found: tournament_id=%s current_round=%s user_team_id=%s",
+            str(tournament_id),
+            current_round,
+            user_team_id,
+        )
+        raise HTTPException(status_code=409, detail="User matchup not found")
 
+    except HTTPException:
+        raise
     except Exception as e:
         print("🚨 Error in simulate_round:", str(e))
         raise HTTPException(status_code=500, detail=str(e))

--- a/tests/test_tournament_full_bracket_progression.py
+++ b/tests/test_tournament_full_bracket_progression.py
@@ -9,6 +9,7 @@ from BackEnd.api.tournament_routes import (
     TournamentResultRequest,
 )
 from BackEnd.db import tournaments_collection, games_collection
+from fastapi import HTTPException
 
 
 def test_full_tournament_advances_bracket(monkeypatch):
@@ -81,7 +82,12 @@ def test_full_tournament_advances_bracket(monkeypatch):
     assert final[0]["away_team"] == r2_winners[1]
 
     # Final
-    matchup3 = simulate_round(SimulateRequest(tournament_id=str(tid)))
+    try:
+        matchup3 = simulate_round(SimulateRequest(tournament_id=str(tid)))
+    except HTTPException as exc:
+        assert exc.status_code == 409
+        matchup3 = {}
+
     if "home" in matchup3:
         home3, away3 = matchup3["home"], matchup3["away"]
     else:


### PR DESCRIPTION
## Summary
- log tournament context and raise HTTP 409 when a user's matchup is missing during round simulation
- propagate HTTP errors directly to callers
- adjust full tournament progression test to expect 409 when final matchup is absent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a4d88acae883289d2f709ead29f0a4