### PR TITLE
Add debug logs for shot and rebound flow

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animateStep.js
+++ b/FrontEnd/static/js/phaser/animation/animateStep.js
@@ -12,6 +12,8 @@ import { gridToPixels } from "../utils/gridToPixels.js";
  */
 import { PASS_DEBUG } from "./ballTween.js";
 
+export const PLAYER_TWEEN_DEBUG = false;
+
 export function animateStep({ scene, sprite, step, duration, ballSprite, currentBallOwnerRef, onAction }) {
   if (scene.skipToEnd) return Promise.resolve();
   return new Promise((resolve) => {
@@ -31,6 +33,16 @@ export function animateStep({ scene, sprite, step, duration, ballSprite, current
       duration,
       ease: "Linear",
       onStart: async () => {
+        if (PLAYER_TWEEN_DEBUG) {
+          const team = sprite?.team_id ?? sprite?.team ?? null;
+          console.log("player:tweenStart", {
+            type: "playerTweenStart",
+            shooterId: null,
+            reboundSpot: null,
+            playerId: sprite?.playerId ?? null,
+            team
+          });
+        }
         if (step.action && onAction) {
           if (PASS_DEBUG && step.action === 'pass') {
             console.log('passStart', { fromId: sprite?.playerId, timestamp: step.timestamp });

--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -40,7 +40,15 @@ function attachBallToPlayer(scene, ballSprite, playerSprite, opts = {}) {
         target: targetId
       });
     }
-    console.log(`ball:attach -> ${targetId}`);
+
+    const logPayload = {
+      type: "ballAttach",
+      shooterId: opts?.debugInfo?.shooterId ?? null,
+      reboundSpot: opts?.debugInfo?.reboundSpot ?? null,
+      playerId: targetId,
+      team: playerSprite?.team_id ?? playerSprite?.team ?? null
+    };
+    console.log("ball:attach", logPayload);
   }
 
   if (scene?.currentBallOwnerRef) {
@@ -212,6 +220,15 @@ export function shootBall({
             scene.game.config.width,
             scene.game.config.height
           );
+          if (SHOT_DEBUG) {
+            console.log("shot:miss", {
+              type: "miss",
+              shooterId,
+              reboundSpot: { x: bounceGridX, y: bounceGridY },
+              playerId: shooterId,
+              team: shooterTeamId
+            });
+          }
           scene.reboundInProgress = true;
           scene.rebounderId = null;
           scene.tweens.add({
@@ -353,7 +370,8 @@ export function animateRebound({
   playerSprites,
   animations,
   rebounderId,
-  ballSpot
+  ballSpot,
+  shooterId
 }) {
   if (!scene || !ballSprite || !ballSpot) return Promise.resolve();
   if (scene?.ftInProgress) return Promise.resolve();
@@ -377,7 +395,13 @@ export function animateRebound({
   const rebounderSprite = playerSprites[rebounderId];
   if (REBOUND_DEBUG) {
     const team = rebounderSprite?.team_id ?? rebounderSprite?.team;
-    console.log("reb:event", { team, playerId: rebounderId });
+    console.log("reb:event", {
+      type: "rebound",
+      shooterId,
+      reboundSpot: ballSpot,
+      playerId: rebounderId,
+      team
+    });
   }
   if (rebounderSprite) {
     const teamId = rebounderSprite.team_id;
@@ -393,7 +417,9 @@ export function animateRebound({
           duration: rebCfg.playerMoveMs,
           ease: "Linear",
           onComplete: () => {
-            attachBallToPlayer(scene, ballSprite, rebounderSprite);
+            attachBallToPlayer(scene, ballSprite, rebounderSprite, {
+              debugInfo: { shooterId, reboundSpot: ballSpot }
+            });
             scene.offenseTeamId = rebounderSprite.team_id;
             scene.events?.emit("possessionChange", {
               offenseTeamId: rebounderSprite.team_id

--- a/FrontEnd/static/js/phaser/animation/freeThrow.js
+++ b/FrontEnd/static/js/phaser/animation/freeThrow.js
@@ -267,6 +267,7 @@ export async function runFreeThrowSequence(
           animations: [],
           rebounderId: null,
           ballSpot: rim,
+          shooterId: turnData.shooter_id
         });
       } else if (shooterSprite) {
         const spotPx = gridToPixels(

--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -750,7 +750,8 @@ async function runFastBreakSequence({ scene, turnData, playerSprites, ballSprite
             turnData.rebounder_player_id ||
             turnData.rebounderId ||
             turnData.rebounder_id,
-          ballSpot: turnData.ballSpot || turnData.ball_spot
+          ballSpot: turnData.ballSpot || turnData.ball_spot,
+          shooterId: turnData.shooterId || turnData.shooter_id
         });
       }
     }
@@ -947,7 +948,9 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
                 duration: rebCfg.playerMoveMs,
                 ease: "Linear",
                 onComplete: () => {
-                  attachBallToPlayer(scene, ballSprite, rebounderSprite);
+                  attachBallToPlayer(scene, ballSprite, rebounderSprite, {
+                    debugInfo: { shooterId: shotInfo?.playerId ?? null, reboundSpot: ballSpot }
+                  });
                   scene.offenseTeamId = rebounderSprite.team_id;
                   scene.events?.emit?.("possessionChange", {
                     offenseTeamId: rebounderSprite.team_id
@@ -978,7 +981,9 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
         const shooterId = evt.shooterId;
         const rebounderSprite = playerSprites[shooterId];
         if (!rebounderSprite) continue;
-        attachBallToPlayer(scene, ballSprite, rebounderSprite);
+        attachBallToPlayer(scene, ballSprite, rebounderSprite, {
+          debugInfo: { shooterId, reboundSpot: evt.rebound?.ballSpot || null }
+        });
         const rimCoords =
           rebounderSprite.team === "home" ? HOME_RIM_COORDS : AWAY_RIM_COORDS;
         const putbackResult = await animatePutbackAttempt(
@@ -997,7 +1002,8 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
             animations: evt.rebound.animations || turnData.animations,
             rebounderId:
               evt.rebound.rebounder_player_id || evt.rebound.rebounderId,
-            ballSpot: putbackResult?.grid || evt.rebound.ballSpot
+            ballSpot: putbackResult?.grid || evt.rebound.ballSpot,
+            shooterId: evt.shooterId
           });
         }
       } else if (evt.event_type === "KICKOUT_RESET") {

--- a/FrontEnd/static/js/phaser/utils/textScroll.js
+++ b/FrontEnd/static/js/phaser/utils/textScroll.js
@@ -7,6 +7,8 @@ export const config = {
   lineSpacing: '1em',
 };
 
+export const TEXT_SCROLL_DEBUG = false;
+
 export function appendToTextScroll(message, cfg = {}) {
   if (!message) return;
   const globalCfg =
@@ -25,7 +27,9 @@ export function appendToTextScroll(message, cfg = {}) {
     return;
   }
 
-  console.debug('textScroll:append', message.slice(0, 40));
+  if (TEXT_SCROLL_DEBUG) {
+    console.debug('textScroll:append', message.slice(0, 40));
+  }
 
   const appendLine = () => {
     const atTop = autoScroll && container.scrollTop === 0;
@@ -47,7 +51,9 @@ export function appendToTextScroll(message, cfg = {}) {
     }
 
     if (autoScroll && atTop) {
-      console.debug('textScroll:autoScroll', message.length);
+      if (TEXT_SCROLL_DEBUG) {
+        console.debug('textScroll:autoScroll', message.length);
+      }
       requestAnimationFrame(() =>
         container.scrollTo({
           top: 0,
@@ -56,7 +62,16 @@ export function appendToTextScroll(message, cfg = {}) {
       );
     }
 
-    console.log('textScroll:append', line.textContent.slice(0, 40));
+    if (TEXT_SCROLL_DEBUG) {
+      const logPayload = {
+        type: 'textScroll',
+        shooterId: null,
+        reboundSpot: null,
+        playerId: null,
+        team: null
+      };
+      console.log('textScroll:update', logPayload);
+    }
   };
 
   const heavyUpdate = container.children.length > maxLines + 20;


### PR DESCRIPTION
## Summary
- log shot misses with shooter, team and rebound spot
- capture rebound event and ball attach details with player and team info
- add debug hooks for player tween starts and text scroll updates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a50b8ac4a48328bf50ca4af1ec2c78