### PR TITLE
Handle server error messages in GameScene fetch

### DIFF
--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -80,7 +80,19 @@ export function createGameScene(Phaser) {
 
 
       if (!res.ok) {
-        console.error("❌ Failed to fetch sim data:", res.statusText);
+        let errorMessage;
+        try {
+          const errData = await res.clone().json();
+          errorMessage = errData.detail || errData.message || errData.error || JSON.stringify(errData);
+        } catch {
+          try {
+            errorMessage = await res.text();
+          } catch {
+            errorMessage = res.statusText;
+          }
+        }
+        console.error("❌ Failed to fetch sim data:", errorMessage);
+        appendToTextScroll(`❌ ${errorMessage}`);
         return;
       }
 


### PR DESCRIPTION
## Summary
- Read and display server error message when `/api/simulate-quarter` returns a non-OK response

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5b91cf5d08328b8f40b5943ca4123