### PR TITLE
feat: add franchise rollup util

### DIFF
--- a/BackEnd/utils/__init__.py
+++ b/BackEnd/utils/__init__.py
@@ -3,6 +3,7 @@
 from .stat_updater import (
     apply_stats_from_summary,
     finalize_game,
+    rollup_game_to_franchise,
     recompute_tournament_leaders,
     update_game_stats,
 )
@@ -10,6 +11,7 @@ from .stat_updater import (
 __all__ = [
     "apply_stats_from_summary",
     "finalize_game",
+    "rollup_game_to_franchise",
     "recompute_tournament_leaders",
     "update_game_stats",
 ]

--- a/BackEnd/utils/stat_updater.py
+++ b/BackEnd/utils/stat_updater.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict
 
 from bson import ObjectId
+from pymongo import ReturnDocument
 
 from BackEnd.constants import BOX_SCORE_KEYS
 from BackEnd.db import db, players_collection, tournaments_collection, games_collection
@@ -234,6 +235,118 @@ def recompute_tournament_leaders(tournament_id: str, limit: int = 10) -> Dict[st
         {"_id": tid}, {"$set": {"leaderboards": leaderboards}}
     )
     return leaderboards
+
+
+def rollup_game_to_franchise(franchise_id: str | ObjectId, game_id: str | ObjectId) -> None:
+    """Aggregate a game's stats into a franchise document.
+
+    The update is idempotent per ``game_id`` thanks to the ``processed_games``
+    guard.  Per-player season and career totals are incremented, per-game
+    averages and shooting percentages are recomputed, and ``game_id`` is
+    appended to ``processed_games``.
+    """
+
+    try:
+        fid = ObjectId(franchise_id)
+    except Exception:
+        fid = franchise_id
+
+    game = games_collection.find_one({"_id": game_id})
+    if not game and isinstance(game_id, str):
+        try:
+            game = games_collection.find_one({"_id": ObjectId(game_id)})
+        except Exception:
+            game = None
+    if not game:
+        return
+
+    players = game.get("players", [])
+    box_score = game.get("box_score", {})
+    team_map = {"home": game.get("home_team"), "away": game.get("away_team")}
+
+    inc_doc: Dict[str, Any] = {}
+    set_doc: Dict[str, Any] = {}
+
+    for p in players:
+        pid = str(p.get("playerId"))
+        team_side = p.get("team")
+        pos = p.get("pos")
+        team_name = team_map.get(team_side)
+        if not pid or not team_name:
+            continue
+        stat_block = box_score.get(team_name, {}).get(pos, p.get("stats", {}))
+        for stat, val in stat_block.items():
+            if stat == "name" or not isinstance(val, (int, float)):
+                continue
+            inc_doc[f"player_stats.{pid}.season.{stat}"] = inc_doc.get(
+                f"player_stats.{pid}.season.{stat}", 0
+            ) + val
+            inc_doc[f"player_stats.{pid}.career.{stat}"] = inc_doc.get(
+                f"player_stats.{pid}.career.{stat}", 0
+            ) + val
+        inc_doc[f"player_stats.{pid}.season.GP"] = inc_doc.get(
+            f"player_stats.{pid}.season.GP", 0
+        ) + 1
+        inc_doc[f"player_stats.{pid}.career.GP"] = inc_doc.get(
+            f"player_stats.{pid}.career.GP", 0
+        ) + 1
+
+        meta = players_collection.find_one(
+            {"_id": pid}, {"first_name": 1, "last_name": 1, "team": 1}
+        )
+        if meta:
+            set_doc[f"player_stats.{pid}.first_name"] = meta.get("first_name", "")
+            set_doc[f"player_stats.{pid}.last_name"] = meta.get("last_name", "")
+            set_doc[f"player_stats.{pid}.team"] = meta.get("team", "")
+
+    if not inc_doc:
+        return
+
+    update_doc: Dict[str, Any] = {
+        "$inc": inc_doc,
+        "$addToSet": {"processed_games": game_id},
+    }
+    if set_doc:
+        update_doc["$set"] = set_doc
+
+    result = db.franchises.find_one_and_update(
+        {"_id": fid, "processed_games": {"$ne": game_id}},
+        update_doc,
+        return_document=ReturnDocument.AFTER,
+    )
+
+    if not result:
+        return
+
+    avg_doc: Dict[str, Any] = {}
+    for p in players:
+        pid = str(p.get("playerId"))
+        pdata = result.get("player_stats", {}).get(pid, {})
+        season_totals = pdata.get("season", {})
+        gp = season_totals.get("GP", 0)
+        averages: Dict[str, Any] = {}
+        if gp:
+            for stat in BOX_SCORE_KEYS:
+                averages[stat] = season_totals.get(stat, 0) / gp
+            averages["FG%"] = (
+                season_totals.get("FGM", 0) / season_totals.get("FGA", 0) * 100
+                if season_totals.get("FGA", 0)
+                else 0.0
+            )
+            averages["FT%"] = (
+                season_totals.get("FTM", 0) / season_totals.get("FTA", 0) * 100
+                if season_totals.get("FTA", 0)
+                else 0.0
+            )
+        else:
+            for stat in BOX_SCORE_KEYS:
+                averages[stat] = 0
+            averages["FG%"] = 0.0
+            averages["FT%"] = 0.0
+        avg_doc[f"player_stats.{pid}.averages"] = averages
+
+    if avg_doc:
+        db.franchises.update_one({"_id": fid}, {"$set": avg_doc})
 
 
 def finalize_game(

--- a/tests/test_rollup_game_to_franchise.py
+++ b/tests/test_rollup_game_to_franchise.py
@@ -1,0 +1,58 @@
+from BackEnd.utils.stat_updater import rollup_game_to_franchise
+from BackEnd.db import db, games_collection, players_collection
+
+
+def setup_function(_fn):
+    games_collection.delete_many({})
+    players_collection.delete_many({})
+    db.franchises.delete_many({})
+
+
+def test_rollup_game_to_franchise_idempotent():
+    players_collection.insert_many(
+        [
+            {"_id": "p1", "first_name": "A", "last_name": "One", "team": "Team1"},
+            {"_id": "p2", "first_name": "B", "last_name": "Two", "team": "Team2"},
+        ]
+    )
+
+    fid = db.franchises.insert_one({"player_stats": {}, "processed_games": []}).inserted_id
+
+    game = {
+        "home_team": "Team1",
+        "away_team": "Team2",
+        "box_score": {
+            "Team1": {"PG": {"name": "A One", "PTS": 10, "FGA": 5, "FGM": 4, "FTA": 2, "FTM": 1}},
+            "Team2": {"PG": {"name": "B Two", "PTS": 8, "FGA": 6, "FGM": 3, "FTA": 1, "FTM": 1}},
+        },
+        "players": [
+            {"playerId": "p1", "team": "home", "pos": "PG"},
+            {"playerId": "p2", "team": "away", "pos": "PG"},
+        ],
+    }
+    gid = games_collection.insert_one(game).inserted_id
+
+    rollup_game_to_franchise(str(fid), str(gid))
+    doc1 = db.franchises.find_one({"_id": fid})
+
+    p1 = doc1["player_stats"]["p1"]
+    p2 = doc1["player_stats"]["p2"]
+    assert p1["season"]["PTS"] == 10
+    assert p1["season"]["FGA"] == 5
+    assert p1["season"]["FGM"] == 4
+    assert p1["season"]["GP"] == 1
+    assert p1["averages"]["PTS"] == 10
+    assert p1["averages"]["FG%"] == 80.0
+    assert p1["averages"]["FT%"] == 50.0
+
+    assert p2["season"]["PTS"] == 8
+    assert p2["averages"]["FG%"] == 50.0
+    assert p2["averages"]["FT%"] == 100.0
+
+    assert doc1["processed_games"] == [str(gid)]
+
+    rollup_game_to_franchise(str(fid), str(gid))
+    doc2 = db.franchises.find_one({"_id": fid})
+
+    assert doc2 == doc1
+


### PR DESCRIPTION
## Summary
- add rollup_game_to_franchise helper to aggregate game stats and compute averages
- expose new helper in utils package
- test rollup_game_to_franchise idempotency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4da3383308328b78ee9ac8232893b