### PR TITLE
Handle truncated animation timelines safely

### DIFF
--- a/BackEnd/models/animator.py
+++ b/BackEnd/models/animator.py
@@ -10,6 +10,7 @@ from BackEnd.utils.shared_defense import (
 from collections import defaultdict
 from BackEnd.constants import HCO_STRING_SPOTS, ACTIONS, RIM_COORDS, TOP_KEY_COORDS
 import random
+import logging
 
 class Animator:
     def __init__(self, game):
@@ -347,7 +348,16 @@ class Animator:
             if not timeline:
                 continue
 
-            hasBallAtStep = [ball_owner_by_step[i] is player for i in range(len(timeline))]
+            logging.debug(
+                "capture_halfcourt_animation: %s timeline=%d ball_owner_steps=%d",
+                pos,
+                len(timeline),
+                len(ball_owner_by_step),
+            )
+
+            max_steps = min(len(timeline), len(ball_owner_by_step))
+            timeline = timeline[:max_steps]
+            hasBallAtStep = [ball_owner_by_step[i] is player for i in range(max_steps)]
 
             timeline.sort(key=lambda tup: tup[0])
             first_spot = timeline[0][2]

--- a/tests/test_animation_event_step_bounds.py
+++ b/tests/test_animation_event_step_bounds.py
@@ -1,0 +1,44 @@
+from BackEnd.models.animator import Animator
+from BackEnd.models.game_manager import GameManager
+from BackEnd.models.player import Player
+
+
+def _build_game():
+    gm = GameManager('Home', 'Away')
+    positions = ['PG', 'SG', 'SF', 'PF', 'C']
+    for team in [gm.home_team, gm.away_team]:
+        lineup = {}
+        for i, pos in enumerate(positions):
+            pdata = {
+                '_id': f'{team.name}_{i}',
+                'first_name': team.name,
+                'last_name': pos,
+                'team': team.name,
+                'attributes': {k: 50 for k in ['SC','SH','ID','OD','PS','BH','RB','AG','ST','ND','IQ','FT','NG']},
+            }
+            lineup[pos] = Player(pdata)
+        team.lineup = lineup
+    return gm
+
+
+def test_capture_halfcourt_animation_event_step_bounds():
+    gm = _build_game()
+    animator = Animator(gm)
+    pg = gm.home_team.lineup['PG']
+    roles = {
+        'shooter': pg,
+        'ball_handler': pg,
+        'steps': [
+            {'timestamp':0, 'pos_actions':{'PG':{'action':'handle_ball','spot':'key'}}, 'events': []},
+            {'timestamp':100, 'pos_actions':{'PG':{'action':'handle_ball','spot':'key'}}, 'events': []},
+        ],
+        'action_timeline': {
+            pg: [
+                (0, 'handle_ball', 'key'),
+                (100, 'handle_ball', 'key'),
+                (200, 'pass', 'key'),  # extra timeline step beyond available steps
+            ]
+        },
+    }
+    # event_step truncates steps to one element; ensure no IndexError
+    animator.capture_halfcourt_animation(roles, event_step=0)


### PR DESCRIPTION
## Summary
- prevent out-of-range access when building half-court animations
- log timeline vs. ball-owner step counts for easier debugging
- add regression test for truncated animation timelines

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5cbafb07883288c3e843036685946