### PR TITLE
Handle simulate round errors in tournament play button

### DIFF
--- a/FrontEnd/static/tournament.js
+++ b/FrontEnd/static/tournament.js
@@ -539,13 +539,19 @@ document.addEventListener("DOMContentLoaded", async () => {
       }
       playBtn.disabled = true;
       try {
+        const payload = { tournament_id: tournament._id };
         const res = await fetch('/simulate-tournament-round', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ tournament_id: tournament._id })
+          body: JSON.stringify(payload)
         });
-        if (!res.ok) throw new Error('Request failed');
         const data = await res.json();
+        console.log('[PlayNow] simulate round', { payload, response: data });
+        if (!res.ok || data.error) {
+          alert(data.detail || data.error || 'Unable to start game');
+          playBtn.disabled = false;
+          return;
+        }
         if (data.already_played) {
           playBtn.disabled = false;
           await refreshTeamStats();


### PR DESCRIPTION
## Summary
- handle non-OK responses and API errors from the play button fetch
- log payload and response for debugging

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4da404de083288a94a60f1cc3bf60