### PR TITLE
Handle truncated animation timelines safely

### DIFF
--- a/BackEnd/models/animator.py
+++ b/BackEnd/models/animator.py
@@ -10,6 +10,7 @@ from BackEnd.utils.shared_defense import (
 from collections import defaultdict
 from BackEnd.constants import HCO_STRING_SPOTS, ACTIONS, RIM_COORDS, TOP_KEY_COORDS
 import random
+import logging
 
 class Animator:
     def __init__(self, game):
@@ -300,12 +301,17 @@ class Animator:
 
         steps = roles["steps"]
         action_timeline = roles["action_timeline"]
-        print(f"[DEBUG] action_timeline: {action_timeline}")
+        logging.debug("action_timeline: %s", action_timeline)
         shooter = roles["shooter"]
         ball_handler = roles["ball_handler"]
 
         if event_step is not None:
             steps = steps[:event_step + 1]
+
+        if not steps:
+            logging.warning("capture_halfcourt_animation: no steps provided")
+            self.latest_packet = []
+            return []
 
         animations = []
 
@@ -338,16 +344,32 @@ class Animator:
 
         for idx, owner in enumerate(ball_owner_by_step):
             if owner is None:
-                print(f"[WARN] No ball owner detected for step {idx}")
+                logging.warning("No ball owner detected for step %d", idx)
 
         for pos, player in off_lineup.items():
             timeline = action_timeline.get(player, [])
-            print("Inside capture_halfcourt_animation")
-            print(f"[DEBUG] timeline for {pos}: {timeline}")
+            logging.debug("Inside capture_halfcourt_animation")
+            logging.debug("timeline for %s: %s", pos, timeline)
             if not timeline:
                 continue
 
-            hasBallAtStep = [ball_owner_by_step[i] is player for i in range(len(timeline))]
+            logging.debug(
+                "capture_halfcourt_animation: %s timeline=%d ball_owner_steps=%d",
+                pos,
+                len(timeline),
+                len(ball_owner_by_step),
+            )
+
+            max_steps = min(len(timeline), len(ball_owner_by_step))
+            if max_steps == 0:
+                logging.warning(
+                    "capture_halfcourt_animation: %s timeline has no matching steps",
+                    pos,
+                )
+                continue
+
+            timeline = timeline[:max_steps]
+            hasBallAtStep = [ball_owner_by_step[i] is player for i in range(max_steps)]
 
             timeline.sort(key=lambda tup: tup[0])
             first_spot = timeline[0][2]
@@ -409,7 +431,7 @@ class Animator:
                 o_coords = HCO_STRING_SPOTS.get(last_spot, HCO_STRING_SPOTS["key"])
                 def_coords = assign_non_bh_defender_coords(o_coords, ball_handler_end_coords, aggression_call, is_away_offense)
             else:
-                print(f"[WARN] No offensive match for defender {pos}, skipping.")
+                logging.warning("No offensive match for defender %s, skipping.", pos)
                 continue
 
             start = getattr(defender, "coords", {"x": 25, "y": 50})
@@ -521,7 +543,7 @@ class Animator:
 
 
         self.latest_packet = animations
-        print(f"[DEBUG] Generated {len(animations)} animations")
+        logging.debug("Generated %d animations", len(animations))
 
         return animations
 

--- a/tests/test_animation_event_step_bounds.py
+++ b/tests/test_animation_event_step_bounds.py
@@ -1,0 +1,57 @@
+from BackEnd.models.animator import Animator
+from BackEnd.models.game_manager import GameManager
+from BackEnd.models.player import Player
+
+
+def _build_game():
+    gm = GameManager('Home', 'Away')
+    positions = ['PG', 'SG', 'SF', 'PF', 'C']
+    for team in [gm.home_team, gm.away_team]:
+        lineup = {}
+        for i, pos in enumerate(positions):
+            pdata = {
+                '_id': f'{team.name}_{i}',
+                'first_name': team.name,
+                'last_name': pos,
+                'team': team.name,
+                'attributes': {k: 50 for k in ['SC','SH','ID','OD','PS','BH','RB','AG','ST','ND','IQ','FT','NG']},
+            }
+            lineup[pos] = Player(pdata)
+        team.lineup = lineup
+    return gm
+
+
+def test_capture_halfcourt_animation_event_step_bounds():
+    gm = _build_game()
+    animator = Animator(gm)
+    pg = gm.home_team.lineup['PG']
+    roles = {
+        'shooter': pg,
+        'ball_handler': pg,
+        'steps': [
+            {'timestamp':0, 'pos_actions':{'PG':{'action':'handle_ball','spot':'key'}}, 'events': []},
+            {'timestamp':100, 'pos_actions':{'PG':{'action':'handle_ball','spot':'key'}}, 'events': []},
+        ],
+        'action_timeline': {
+            pg: [
+                (0, 'handle_ball', 'key'),
+                (100, 'handle_ball', 'key'),
+                (200, 'pass', 'key'),  # extra timeline step beyond available steps
+            ]
+        },
+    }
+    # event_step truncates steps to one element; ensure no IndexError
+    animator.capture_halfcourt_animation(roles, event_step=0)
+
+
+def test_capture_halfcourt_animation_no_steps_returns_empty():
+    gm = _build_game()
+    animator = Animator(gm)
+    pg = gm.home_team.lineup['PG']
+    roles = {
+        'shooter': pg,
+        'ball_handler': pg,
+        'steps': [],
+        'action_timeline': {pg: [(0, 'handle_ball', 'key')]},
+    }
+    assert animator.capture_halfcourt_animation(roles) == []


### PR DESCRIPTION
## Summary
- guard half-court animation when no steps are produced
- log skipped timelines lacking matching steps to aid future debugging
- add regression test for empty step list

## Testing
- `pytest tests/test_animation_event_step_bounds.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5cbafb07883288c3e843036685946