### PR TITLE
Fix rebound resolution to use player ids

### DIFF
--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -923,34 +923,39 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
           awayTeamId
         });
       } else if (ballSpot) {
-        let rebounderId =
+        const rebounderId =
           turnData.rebounder_player_id ||
           turnData.rebounderId ||
           turnData.rebounder_id ||
           null;
-        const rebounderName = turnData.ball_handler?.trim();
-        if (!rebounderId && rebounderName) {
-          rebounderId = scene.nameToId?.[rebounderName];
-          if (!rebounderId && scene.playerInfo) {
-            for (const [id, info] of Object.entries(scene.playerInfo)) {
-              const fullName =
-                info?.name || `${info.first_name ?? ""} ${info.last_name ?? ""}`.trim();
-              if (fullName.toLowerCase() === rebounderName.toLowerCase()) {
-                rebounderId = id;
-                break;
-              }
-            }
-          }
-        }
         if (rebounderId) {
-          await animateRebound({
-            scene,
-            ballSprite,
-            playerSprites,
-            animations: turnData.animations,
-            rebounderId,
-            ballSpot
-          });
+          const rebounderSprite = playerSprites[rebounderId];
+          if (rebounderSprite) {
+            const spotPx = gridToPixels(
+              ballSpot.x,
+              ballSpot.y,
+              scene.game.config.width,
+              scene.game.config.height
+            );
+            await new Promise((resolve) => {
+              scene.tweens.add({
+                targets: rebounderSprite,
+                x: spotPx.x,
+                y: spotPx.y,
+                duration: 300,
+                ease: "Linear",
+                onComplete: () => {
+                  attachBallToPlayer(scene, ballSprite, rebounderSprite);
+                  scene.offenseTeamId = rebounderSprite.team_id;
+                  scene.events?.emit?.("possessionChange", {
+                    offenseTeamId: rebounderSprite.team_id
+                  });
+                  resolve();
+                },
+                onStop: resolve
+              });
+            });
+          }
         }
       }
       break;

--- a/tests/js/runDefensiveReboundFlip.mjs
+++ b/tests/js/runDefensiveReboundFlip.mjs
@@ -34,7 +34,7 @@ const turnData = {
   starting_possession_team_id: 'HOME',
   possession_team_id: 'HOME',
   result_type: 'MISS',
-  ball_handler: 'PG A',
+  rebounder_player_id: 'pgA',
   animations: [
     {
       playerId: 'pg',

--- a/tests/js/runReboundAnimation.mjs
+++ b/tests/js/runReboundAnimation.mjs
@@ -58,7 +58,7 @@ function createBallSprite() {
     starting_possession_team_id: 'HOME',
     possession_team_id: 'HOME',
     result_type: 'MISS',
-    ball_handler: 'C',
+    rebounder_player_id: 'c',
     animations: [],
     events: [{ event_type: 'PUTBACK_ATTEMPT', shooterId: 'c', result: 'MAKE', duration: 0 }]
   };
@@ -75,7 +75,7 @@ let reboundAttached;
     starting_possession_team_id: 'HOME',
     possession_team_id: 'HOME',
     result_type: 'MISS',
-    ball_handler: 'C',
+    rebounder_player_id: 'c',
     animations: [],
     events: [{ event_type: 'PUTBACK_ATTEMPT', shooterId: 'c', result: 'MISS', duration: 0, rebound: { rebounderId: 'pg', ballSpot: { x: 0, y: 0 } } }]
   };
@@ -93,7 +93,7 @@ let kickoutResult;
     starting_possession_team_id: 'HOME',
     possession_team_id: 'HOME',
     result_type: 'MISS',
-    ball_handler: 'C',
+    rebounder_player_id: 'c',
     animations: [],
     events: [{ event_type: 'KICKOUT_RESET', rebounderId: 'c', pgId: 'pg', pass: { fromCoords: { x: 0, y: 0 }, toCoords: { x: 1, y: 1 }, duration: 0 } }]
   };


### PR DESCRIPTION
## Summary
- resolve rebounder using `rebounder_player_id` and tween sprite to bounce spot before attaching ball
- adjust test scripts to use `rebounder_player_id`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4e58b9b7083289ba8005e2141d200