### PR TITLE
Increase fast break shot rim hold duration

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animation_config.js
+++ b/FrontEnd/static/js/phaser/animation/animation_config.js
@@ -42,7 +42,8 @@ const defaults = {
     passMs: 250,
     shotMs: 500,
     arcHeight: 60,
-    rimHoldMs: 800,
+    // Time to hold the ball at the rim after a made fast break shot
+    rimHoldMs: 2000,
   },
 };
 

--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -799,8 +799,9 @@ async function runFastBreakSequence({ scene, turnData, playerSprites, ballSprite
         arc: { height: arcHeight }
       });
       if (turnData.result_type === "MAKE") {
+        const rimHoldMs = animationConfig.fastBreak?.rimHoldMs ?? 2000;
         await new Promise((resolve) =>
-          scene.time.delayedCall(1000, resolve)
+          scene.time.delayedCall(rimHoldMs, resolve)
         );
         const newOffenseSide =
           shooterSprite.team === "home" ? "away" : "home";


### PR DESCRIPTION
## Summary
- Hold fast break makes at the rim for 2 seconds before the inbound
- Expose `fastBreak.rimHoldMs` in animation config for easier tuning

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5bf4e47fc8328b276283690617ec5