### PR TITLE
Add rebound reboundInProgress flag to guard ball attachment

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -24,6 +24,10 @@ function attachBallToPlayer(scene, ballSprite, playerSprite, opts = {}) {
     }
   }
 
+  if (scene.reboundInProgress && targetId !== scene.rebounderId) {
+    return;
+  }
+
   if (REBOUND_DEBUG) {
     if (
       scene?.currentBallOwnerRef &&
@@ -207,7 +211,8 @@ export function shootBall({
             scene.game.config.width,
             scene.game.config.height
           );
-
+          scene.reboundInProgress = true;
+          scene.rebounderId = null;
           scene.tweens.add({
             targets: ballSprite,
             x: bounce.x,
@@ -293,28 +298,29 @@ export function animatePutbackAttempt(
               awayTeamId
             });
             resolve();
-          } else if (result === "MISS") {
-            const isHomeTeam = shooterSprite.team === "home";
-            const bounceGridX = isHomeTeam ? rimCoords.x - 6 : rimCoords.x + 6;
-            const bounceGridY =
-              rimCoords.y + Phaser.Math.Between(-6, 6);
-            const bounce = gridToPixels(
-              bounceGridX,
-              bounceGridY,
-              scene.game.config.width,
-              scene.game.config.height
-            );
-
-            scene.tweens.add({
-              targets: ballSprite,
-              x: bounce.x,
-              y: bounce.y,
-              duration: duration / 3,
-              ease: "Sine.easeOut",
-              onComplete: () =>
-                resolve({ grid: { x: bounceGridX, y: bounceGridY } })
-            });
-          } else {
+            } else if (result === "MISS") {
+              const isHomeTeam = shooterSprite.team === "home";
+              const bounceGridX = isHomeTeam ? rimCoords.x - 6 : rimCoords.x + 6;
+              const bounceGridY =
+                rimCoords.y + Phaser.Math.Between(-6, 6);
+              const bounce = gridToPixels(
+                bounceGridX,
+                bounceGridY,
+                scene.game.config.width,
+                scene.game.config.height
+              );
+              scene.reboundInProgress = true;
+              scene.rebounderId = null;
+              scene.tweens.add({
+                targets: ballSprite,
+                x: bounce.x,
+                y: bounce.y,
+                duration: duration / 3,
+                ease: "Sine.easeOut",
+                onComplete: () =>
+                  resolve({ grid: { x: bounceGridX, y: bounceGridY } })
+              });
+            } else {
             // FOUL or unrecognized result: backend will handle next steps
             resolve();
           }
@@ -348,6 +354,7 @@ export function animateRebound({
   if (!scene || !ballSprite || !ballSpot) return Promise.resolve();
   if (scene?.ftInProgress) return Promise.resolve();
 
+  scene.rebounderId = rebounderId;
   const promises = [];
   const finalPositions = [];
   const MIN_X_SEP = 3;
@@ -386,6 +393,8 @@ export function animateRebound({
             scene.events?.emit("possessionChange", {
               offenseTeamId: rebounderSprite.team_id
             });
+            scene.reboundInProgress = false;
+            scene.rebounderId = null;
             resolve();
           },
           onStop: resolve

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -10,6 +10,8 @@ export function createGameScene(Phaser) {
     constructor() {
       super("GameScene");
       this.lastTurnShown = -1;
+      this.reboundInProgress = false;
+      this.rebounderId = null;
     }
 
     init(data) {

--- a/tests/js/runReboundInProgress.mjs
+++ b/tests/js/runReboundInProgress.mjs
@@ -1,0 +1,51 @@
+import { attachBallToPlayer, animateRebound } from '../../FrontEnd/static/js/phaser/animation/ballManager.js';
+
+function makeScene() {
+  return {
+    tweens: {
+      add: ({ targets, x, y, duration, ease, onComplete, onStop }) => {
+        if (targets && targets[0]) {
+          targets[0].x = x;
+          targets[0].y = y;
+        }
+        if (onComplete) onComplete();
+        return { stop: () => { if (onStop) onStop(); } };
+      },
+      killTweensOf: () => {}
+    },
+    time: { delayedCall: (ms, fn) => fn() },
+    game: { config: { width: 100, height: 50 } },
+    playerSprites: {
+      a: { x: 0, y: 0, playerId: 'a', team: 'home', team_id: 'HOME' },
+      b: { x: 0, y: 0, playerId: 'b', team: 'home', team_id: 'HOME' }
+    },
+    events: { emit: () => {} },
+    reboundInProgress: true,
+    rebounderId: 'a'
+  };
+}
+
+const scene = makeScene();
+const ballSprite = { setPosition(){}, setVisible(){}, setDepth(){} };
+
+// Attempt to attach to non-rebounder while rebound in progress
+attachBallToPlayer(scene, ballSprite, scene.playerSprites.b);
+const first = scene.ballAttachedToPlayerId ?? null;
+
+// Animate rebound to attach to rebounder and clear flag
+await animateRebound({
+  scene,
+  ballSprite,
+  playerSprites: scene.playerSprites,
+  animations: [],
+  rebounderId: 'a',
+  ballSpot: { x: 0, y: 0 }
+});
+const afterRebound = scene.ballAttachedToPlayerId;
+const flagAfterRebound = scene.reboundInProgress;
+
+// Now that flag is cleared, attaching to another player works
+attachBallToPlayer(scene, ballSprite, scene.playerSprites.b);
+const final = scene.ballAttachedToPlayerId;
+
+console.log(JSON.stringify({ first, afterRebound, flagAfterRebound, final }));

--- a/tests/test_rebound_in_progress_flag.py
+++ b/tests/test_rebound_in_progress_flag.py
@@ -1,0 +1,19 @@
+import json
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def run_node(loader, script):
+    cmd = ["node", "--loader", str(ROOT / loader), str(ROOT / script)]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return json.loads(completed.stdout.strip().splitlines()[-1])
+
+
+def test_rebound_in_progress_blocks_non_rebounder():
+    result = run_node("tests/js/httpsLoaderNoStubBall.mjs", "tests/js/runReboundInProgress.mjs")
+    assert result["first"] is None
+    assert result["afterRebound"] == "a"
+    assert result["flagAfterRebound"] is False
+    assert result["final"] == "b"


### PR DESCRIPTION
## Summary
- track `reboundInProgress` and rebounder id on the scene
- gate `attachBallToPlayer` while a rebound is in progress
- set/clear flag around bounce and rebound attachment
- add tests for rebound flag behavior

## Testing
- `pytest tests/test_frontend_rebound_animation.py tests/test_rebound_in_progress_flag.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a4e732f3c883288549a1db2209b6de