### PR TITLE
Add per-game and shooting percentage rollups

### DIFF
--- a/BackEnd/utils/stat_updater.py
+++ b/BackEnd/utils/stat_updater.py
@@ -245,8 +245,8 @@ def rollup_game_to_franchise(franchise_id: str | ObjectId, game_id: str | Object
 
     The update is idempotent per ``game_id`` thanks to the ``processed_games``
     guard.  Per-player season and career totals are incremented, per-game
-    averages and shooting percentages are recomputed, and ``game_id`` is
-    appended to ``processed_games``.
+    averages and shooting percentages are recomputed within the ``season`` and
+    ``career`` blocks, and ``game_id`` is appended to ``processed_games``.
     """
 
     try:
@@ -321,35 +321,41 @@ def rollup_game_to_franchise(franchise_id: str | ObjectId, game_id: str | Object
     if not result:
         return
 
-    avg_doc: Dict[str, Any] = {}
+    def per_game_block(totals: Dict[str, Any]) -> Dict[str, float]:
+        gp = totals.get("GP", 0)
+        if not gp:
+            return {stat: 0 for stat in BOX_SCORE_KEYS}
+        return {stat: totals.get(stat, 0) / gp for stat in BOX_SCORE_KEYS}
+
+    def pct_block(totals: Dict[str, Any]) -> Dict[str, float]:
+        fga = totals.get("FGA", 0)
+        fgm = totals.get("FGM", 0)
+        tpa = totals.get("3PTA", 0)
+        tpm = totals.get("3PTM", 0)
+        fta = totals.get("FTA", 0)
+        ftm = totals.get("FTM", 0)
+        pts = totals.get("PTS", 0)
+        fg_pct = (fgm / fga * 100) if fga else 0.0
+        fg3_pct = (tpm / tpa * 100) if tpa else 0.0
+        ft_pct = (ftm / fta * 100) if fta else 0.0
+        ts_den = 2 * (fga + 0.44 * fta)
+        ts_pct = (pts / ts_den * 100) if ts_den else 0.0
+        efg_pct = ((fgm + 0.5 * tpm) / fga * 100) if fga else 0.0
+        return {"FG%": fg_pct, "3PT%": fg3_pct, "FT%": ft_pct, "TS%": ts_pct, "eFG%": efg_pct}
+
+    stats_doc: Dict[str, Any] = {}
     for p in players:
         pid = str(p.get("playerId"))
         pdata = result.get("player_stats", {}).get(pid, {})
         season_totals = pdata.get("season", {})
-        gp = season_totals.get("GP", 0)
-        averages: Dict[str, Any] = {}
-        if gp:
-            for stat in BOX_SCORE_KEYS:
-                averages[stat] = season_totals.get(stat, 0) / gp
-            averages["FG%"] = (
-                season_totals.get("FGM", 0) / season_totals.get("FGA", 0) * 100
-                if season_totals.get("FGA", 0)
-                else 0.0
-            )
-            averages["FT%"] = (
-                season_totals.get("FTM", 0) / season_totals.get("FTA", 0) * 100
-                if season_totals.get("FTA", 0)
-                else 0.0
-            )
-        else:
-            for stat in BOX_SCORE_KEYS:
-                averages[stat] = 0
-            averages["FG%"] = 0.0
-            averages["FT%"] = 0.0
-        avg_doc[f"player_stats.{pid}.averages"] = averages
+        career_totals = pdata.get("career", {})
+        stats_doc[f"player_stats.{pid}.season.per_game"] = per_game_block(season_totals)
+        stats_doc[f"player_stats.{pid}.career.per_game"] = per_game_block(career_totals)
+        stats_doc[f"player_stats.{pid}.season.percentages"] = pct_block(season_totals)
+        stats_doc[f"player_stats.{pid}.career.percentages"] = pct_block(career_totals)
 
-    if avg_doc:
-        db.franchises.update_one({"_id": fid}, {"$set": avg_doc})
+    if stats_doc:
+        db.franchises.update_one({"_id": fid}, {"$set": stats_doc})
 
 
 def finalize_game(

--- a/tests/test_rollup_game_to_franchise.py
+++ b/tests/test_rollup_game_to_franchise.py
@@ -1,5 +1,6 @@
 from BackEnd.utils.stat_updater import rollup_game_to_franchise
 from BackEnd.db import db, games_collection, players_collection
+from pytest import approx
 
 
 def setup_function(_fn):
@@ -41,13 +42,19 @@ def test_rollup_game_to_franchise_idempotent():
     assert p1["season"]["FGA"] == 5
     assert p1["season"]["FGM"] == 4
     assert p1["season"]["GP"] == 1
-    assert p1["averages"]["PTS"] == 10
-    assert p1["averages"]["FG%"] == 80.0
-    assert p1["averages"]["FT%"] == 50.0
+    assert p1["season"]["per_game"]["PTS"] == 10
+    assert p1["season"]["percentages"]["FG%"] == 80.0
+    assert p1["season"]["percentages"]["FT%"] == 50.0
+    assert p1["season"]["percentages"]["TS%"] == approx(85.0340136, rel=1e-3)
+    assert p1["season"]["percentages"]["eFG%"] == 80.0
+
+    assert p1["career"]["per_game"]["PTS"] == 10
+    assert p1["career"]["percentages"]["FG%"] == 80.0
 
     assert p2["season"]["PTS"] == 8
-    assert p2["averages"]["FG%"] == 50.0
-    assert p2["averages"]["FT%"] == 100.0
+    assert p2["season"]["percentages"]["FG%"] == 50.0
+    assert p2["season"]["percentages"]["FT%"] == 100.0
+    assert p2["career"]["percentages"]["FG%"] == 50.0
 
     assert doc1["processed_games"] == [str(gid)]
 


### PR DESCRIPTION
## Summary
- compute per-game averages and shooting percentages for season and career stats
- include FG%, 3PT%, FT%, TS%, and eFG% during franchise rollup
- adjust franchise rollup test for new stat structure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4df552f0c8328800ade044dfcb5f9