### PR TITLE
Add wildcard indexes for franchise player stats

### DIFF
--- a/BackEnd/db.py
+++ b/BackEnd/db.py
@@ -26,6 +26,7 @@ if client:
     tournaments_collection = db["tournaments"]
     training_log_collection = db["training_sessions"]
     franchise_state_collection = db["franchise_state"]
+    franchises_collection = db["franchises"]
 else:
     import mongomock
     client = mongomock.MongoClient()
@@ -36,5 +37,6 @@ else:
     tournaments_collection = db["tournaments"]
     training_log_collection = db["training_sessions"]
     franchise_state_collection = db["franchise_state"]
+    franchises_collection = db["franchises"]
 
 

--- a/docs/database_setup.md
+++ b/docs/database_setup.md
@@ -1,0 +1,17 @@
+# Database Setup
+
+Use the helper script to create database indexes for franchise documents.
+
+```bash
+python scripts/setup_franchise_indexes.py
+```
+
+This script adds wildcard indexes for:
+
+- `players.<pid>.meta.team_id`
+- `players.<pid>.season.totals.*`
+- `players.<pid>.career.totals.*`
+
+Running the script once during migrations or environment setup ensures
+queries targeting player metadata or aggregated statistics are
+optimized.

--- a/scripts/setup_franchise_indexes.py
+++ b/scripts/setup_franchise_indexes.py
@@ -1,0 +1,21 @@
+"""Create wildcard indexes for the franchises collection.
+
+This script ensures efficient queries on player metadata and aggregated
+statistics within franchise documents. It can be run as part of a database
+migration or one-time setup step after deploying the application.
+"""
+
+from BackEnd.db import franchises_collection
+
+INDEX_SPECS = [
+    ("players.$**.meta.team_id", 1),
+    ("players.$**.season.totals.$**", 1),
+    ("players.$**.career.totals.$**", 1),
+]
+
+for field, order in INDEX_SPECS:
+    try:
+        name = franchises_collection.create_index([(field, order)])
+        print(f"✅ Created index '{name}' for '{field}'")
+    except Exception as exc:
+        print(f"⚠️ Failed to create index for '{field}': {exc}")


### PR DESCRIPTION
## Summary
- expose `franchises_collection` in DB module
- add `scripts/setup_franchise_indexes.py` to create wildcard indexes for franchise player metadata and totals
- document running the index setup script

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4d86641908328940c8e736400c229