### PR TITLE
Add configurable rebound animation settings

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animation_config.js
+++ b/FrontEnd/static/js/phaser/animation/animation_config.js
@@ -21,6 +21,14 @@ const defaults = {
     easing: 'Sine.easeInOut',
     arc: null,
   },
+  rebound: {
+    // Area (in grid units) around the rim where missed shots can land
+    bounceArea: { x: 6, y: 6 },
+    // Duration in ms for players to collapse toward the rebound spot
+    playerMoveMs: 300,
+    // Delay before possession is considered secured
+    attachDelayMs: 1000,
+  },
   freeThrow: {
     lineupMoveMs: 800,
     shooterPrepMs: 400,
@@ -47,6 +55,16 @@ export const animationConfig = {
   inbound: { ...defaults.inbound, ...(overrides.inbound || {}) },
   kickout: { ...defaults.kickout, ...(overrides.kickout || {}) },
   steal: { ...defaults.steal, ...(overrides.steal || {}) },
+  rebound: {
+    bounceArea: {
+      ...defaults.rebound.bounceArea,
+      ...(overrides.rebound?.bounceArea || {}),
+    },
+    playerMoveMs:
+      overrides.rebound?.playerMoveMs ?? defaults.rebound.playerMoveMs,
+    attachDelayMs:
+      overrides.rebound?.attachDelayMs ?? defaults.rebound.attachDelayMs,
+  },
   freeThrow: { ...defaults.freeThrow, ...(overrides.freeThrow || {}) },
   fastBreak: { ...defaults.fastBreak, ...(overrides.fastBreak || {}) },
 };

--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -200,11 +200,12 @@ export function shootBall({
           }
         } else if (result === "MISS") {
           // Bounce the ball off the rim
+          const rebCfg = animationConfig.rebound;
           const bounceGridX = isHomeTeam
-            ? rimCoords.x - 6
-            : rimCoords.x + 6;
+            ? rimCoords.x - rebCfg.bounceArea.x
+            : rimCoords.x + rebCfg.bounceArea.x;
           const bounceGridY =
-            rimCoords.y + Phaser.Math.Between(-6, 6);
+            rimCoords.y + Phaser.Math.Between(-rebCfg.bounceArea.y, rebCfg.bounceArea.y);
           const bounce = gridToPixels(
             bounceGridX,
             bounceGridY,
@@ -300,9 +301,12 @@ export function animatePutbackAttempt(
             resolve();
             } else if (result === "MISS") {
               const isHomeTeam = shooterSprite.team === "home";
-              const bounceGridX = isHomeTeam ? rimCoords.x - 6 : rimCoords.x + 6;
+              const rebCfg = animationConfig.rebound;
+              const bounceGridX = isHomeTeam
+                ? rimCoords.x - rebCfg.bounceArea.x
+                : rimCoords.x + rebCfg.bounceArea.x;
               const bounceGridY =
-                rimCoords.y + Phaser.Math.Between(-6, 6);
+                rimCoords.y + Phaser.Math.Between(-rebCfg.bounceArea.y, rebCfg.bounceArea.y);
               const bounce = gridToPixels(
                 bounceGridX,
                 bounceGridY,
@@ -355,6 +359,7 @@ export function animateRebound({
   if (scene?.ftInProgress) return Promise.resolve();
 
   scene.rebounderId = rebounderId;
+  const rebCfg = animationConfig.rebound;
   const promises = [];
   const finalPositions = [];
   const MIN_X_SEP = 3;
@@ -385,7 +390,7 @@ export function animateRebound({
           targets: rebounderSprite,
           x: spotPx.x,
           y: spotPx.y,
-          duration: 300,
+          duration: rebCfg.playerMoveMs,
           ease: "Linear",
           onComplete: () => {
             attachBallToPlayer(scene, ballSprite, rebounderSprite);
@@ -461,7 +466,7 @@ export function animateRebound({
           targets: sprite,
           x: targetPx.x,
           y: targetPx.y,
-          duration: 300,
+          duration: rebCfg.playerMoveMs,
           ease: "Linear",
           onComplete: resolve,
           onStop: resolve
@@ -482,9 +487,9 @@ export function animateRebound({
           console.log("[rebound]", logPayload);
         }
         if (scene.time?.delayedCall) {
-          scene.time.delayedCall(1000, resolve);
+          scene.time.delayedCall(rebCfg.attachDelayMs, resolve);
         } else {
-          setTimeout(resolve, 1000);
+          setTimeout(resolve, rebCfg.attachDelayMs);
         }
       })
   );

--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -937,12 +937,14 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
               scene.game.config.width,
               scene.game.config.height
             );
+            const rebCfg = animationConfig.rebound;
+            scene.rebounderId = rebounderId;
             await new Promise((resolve) => {
               scene.tweens.add({
                 targets: rebounderSprite,
                 x: spotPx.x,
                 y: spotPx.y,
-                duration: 300,
+                duration: rebCfg.playerMoveMs,
                 ease: "Linear",
                 onComplete: () => {
                   attachBallToPlayer(scene, ballSprite, rebounderSprite);
@@ -950,7 +952,13 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
                   scene.events?.emit?.("possessionChange", {
                     offenseTeamId: rebounderSprite.team_id
                   });
-                  resolve();
+                  scene.reboundInProgress = false;
+                  scene.rebounderId = null;
+                  if (scene.time?.delayedCall) {
+                    scene.time.delayedCall(rebCfg.attachDelayMs, resolve);
+                  } else {
+                    setTimeout(resolve, rebCfg.attachDelayMs);
+                  }
                 },
                 onStop: resolve
               });

--- a/docs/rebound_animation_config.md
+++ b/docs/rebound_animation_config.md
@@ -1,0 +1,17 @@
+# Rebound Animation Defaults
+
+The front-end animation config exposes a `rebound` block in
+`FrontEnd/static/js/phaser/animation/animation_config.js`. It controls how
+missed shots and putbacks bounce and how players collapse toward the ball.
+
+Default values:
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `bounceArea` | `{ x: 6, y: 6 }` | Grid offset around the rim where missed shots may land. |
+| `playerMoveMs` | `300` | Milliseconds for players to move toward the rebound spot. |
+| `attachDelayMs` | `1000` | Delay before the ball attaches to the rebounder after players arrive. |
+
+Overrides can be supplied at runtime via `globalThis.animation_config.rebound`.
+Existing behaviours like made shots and free throws use other config values and
+are unchanged by these defaults.


### PR DESCRIPTION
## Summary
- expose `rebound` settings in `animation_config.js` with bounce area, player move speed, and attach delay
- refactor rebound and shot handling to read from config values
- document rebound animation defaults

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4e9d30b0883288b124b4cdef34afe