### PR TITLE
Add franchise stat validation and backfill tooling

### DIFF
--- a/BackEnd/utils/__init__.py
+++ b/BackEnd/utils/__init__.py
@@ -4,6 +4,7 @@ from .stat_updater import (
     apply_stats_from_summary,
     finalize_game,
     rollup_game_to_franchise,
+    backfill_franchise_player_stats,
     recompute_tournament_leaders,
     update_game_stats,
 )
@@ -12,6 +13,7 @@ __all__ = [
     "apply_stats_from_summary",
     "finalize_game",
     "rollup_game_to_franchise",
+    "backfill_franchise_player_stats",
     "recompute_tournament_leaders",
     "update_game_stats",
 ]

--- a/BackEnd/utils/stat_updater.py
+++ b/BackEnd/utils/stat_updater.py
@@ -7,6 +7,50 @@ from BackEnd.constants import BOX_SCORE_KEYS
 from BackEnd.db import db, players_collection, tournaments_collection, games_collection
 
 
+def _clean_stat_block(stats: Dict[str, Any]) -> Dict[str, float]:
+    """Return only numeric, non-negative stat entries.
+
+    Any field that is not a number or is negative is discarded. The ``name``
+    field, sometimes present in box score rows, is also ignored.
+    """
+
+    clean: Dict[str, float] = {}
+    for stat, val in stats.items():
+        if stat == "name":
+            continue
+        if isinstance(val, (int, float)) and val >= 0:
+            clean[stat] = val
+    return clean
+
+
+def _per_game_block(totals: Dict[str, Any]) -> Dict[str, float]:
+    """Return per-game averages for a totals block."""
+
+    gp = totals.get("GP", 0)
+    if not gp:
+        return {stat: 0 for stat in BOX_SCORE_KEYS}
+    return {stat: totals.get(stat, 0) / gp for stat in BOX_SCORE_KEYS}
+
+
+def _pct_block(totals: Dict[str, Any]) -> Dict[str, float]:
+    """Return shooting percentage metrics for a totals block."""
+
+    fga = totals.get("FGA", 0)
+    fgm = totals.get("FGM", 0)
+    tpa = totals.get("3PTA", 0)
+    tpm = totals.get("3PTM", 0)
+    fta = totals.get("FTA", 0)
+    ftm = totals.get("FTM", 0)
+    pts = totals.get("PTS", 0)
+    fg_pct = (fgm / fga * 100) if fga else 0.0
+    fg3_pct = (tpm / tpa * 100) if tpa else 0.0
+    ft_pct = (ftm / fta * 100) if fta else 0.0
+    ts_den = 2 * (fga + 0.44 * fta)
+    ts_pct = (pts / ts_den * 100) if ts_den else 0.0
+    efg_pct = ((fgm + 0.5 * tpm) / fga * 100) if fga else 0.0
+    return {"FG%": fg_pct, "3PT%": fg3_pct, "FT%": ft_pct, "TS%": ts_pct, "eFG%": efg_pct}
+
+
 def init_franchise_player_stats(franchise_id: str | ObjectId, roster: list[dict]) -> None:
     """Seed a franchise document with zeroed player stat containers.
 
@@ -78,13 +122,10 @@ def apply_stats_from_summary(summary: Dict[str, Any], game_id: str, tournament_i
         stat_block = box_score.get(team_name, {}).get(pos, {})
         inc_fields: Dict[str, Any] = {}
         set_fields: Dict[str, Any] = {}
-        for stat, val in stat_block.items():
-            if stat == "name":
-                continue
-            if isinstance(val, (int, float)):
-                inc_fields[f"stats.season.{stat}"] = val
-                inc_fields[f"stats.career.{stat}"] = val
-                set_fields[f"stats.game.{stat}"] = 0
+        for stat, val in _clean_stat_block(stat_block).items():
+            inc_fields[f"stats.season.{stat}"] = val
+            inc_fields[f"stats.career.{stat}"] = val
+            set_fields[f"stats.game.{stat}"] = 0
         if not inc_fields and not set_fields:
             continue
         update_doc: Dict[str, Any] = {"$addToSet": {"stats.applied_games": token}}
@@ -278,9 +319,7 @@ def rollup_game_to_franchise(franchise_id: str | ObjectId, game_id: str | Object
         if not pid or not team_name:
             continue
         stat_block = box_score.get(team_name, {}).get(pos, p.get("stats", {}))
-        for stat, val in stat_block.items():
-            if stat == "name" or not isinstance(val, (int, float)):
-                continue
+        for stat, val in _clean_stat_block(stat_block).items():
             inc_doc[f"player_stats.{pid}.season.{stat}"] = inc_doc.get(
                 f"player_stats.{pid}.season.{stat}", 0
             ) + val
@@ -321,41 +360,72 @@ def rollup_game_to_franchise(franchise_id: str | ObjectId, game_id: str | Object
     if not result:
         return
 
-    def per_game_block(totals: Dict[str, Any]) -> Dict[str, float]:
-        gp = totals.get("GP", 0)
-        if not gp:
-            return {stat: 0 for stat in BOX_SCORE_KEYS}
-        return {stat: totals.get(stat, 0) / gp for stat in BOX_SCORE_KEYS}
-
-    def pct_block(totals: Dict[str, Any]) -> Dict[str, float]:
-        fga = totals.get("FGA", 0)
-        fgm = totals.get("FGM", 0)
-        tpa = totals.get("3PTA", 0)
-        tpm = totals.get("3PTM", 0)
-        fta = totals.get("FTA", 0)
-        ftm = totals.get("FTM", 0)
-        pts = totals.get("PTS", 0)
-        fg_pct = (fgm / fga * 100) if fga else 0.0
-        fg3_pct = (tpm / tpa * 100) if tpa else 0.0
-        ft_pct = (ftm / fta * 100) if fta else 0.0
-        ts_den = 2 * (fga + 0.44 * fta)
-        ts_pct = (pts / ts_den * 100) if ts_den else 0.0
-        efg_pct = ((fgm + 0.5 * tpm) / fga * 100) if fga else 0.0
-        return {"FG%": fg_pct, "3PT%": fg3_pct, "FT%": ft_pct, "TS%": ts_pct, "eFG%": efg_pct}
-
     stats_doc: Dict[str, Any] = {}
     for p in players:
         pid = str(p.get("playerId"))
         pdata = result.get("player_stats", {}).get(pid, {})
         season_totals = pdata.get("season", {})
         career_totals = pdata.get("career", {})
-        stats_doc[f"player_stats.{pid}.season.per_game"] = per_game_block(season_totals)
-        stats_doc[f"player_stats.{pid}.career.per_game"] = per_game_block(career_totals)
-        stats_doc[f"player_stats.{pid}.season.percentages"] = pct_block(season_totals)
-        stats_doc[f"player_stats.{pid}.career.percentages"] = pct_block(career_totals)
+        stats_doc[f"player_stats.{pid}.season.per_game"] = _per_game_block(season_totals)
+        stats_doc[f"player_stats.{pid}.career.per_game"] = _per_game_block(career_totals)
+        stats_doc[f"player_stats.{pid}.season.percentages"] = _pct_block(season_totals)
+        stats_doc[f"player_stats.{pid}.career.percentages"] = _pct_block(career_totals)
 
     if stats_doc:
         db.franchises.update_one({"_id": fid}, {"$set": stats_doc})
+
+
+def backfill_franchise_player_stats(franchise_id: str | ObjectId) -> None:
+    """Migrate a franchise document from legacy ``players`` schema.
+
+    Existing ``players`` entries are converted to the ``player_stats`` structure
+    used by :func:`rollup_game_to_franchise`.  ``applied_games`` is renamed to
+    ``processed_games`` and per-game/percentage helpers are generated for both
+    season and career totals.
+    """
+
+    try:
+        fid = ObjectId(franchise_id)
+    except Exception:
+        fid = franchise_id
+
+    doc = db.franchises.find_one({"_id": fid})
+    if not doc:
+        return
+
+    player_stats: Dict[str, Any] = {}
+    for pid, pdata in (doc.get("players") or {}).items():
+        meta = pdata.get("meta", {})
+        season_totals = _clean_stat_block(pdata.get("season", {}))
+        career_totals = _clean_stat_block(pdata.get("career", {}))
+        player_stats[pid] = {
+            "first_name": meta.get("first_name", ""),
+            "last_name": meta.get("last_name", ""),
+            "team": meta.get("team", ""),
+            "season": {
+                **season_totals,
+                "per_game": _per_game_block(season_totals),
+                "percentages": _pct_block(season_totals),
+            },
+            "career": {
+                **career_totals,
+                "per_game": _per_game_block(career_totals),
+                "percentages": _pct_block(career_totals),
+            },
+        }
+
+    processed_games = [str(g) for g in doc.get("applied_games", []) if g]
+
+    db.franchises.update_one(
+        {"_id": fid},
+        {
+            "$set": {
+                "player_stats": player_stats,
+                "processed_games": processed_games,
+            },
+            "$unset": {"players": "", "applied_games": ""},
+        },
+    )
 
 
 def finalize_game(
@@ -428,9 +498,7 @@ def finalize_game(
             if not pid or not team_name:
                 continue
             stat_block = box_score.get(team_name, {}).get(pos, p.get("stats", {}))
-            for stat, val in stat_block.items():
-                if stat == "name" or not isinstance(val, (int, float)):
-                    continue
+            for stat, val in _clean_stat_block(stat_block).items():
                 inc_doc[f"players.{pid}.season.{stat}"] = inc_doc.get(
                     f"players.{pid}.season.{stat}", 0
                 ) + val

--- a/docs/backfill_franchise_player_stats.md
+++ b/docs/backfill_franchise_player_stats.md
@@ -1,0 +1,19 @@
+# Backfill Franchise Player Stats
+
+Use the helper script to migrate existing franchise documents to the new
+`player_stats` schema. The script copies legacy `players` data, computes per-game
+averages and shooting percentages, and stores processed game ids.
+
+```bash
+python scripts/backfill_franchise_player_stats.py
+```
+
+The command processes every franchise in the database. To migrate a single
+franchise, provide its identifier:
+
+```bash
+python scripts/backfill_franchise_player_stats.py --franchise-id <FRANCHISE_ID>
+```
+
+Ensure the `MONGO_URI` environment variable points at your database before
+running the backfill.

--- a/scripts/backfill_franchise_player_stats.py
+++ b/scripts/backfill_franchise_player_stats.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Backfill legacy franchise documents to the new player_stats schema."""
+
+import argparse
+import os
+import sys
+
+# Ensure BackEnd package is importable when running as a script
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from BackEnd.db import db
+from BackEnd.utils.stat_updater import backfill_franchise_player_stats
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Migrate franchise documents to the new player_stats schema",
+    )
+    parser.add_argument(
+        "--franchise-id",
+        help="Optional specific franchise _id to migrate. If omitted, all franchises are processed.",
+    )
+    args = parser.parse_args()
+
+    if args.franchise_id:
+        backfill_franchise_player_stats(args.franchise_id)
+        print(f"Updated franchise {args.franchise_id}")
+    else:
+        for doc in db["franchises"].find({}):
+            fid = doc.get("_id")
+            backfill_franchise_player_stats(fid)
+            print(f"Updated franchise {fid}")
+    print("Backfill complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_backfill_franchise_player_stats.py
+++ b/tests/test_backfill_franchise_player_stats.py
@@ -1,0 +1,35 @@
+from BackEnd.db import db
+from BackEnd.utils.stat_updater import backfill_franchise_player_stats
+
+
+def setup_function(_fn):
+    db.franchises.delete_many({})
+
+
+def test_backfill_franchise_player_stats_transforms_document():
+    fid = db.franchises.insert_one(
+        {
+            "players": {
+                "p1": {
+                    "meta": {"first_name": "A", "last_name": "One", "team": "Team1"},
+                    "season": {"PTS": 10, "FGA": 5, "FGM": 4, "STL": -1, "GP": 1},
+                    "career": {"PTS": 20, "FGA": 10, "FGM": 8, "GP": 2},
+                }
+            },
+            "applied_games": ["g1"],
+        }
+    ).inserted_id
+
+    backfill_franchise_player_stats(str(fid))
+    doc = db.franchises.find_one({"_id": fid}) or {}
+
+    assert "players" not in doc
+    assert "applied_games" not in doc
+    assert doc.get("processed_games") == ["g1"]
+
+    p1 = doc.get("player_stats", {}).get("p1", {})
+    assert p1.get("first_name") == "A"
+    assert p1.get("season", {}).get("PTS") == 10
+    assert "STL" not in p1.get("season", {})
+    assert p1.get("season", {}).get("per_game", {}).get("PTS") == 10
+    assert p1.get("season", {}).get("percentages", {}).get("FG%") == 80.0

--- a/tests/test_rollup_game_to_franchise.py
+++ b/tests/test_rollup_game_to_franchise.py
@@ -63,3 +63,36 @@ def test_rollup_game_to_franchise_idempotent():
 
     assert doc2 == doc1
 
+
+def test_rollup_game_to_franchise_validates_stats():
+    players_collection.insert_one(
+        {"_id": "p1", "first_name": "A", "last_name": "One", "team": "Team1"}
+    )
+
+    fid = db.franchises.insert_one({"player_stats": {}, "processed_games": []}).inserted_id
+
+    game = {
+        "home_team": "Team1",
+        "away_team": "Team2",
+        "box_score": {
+            "Team1": {
+                "PG": {"name": "A One", "PTS": -5, "FGA": "5", "FGM": 4}
+            },
+            "Team2": {},
+        },
+        "players": [
+            {"playerId": "p1", "team": "home", "pos": "PG"},
+        ],
+    }
+    gid = games_collection.insert_one(game).inserted_id
+
+    rollup_game_to_franchise(str(fid), str(gid))
+    doc = db.franchises.find_one({"_id": fid})
+    p1 = doc["player_stats"]["p1"]
+
+    assert "PTS" not in p1["season"]
+    assert "FGA" not in p1["season"]
+    assert p1["season"]["FGM"] == 4
+    assert p1["season"]["percentages"]["FG%"] == 0
+    assert doc["processed_games"] == [str(gid)]
+


### PR DESCRIPTION
## Summary
- validate stat fields to ensure numeric and non-negative before updating aggregates
- add backfill_franchise_player_stats() to migrate legacy franchise docs and populate processed_games
- document and script how to run the franchise backfill

## Testing
- `pytest tests/test_rollup_game_to_franchise.py::test_rollup_game_to_franchise_validates_stats -q`
- `pytest tests/test_backfill_franchise_player_stats.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4e192b77083288124b56c9a42983a