### PR TITLE
Trigger defensive rebound setup after ball attachment

### DIFF
--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -1036,7 +1036,7 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
                 onStop: resolve
               });
             });
-            if (String(rebounderSprite.team_id) !== String(shooterTeamId)) {
+            if (turnData.rebound_type === "DREB" && !turnData.fast_break) {
               await runDefensiveReboundSetup({
                 scene,
                 ballSprite,


### PR DESCRIPTION
## Summary
- run defensive rebound setup after defensive rebounds without fast breaks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5b82f84a083289790197f1f44b739