### PR TITLE
feat: add rebound field typings

### DIFF
--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -743,7 +743,10 @@ async function runFastBreakSequence({ scene, turnData, playerSprites, ballSprite
           ballSprite,
           playerSprites,
           animations,
-          rebounderId: turnData.rebounderId || turnData.rebounder_id,
+          rebounderId:
+            turnData.rebounder_player_id ||
+            turnData.rebounderId ||
+            turnData.rebounder_id,
           ballSpot: turnData.ballSpot || turnData.ball_spot
         });
       }
@@ -888,7 +891,9 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
         fromCoords: shotInfo.step.coords,
         startTimestamp: shotInfo.step.timestamp,
         // Map rebound result types to "MISS" so shootBall returns a landing spot
-        result: ["DREB", "OREB"].includes(turnData.result_type)
+        result: ["DREB", "OREB"].includes(
+          turnData.rebound_type || turnData.result_type
+        )
           ? "MISS"
           : turnData.result_type,
         shooterPos,
@@ -915,9 +920,13 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
           awayTeamId
         });
       } else if (ballSpot) {
+        let rebounderId =
+          turnData.rebounder_player_id ||
+          turnData.rebounderId ||
+          turnData.rebounder_id ||
+          null;
         const rebounderName = turnData.ball_handler?.trim();
-        let rebounderId = null;
-        if (rebounderName) {
+        if (!rebounderId && rebounderName) {
           rebounderId = scene.nameToId?.[rebounderName];
           if (!rebounderId && scene.playerInfo) {
             for (const [id, info] of Object.entries(scene.playerInfo)) {
@@ -970,7 +979,8 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
             ballSprite,
             playerSprites,
             animations: evt.rebound.animations || turnData.animations,
-            rebounderId: evt.rebound.rebounderId,
+            rebounderId:
+              evt.rebound.rebounder_player_id || evt.rebound.rebounderId,
             ballSpot: putbackResult?.grid || evt.rebound.ballSpot
           });
         }
@@ -978,7 +988,7 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
         await animateKickoutReset(
           scene,
           ballSprite,
-          evt.rebounderId,
+          evt.rebounder_player_id || evt.rebounderId,
           evt.pgId,
           evt.pass,
           evt.pass?.duration

--- a/FrontEnd/static/js/types.d.ts
+++ b/FrontEnd/static/js/types.d.ts
@@ -1,0 +1,12 @@
+export interface TurnData {
+  starting_possession_team_id?: string;
+  possession_team_id?: string;
+  result_type: string;
+  ball_handler?: string;
+  rebounder_player_id?: string;
+  rebounding_team?: string;
+  rebound_type?: string;
+  animations: any[];
+  events?: any[];
+  [key: string]: any;
+}

--- a/docs/backend_ticket_rebound_fields.md
+++ b/docs/backend_ticket_rebound_fields.md
@@ -1,0 +1,16 @@
+# Backend Ticket: Add Rebound Fields to Miss Events
+
+## Summary
+Shot miss events returned by the backend do not include rebound details. Front-end needs the following fields to properly animate rebounds and track possession:
+
+- `rebounder_player_id` – player ID of the rebounder
+- `rebounding_team` – team ID of the rebounder's team
+- `rebound_type` – indicates `OREB` or `DREB`
+
+## Request
+Update backend miss event payloads to include the fields above. Ensure they are present for both defensive and offensive rebounds and maintain snake_case naming.
+
+## Acceptance Criteria
+- Miss event responses include `rebounder_player_id`, `rebounding_team`, and `rebound_type`.
+- Existing tests are updated or new tests added to cover these fields.
+- Front-end can consume these fields without additional parsing.


### PR DESCRIPTION
## Summary
- support new rebound fields in turn animation
- document backend requirement for rebound data

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4e2bf4ec483289c2baf8e94750a39