### PR TITLE
Handle missing shooter in free throw logic

### DIFF
--- a/BackEnd/engine/phase_resolution.py
+++ b/BackEnd/engine/phase_resolution.py
@@ -1,5 +1,6 @@
 import random
 from typing import TYPE_CHECKING
+from fastapi import HTTPException
 from BackEnd.utils.shared import (
     get_name_safe, 
     get_player_position,
@@ -83,16 +84,19 @@ def resolve_non_shooting_foul(roles, game):
     #     ball_handler = shooter
     
     if def_team.team_fouls >= 10:
+        game_state["offensive_state"] = "FREE_THROW"
         game_state["free_throws"] = 2
         game_state["free_throws_remaining"] = 2
         game_state["one_and_one"] = False
         game_state["last_ball_handler"] = ball_handler
+        game_state["shooter"] = ball_handler
     elif def_team.team_fouls >= 5:
         game_state["offensive_state"] = "FREE_THROW"
         game_state["free_throws"] = 2
         game_state["free_throws_remaining"] = 2
         game_state["one_and_one"] = True
         game_state["last_ball_handler"] = ball_handler
+        game_state["shooter"] = ball_handler
     else:
         game_state["offensive_state"] = "HCO"
         game_state["free_throws"] = 0
@@ -285,6 +289,8 @@ def resolve_fast_break_logic(game: "GameManager"):
 def resolve_free_throw_logic(game):
     game_state, off_team, def_team, off_lineup, def_lineup = unpack_game_context(game)
     shooter = game_state.get("shooter") or game_state.get("last_ball_handler")
+    if shooter is None:
+        raise HTTPException(status_code=400, detail="No shooter set for free throw")
     attrs = shooter.attributes
 
     # FT outcome calculation

--- a/tests/test_free_throw_logic.py
+++ b/tests/test_free_throw_logic.py
@@ -1,3 +1,5 @@
+import pytest
+from fastapi import HTTPException
 from tests.test_utils import build_mock_game
 from BackEnd.engine.phase_resolution import resolve_free_throw_logic
 
@@ -43,3 +45,18 @@ def test_one_and_one_front_end_records_points_and_totals():
     assert shooter.stats["game"]["PTS"] == 1
     assert game.game_state["free_throws_remaining"] == 1
     assert game.game_state["one_and_one"] is False
+
+
+def test_missing_shooter_returns_400():
+    game = build_mock_game()
+    game.game_state.update({
+        "offensive_state": "FREE_THROW",
+        "free_throws_remaining": 1,
+        "shooter": None,
+        "last_ball_handler": None,
+    })
+
+    with pytest.raises(HTTPException) as excinfo:
+        resolve_free_throw_logic(game)
+
+    assert excinfo.value.status_code == 400


### PR DESCRIPTION
## Summary
- Validate free-throw shooter and raise HTTP 400 if missing
- Set `last_ball_handler` and `shooter` before entering bonus free throws
- Add regression test for missing shooter scenario

## Testing
- `pytest tests/test_free_throw_logic.py -q`
- `pytest tests/test_phase_resolution.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5b6957a8483288c82316395ef2d2a