### PR TITLE
Add 1s pause before inbound after fast break makes

### DIFF
--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -729,6 +729,9 @@ async function runFastBreakSequence({ scene, turnData, playerSprites, ballSprite
         arc: { height: arcHeight }
       });
       if (turnData.result_type === "MAKE") {
+        await new Promise((resolve) =>
+          scene.time.delayedCall(1000, resolve)
+        );
         const newOffenseSide =
           shooterSprite.team === "home" ? "away" : "home";
         await runInboundSetup({


### PR DESCRIPTION
## Summary
- Insert a one-second delay before baseline inbound setup when a fast break shot is made

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4e234bfb48328aa863a73aea6bd96