### PR TITLE
Guard fast-break sequences with progress flag

### DIFF
--- a/BackEnd/models/turn_manager.py
+++ b/BackEnd/models/turn_manager.py
@@ -165,7 +165,7 @@ class TurnManager:
         elif state == "FAST_BREAK":
             self.logger.log("fb:start")
             self.game.game_state["fastBreakInProgress"] = True
-            result = self.resolve_fast_break()
+            result = resolve_fast_break_logic(self.game)
         else:
             calls = self.set_playcalls()
             self.game.game_state["current_playcall"] = calls["offense"]
@@ -180,11 +180,13 @@ class TurnManager:
         result["starting_possession_team_id"] = self.game.offense_team.team_id
 
         # STEP 4: Final updates (clock, logs, animation)
-        self.update_clock_and_possession(result)
-        self.logger.log_turn_result(result)
-        if state == "FAST_BREAK":
-            self.logger.log("fb:end")
-            self.game.game_state["fastBreakInProgress"] = False
+        try:
+            self.update_clock_and_possession(result)
+            self.logger.log_turn_result(result)
+        finally:
+            if state == "FAST_BREAK":
+                self.logger.log("fb:end")
+                self.game.game_state["fastBreakInProgress"] = False
         # If animations weren’t assigned yet (e.g. fast break, free throw), use fallback
         if "animations" not in result:
             roles = result.get("roles")

--- a/FrontEnd/static/js/phaser/animation/animateGameTurns.js
+++ b/FrontEnd/static/js/phaser/animation/animateGameTurns.js
@@ -19,6 +19,7 @@ export async function animateGameTurns({ //hasBallAtStep
   const allPlayers = simData.players || [];
 
   const handlePossessionFlip = (payload = {}) => {
+    if (scene.fastBreakInProgress) return;
     scene.possessionFlipInProgress = true;
     scene.offenseTeamId = payload.offenseTeamId;
     if (REBOUND_DEBUG) {
@@ -48,7 +49,9 @@ export async function animateGameTurns({ //hasBallAtStep
     }
 
     if (turn.result_type === "SIDE_INBOUND") {
-      await runSideInboundSetup({ scene, ballSprite, playerSprites, turnData: turn });
+      if (!scene.fastBreakInProgress) {
+        await runSideInboundSetup({ scene, ballSprite, playerSprites, turnData: turn });
+      }
       if (onUpdate) {
         try {
           onUpdate(turn);

--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -48,12 +48,12 @@ function attachBallToPlayer(scene, ballSprite, playerSprite, opts = {}) {
 
 function runInboundSetup(opts) {
   const scene = opts.scene;
-  if (scene.possessionFlipInProgress) return Promise.resolve();
+  if (scene.possessionFlipInProgress || scene.fastBreakInProgress) return Promise.resolve();
   return baseRunInboundSetup(opts);
 }
 
 function runPass(scene, cfg = {}) {
-  if (scene.possessionFlipInProgress) return Promise.resolve();
+  if (scene.possessionFlipInProgress || scene.fastBreakInProgress) return Promise.resolve();
   return baseRunPass(scene, cfg);
 }
 

--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -23,7 +23,7 @@ const MAX_STEP_DURATION = 1000; // ms
  * Assigns the ball to the correct player for the current stepIndex
  */
 function updateBallOwnership({ scene, ballSprite, animations, playerSprites, stepIndex, offenseTeamId, currentBallOwnerRef }) {
-  if (scene?.skipToEnd) return;
+  if (scene?.skipToEnd || scene?.fastBreakInProgress) return;
 
   if (scene.passInFlight) return;
 
@@ -115,7 +115,7 @@ async function runSetupTween({ scene, ballSprite, animations, playerSprites, cur
 
 // Setup sideline inbound play
 async function runSideInboundSetup({ scene, ballSprite, playerSprites, turnData }) {
-  if (!turnData || scene?.skipToEnd || scene?.ftInProgress) return;
+  if (!turnData || scene?.skipToEnd || scene?.ftInProgress || scene?.fastBreakInProgress) return;
 
   const { ball_spot, oDestinations = {}, dDestinations = {}, possession_team_id } = turnData;
   const offenseTeamId = scene.currentOffenseTeamId ?? possession_team_id;


### PR DESCRIPTION
## Summary
- Ensure `fastBreakInProgress` wraps `resolve_fast_break_logic` and is cleared after updates
- Skip ownership sync and side inbound setup when fast break is active
- Halt possession flips, inbound scheduling, and passes during fast breaks

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4db61c37c8328a0455e05ee996a5d