### PR TITLE
fix: improve simulate-quarter logging

### DIFF
--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -60,7 +60,7 @@ export function createGameScene(Phaser) {
       const homeTeam = this.rosters.homeRoster.team_name;
       const awayTeam = this.rosters.awayRoster.team_name;
 
-    console.log("📨 Sending /api/simulate request for:", homeTeam, "vs", awayTeam);
+    console.log("📨 Sending /api/simulate-quarter request for:", homeTeam, "vs", awayTeam);
 
       const payload = { home_team: homeTeam, away_team: awayTeam };
       if (this.gameId) payload.game_id = this.gameId;
@@ -73,6 +73,10 @@ export function createGameScene(Phaser) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload)
       });
+      if (!this.constructor._loggedSimQuarter) {
+        console.debug("🛠️ /api/simulate-quarter payload keys:", Object.keys(payload), "response status:", res.status);
+        this.constructor._loggedSimQuarter = true;
+      }
 
 
       if (!res.ok) {


### PR DESCRIPTION
## Summary
- log simulate-quarter fetch requests correctly
- add one-time dev logging for request payload keys and response status

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5b82a2220832898dfcce9a3666ee7