### PR TITLE
Read rebounder id from turn data

### DIFF
--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -218,23 +218,15 @@ export function createGameScene(Phaser) {
           }
         }
 
-        if ((turn.result_type === 'DREB' || turn.result_type === 'OREB') && turn.ball_handler) {
-          const rebId = this.nameToId[turn.ball_handler];
-          if (rebId) {
-            const ps = this.playerStats[rebId];
+        const rebounderId =
+          turn.rebounder_player_id ||
+          turn.rebounderId ||
+          turn.rebounder_id;
+        if (rebounderId) {
+          const ps = this.playerStats[rebounderId];
+          if (ps) {
             ps.REB += 1;
             if (ps.cells?.reb) ps.cells.reb.textContent = ps.REB;
-          }
-        } else if (turn.text) {
-          const m = turn.text.match(/([A-Za-z\-\'\.\s]+) grabs the rebound/);
-          if (m) {
-            const name = m[1].trim();
-            const rebId = this.nameToId[name];
-            if (rebId) {
-              const ps = this.playerStats[rebId];
-              ps.REB += 1;
-              if (ps.cells?.reb) ps.cells.reb.textContent = ps.REB;
-            }
           }
         }
       };


### PR DESCRIPTION
## Summary
- use `rebounder_player_id` on turns to credit rebounds in GameScene scoreboard
- drop inference via `ball_handler` or text parsing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4e8c03bd4832898d9e73880953fd9