### PR TITLE
Use config defaults for putback animation

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -265,8 +265,9 @@ export function animatePutbackAttempt(
   ballSprite,
   shooterId,
   rimCoords,
-  duration = 500,
-  result
+  duration = animationConfig.putback.duration,
+  result,
+  easing = animationConfig.putback.easing
 ) {
   if (!scene || !ballSprite) return Promise.resolve();
   if (scene?.ftInProgress) return Promise.resolve();
@@ -291,7 +292,7 @@ export function animatePutbackAttempt(
       x: rim.x,
       y: rim.y,
       duration,
-      ease: "Sine.easeInOut",
+      ease: easing,
       onComplete: () => {
         const handleComplete = async () => {
           if (result === "MAKE") {


### PR DESCRIPTION
## Summary
- default putback attempt duration to `animationConfig.putback.duration`
- allow overriding easing, defaulting to `animationConfig.putback.easing`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5c339e0d8832890b6eaf42fd918b8