### PR TITLE
feat: add offensive rebound and putback animation configs

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animation_config.js
+++ b/FrontEnd/static/js/phaser/animation/animation_config.js
@@ -45,6 +45,8 @@ const defaults = {
     // Time to hold the ball at the rim after a made fast break shot
     rimHoldMs: 2000,
   },
+  offensiveRebound: { pauseMs: 1000 },
+  putback: { duration: 500, easing: 'Sine.easeInOut' },
 };
 
 const overrides =
@@ -68,6 +70,11 @@ export const animationConfig = {
   },
   freeThrow: { ...defaults.freeThrow, ...(overrides.freeThrow || {}) },
   fastBreak: { ...defaults.fastBreak, ...(overrides.fastBreak || {}) },
+  offensiveRebound: {
+    ...defaults.offensiveRebound,
+    ...(overrides.offensiveRebound || {}),
+  },
+  putback: { ...defaults.putback, ...(overrides.putback || {}) },
 };
 
 export default animationConfig;


### PR DESCRIPTION
## Summary
- add default offensive rebound and putback animation settings
- allow overriding offensive rebound and putback configs via global `animation_config`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5c25511948328bbbab5bfbd022a43