### PR TITLE
Add franchise stat leaders API and frontend integration

### DIFF
--- a/BackEnd/api/franchise_routes.py
+++ b/BackEnd/api/franchise_routes.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from bson import ObjectId
 import logging
 import random
+from typing import Any
 from BackEnd.main import run_simulation
 
 from BackEnd.db import db, franchise_state_collection
@@ -467,24 +468,98 @@ def season_schedule(franchise_id: str):
     return {"schedule": weeks}
 
 
+def get_leaders(
+    franchise_id: str,
+    scope: str = "season",
+    stat: str = "PTS",
+    limit: int = 10,
+):
+    """Return the top players for a given stat within a franchise.
+
+    Players are sourced from the franchise document to avoid cross-collection
+    joins. For small rosters the sorting is performed in-memory. When the
+    number of players grows large an aggregation pipeline is used so MongoDB
+    can leverage indexes on the ``players`` subdocument.
+    """
+
+    try:
+        fid = ObjectId(franchise_id)
+    except Exception:
+        fid = franchise_id
+
+    doc = db.franchises.find_one({"_id": fid}, {"players": 1}) or {}
+    players = doc.get("players", {}) or {}
+
+    if len(players) <= 500:
+        rows: list[dict[str, Any]] = []
+        for pid, pdata in players.items():
+            meta = pdata.get("meta", {})
+            block = pdata.get(scope, {}) or {}
+            totals = block.get("totals", block)
+            value = totals.get(stat, 0)
+            rows.append(
+                {
+                    "player_id": pid,
+                    "first_name": meta.get("first_name", ""),
+                    "last_name": meta.get("last_name", ""),
+                    "team": meta.get("team", meta.get("team_id", "")),
+                    "value": value,
+                }
+            )
+
+        rows.sort(key=lambda r: r["value"], reverse=True)
+        return rows[:limit]
+
+    pipeline = [
+        {"$match": {"_id": fid}},
+        {"$project": {"players": {"$objectToArray": "$players"}}},
+        {"$unwind": "$players"},
+        {
+            "$project": {
+                "player_id": "$players.k",
+                "meta": "$players.v.meta",
+                "value": f"$players.v.{scope}.totals.{stat}",
+            }
+        },
+        {"$sort": {"value": -1}},
+        {"$limit": limit},
+    ]
+
+    agg = list(db.franchises.aggregate(pipeline))
+    results: list[dict[str, Any]] = []
+    for p in agg:
+        meta = p.get("meta", {})
+        results.append(
+            {
+                "player_id": p.get("player_id"),
+                "first_name": meta.get("first_name", ""),
+                "last_name": meta.get("last_name", ""),
+                "team": meta.get("team", meta.get("team_id", "")),
+                "value": p.get("value", 0),
+            }
+        )
+
+    return results
+
+
 @router.get("/franchise/leaders")
-def leaders():
-    players = list(db.players.find())
+def leaders(
+    franchise_id: str,
+    scope: str = "season",
+    limit: int = 10,
+):
     categories = ["PTS", "AST", "TPM", "REB", "BLK", "STL"]
-    result = {}
+    result: dict[str, list[dict[str, Any]]] = {}
     for cat in categories:
-        sorted_players = sorted(
-            players,
-            key=lambda p: p.get("stats", {}).get("season", {}).get(cat, 0),
-            reverse=True
-        )[:10]
+        top = get_leaders(franchise_id, scope=scope, stat=cat, limit=limit)
         result[cat] = [
             {
+                "player_id": p.get("player_id"),
                 "name": f"{p.get('first_name', '')} {p.get('last_name', '')}".strip(),
                 "team": p.get("team"),
-                "value": p.get("stats", {}).get("season", {}).get(cat, 0)
+                "value": p.get("value", 0),
             }
-            for p in sorted_players
+            for p in top
         ]
     return result
 

--- a/FrontEnd/static/franchise-command-center.js
+++ b/FrontEnd/static/franchise-command-center.js
@@ -197,12 +197,12 @@ async function init() {
   }
   const standingsData = await fetchJSON(`/franchise/standings?franchise_id=${franchiseId}`);
   renderStandings(standingsData);
-  const scheduleData = await fetchJSON(`/franchise/schedule?franchise_id=${franchiseId}`);
-  renderSchedule(scheduleData);
-  renderLeaders(await fetchJSON('/franchise/leaders'));
-  renderTeamStats(await fetchJSON('/franchise/team-stats'));
-  renderRecruits(await fetchJSON('/franchise/recruits'));
-}
+    const scheduleData = await fetchJSON(`/franchise/schedule?franchise_id=${franchiseId}`);
+    renderSchedule(scheduleData);
+    renderLeaders(await fetchJSON(`/franchise/leaders?franchise_id=${franchiseId}`));
+    renderTeamStats(await fetchJSON('/franchise/team-stats'));
+    renderRecruits(await fetchJSON('/franchise/recruits'));
+  }
 
 const playNowBtn = document.getElementById('play-now');
 playNowBtn.disabled = true;

--- a/tests/test_franchise_leaders_endpoint.py
+++ b/tests/test_franchise_leaders_endpoint.py
@@ -1,0 +1,47 @@
+from fastapi.testclient import TestClient
+
+from BackEnd.api.api import app
+from BackEnd.api.franchise_routes import get_leaders
+from BackEnd.db import db
+
+client = TestClient(app)
+
+
+def setup_function(_fn):
+    db.franchises.delete_many({})
+
+
+def seed_franchise():
+    fid = db.franchises.insert_one(
+        {
+            "players": {
+                "p1": {
+                    "meta": {"first_name": "Ann", "last_name": "Alpha", "team": "A"},
+                    "season": {"totals": {"PTS": 20}},
+                },
+                "p2": {
+                    "meta": {"first_name": "Bob", "last_name": "Beta", "team": "B"},
+                    "season": {"totals": {"PTS": 15}},
+                },
+                "p3": {
+                    "meta": {"first_name": "Cara", "last_name": "Gamma", "team": "C"},
+                    "season": {"totals": {"PTS": 5}},
+                },
+            }
+        }
+    ).inserted_id
+    return str(fid)
+
+
+def test_get_leaders_and_endpoint():
+    fid = seed_franchise()
+
+    top = get_leaders(fid, stat="PTS", limit=2)
+    assert [p["player_id"] for p in top] == ["p1", "p2"]
+
+    resp = client.get(f"/franchise/leaders?franchise_id={fid}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["PTS"][0]["name"] == "Ann Alpha"
+    assert data["PTS"][0]["value"] == 20
+    assert data["PTS"][1]["name"] == "Bob Beta"


### PR DESCRIPTION
## Summary
- add `get_leaders` utility to compute top franchise players for a stat using in-memory or aggregated sorting
- expose `/franchise/leaders` endpoint with franchise-specific leaderboards
- hook Leaders tab to new endpoint
- add test for franchise leader retrieval

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4ddf88b148328bf35a94baf9897cb