### PR TITLE
Add team player stats endpoints for franchise mode

### DIFF
--- a/BackEnd/api/franchise_routes.py
+++ b/BackEnd/api/franchise_routes.py
@@ -503,6 +503,108 @@ def team_stats():
     return {"teams": output}
 
 
+def get_team_player_stats(
+    franchise_id: str,
+    team_id: str,
+    scope: str = "season",
+    *,
+    sort: str | None = "PTS",
+    direction: str = "desc",
+    page: int = 1,
+    limit: int | None = None,
+):
+    """Return players for ``team_id`` within ``franchise_id``.
+
+    Filters franchise ``players`` by ``meta.team_id`` and returns the requested
+    stat block (``season`` by default).  Results may be sorted and paginated for
+    UI consumption.
+    """
+
+    try:
+        fid = ObjectId(franchise_id)
+    except Exception:
+        fid = franchise_id
+
+    doc = db.franchises.find_one({"_id": fid}, {"players": 1}) or {}
+    players = doc.get("players", {})
+    team_id_str = str(team_id)
+    results: list[dict] = []
+    for pid, pdata in players.items():
+        meta = pdata.get("meta", {})
+        if str(meta.get("team_id")) != team_id_str:
+            continue
+        block = pdata.get(scope, {})
+        results.append(
+            {
+                "player_id": pid,
+                "first_name": meta.get("first_name", ""),
+                "last_name": meta.get("last_name", ""),
+                "stats": block,
+            }
+        )
+
+    if sort:
+        reverse = direction.lower() != "asc"
+        results.sort(key=lambda x: x["stats"].get(sort, 0), reverse=reverse)
+
+    if limit:
+        start = max(page - 1, 0) * limit
+        results = results[start : start + limit]
+
+    return results
+
+
+@router.get("/franchise/team-player-stats/{team_id}")
+def team_player_stats_endpoint(
+    team_id: str,
+    franchise_id: str,
+    scope: str = "season",
+    page: int = 1,
+    limit: int | None = None,
+    sort: str | None = "PTS",
+    direction: str = "desc",
+):
+    tid = _normalize_team_id(team_id)
+    players = get_team_player_stats(
+        franchise_id,
+        str(tid),
+        scope,
+        sort=sort,
+        direction=direction,
+        page=page,
+        limit=limit,
+    )
+    return {"players": players}
+
+
+@router.get("/franchise/team-player-stats")
+def user_team_player_stats_endpoint(
+    franchise_id: str,
+    scope: str = "season",
+    page: int = 1,
+    limit: int | None = None,
+    sort: str | None = "PTS",
+    direction: str = "desc",
+):
+    state = franchise_state_collection.find_one({"_id": "state"}) or {}
+    team_name = state.get("team")
+    if not team_name:
+        raise HTTPException(status_code=404, detail="User team not selected")
+    team_doc = db.teams.find_one({"name": team_name}, {"_id": 1})
+    if not team_doc:
+        raise HTTPException(status_code=404, detail="Team not found")
+    players = get_team_player_stats(
+        franchise_id,
+        str(team_doc["_id"]),
+        scope,
+        sort=sort,
+        direction=direction,
+        page=page,
+        limit=limit,
+    )
+    return {"players": players}
+
+
 @router.get("/franchise/recruits")
 def recruits():
     recs = list(db.recruits.find({}, {"_id": 0}).limit(40))

--- a/BackEnd/models/franchise_manager.py
+++ b/BackEnd/models/franchise_manager.py
@@ -96,7 +96,7 @@ class FranchiseManager:
         prev_stats = existing.get("players", {})
         players_map: dict[str, dict] = {}
         players = self.db.players.find(
-            {}, {"first_name": 1, "last_name": 1, "team": 1}
+            {}, {"first_name": 1, "last_name": 1, "team": 1, "team_id": 1}
         )
         for p in players:
             pid = str(p.get("_id"))
@@ -106,6 +106,9 @@ class FranchiseManager:
                 "last_name": p.get("last_name", ""),
                 "team": p.get("team", ""),
             }
+            tid = p.get("team_id")
+            if tid is not None:
+                meta["team_id"] = str(tid)
             players_map[pid] = {
                 "meta": meta,
                 "season": zero_stats.copy(),

--- a/BackEnd/utils/stat_updater.py
+++ b/BackEnd/utils/stat_updater.py
@@ -38,6 +38,9 @@ def init_franchise_player_stats(franchise_id: str | ObjectId, roster: list[dict]
             "last_name": player.get("last_name", ""),
             "team": player.get("team", ""),
         }
+        tid = player.get("team_id")
+        if tid is not None:
+            meta["team_id"] = str(tid)
         update[f"players.{pid}"] = {
             "meta": meta,
             "season": zero_stats.copy(),

--- a/tests/test_franchise_team_player_stats.py
+++ b/tests/test_franchise_team_player_stats.py
@@ -1,0 +1,62 @@
+from fastapi.testclient import TestClient
+
+from BackEnd.api.api import app
+from BackEnd.api.franchise_routes import get_team_player_stats
+from BackEnd.db import db, franchise_state_collection
+
+
+client = TestClient(app)
+
+
+def setup_function(_fn):
+    db.franchises.delete_many({})
+    db.teams.delete_many({})
+    franchise_state_collection.delete_many({})
+
+
+def seed_franchise():
+    fid = db.franchises.insert_one(
+        {
+            "players": {
+                "p1": {
+                    "meta": {"team_id": "t1", "first_name": "A", "last_name": "One"},
+                    "season": {"PTS": 5},
+                },
+                "p2": {
+                    "meta": {"team_id": "t1", "first_name": "B", "last_name": "Two"},
+                    "season": {"PTS": 10},
+                },
+                "p3": {
+                    "meta": {"team_id": "t2", "first_name": "C", "last_name": "Three"},
+                    "season": {"PTS": 7},
+                },
+            }
+        }
+    ).inserted_id
+    return str(fid)
+
+
+def test_get_team_player_stats_and_endpoints():
+    fid = seed_franchise()
+
+    # ensure teams exist for endpoint normalization
+    db.teams.insert_many([
+        {"_id": "t1", "name": "Team1"},
+        {"_id": "t2", "name": "Team2"},
+    ])
+
+    players = get_team_player_stats(fid, "t1")
+    assert [p["player_id"] for p in players] == ["p2", "p1"]
+
+    resp = client.get(f"/franchise/team-player-stats/t1?franchise_id={fid}&limit=1")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["players"]) == 1
+    assert data["players"][0]["player_id"] == "p2"
+
+    franchise_state_collection.insert_one({"_id": "state", "team": "Team1"})
+    resp = client.get(f"/franchise/team-player-stats?franchise_id={fid}")
+    assert resp.status_code == 200
+    data2 = resp.json()
+    assert [p["player_id"] for p in data2["players"]] == ["p2", "p1"]
+


### PR DESCRIPTION
## Summary
- add `get_team_player_stats` helper with filtering, sorting, and pagination
- expose team-player stats endpoints for user team and any team
- track `team_id` in franchise player metadata
- test team player stats retrieval via new API endpoints

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4dbfa2bd48328a46b93e3eb5217e9