### PR TITLE
Log rebounder movement

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -408,6 +408,14 @@ export function animateRebound({
     scene.offenseTeamId = teamId;
     scene.events?.emit?.("possessionChange", { offenseTeamId: teamId });
     finalPositions.push({ playerId: rebounderId, grid: { ...ballSpot } });
+    if (REBOUND_DEBUG) {
+      console.log("reb:moveStart", {
+        playerId: rebounderId,
+        from: { x: rebounderSprite.x, y: rebounderSprite.y },
+        to: { x: spotPx.x, y: spotPx.y },
+        duration: rebCfg.playerMoveMs
+      });
+    }
     promises.push(
       new Promise((resolve) => {
         scene.tweens.add({
@@ -417,6 +425,13 @@ export function animateRebound({
           duration: rebCfg.playerMoveMs,
           ease: "Linear",
           onComplete: () => {
+            if (REBOUND_DEBUG) {
+              console.log("reb:moveEnd", {
+                playerId: rebounderId,
+                x: spotPx.x,
+                y: spotPx.y
+              });
+            }
             attachBallToPlayer(scene, ballSprite, rebounderSprite, {
               debugInfo: { shooterId, reboundSpot: ballSpot }
             });


### PR DESCRIPTION
## Summary
- log rebounder movement during rebound animation for easier debugging

## Testing
- `pytest`

## Instrumentation
**Pre-change shooter attachment log**
```
ball:attach {
  type: 'ballAttach',
  shooterId: 'pg',
  reboundSpot: null,
  playerId: 'pg',
  team: 'home'
}
```
**Post-change rebounder movement log**
```
reb:moveStart {
  playerId: 'r1',
  from: { x: 0, y: 0 },
  to: { x: 10, y: 45 },
  duration: 300
}
reb:moveEnd { playerId: 'r1', x: 10, y: 45 }
```

------
https://chatgpt.com/codex/tasks/task_e_68a5139679dc832897ea272dba3fac0b