### PR TITLE
Handle empty rebounder pools gracefully

### DIFF
--- a/BackEnd/utils/shared.py
+++ b/BackEnd/utils/shared.py
@@ -1,4 +1,5 @@
 import random
+import logging
 from BackEnd.constants import TURNOVER_CALC_DICT, POSITION_LIST, HCO_STRING_SPOTS
 
 
@@ -118,6 +119,16 @@ def resolve_offensive_rebound(game, rebounder):
 
     game_state, off_team, def_team, off_lineup, def_lineup = unpack_game_context(game)
 
+    # If no offensive rebounder is available, treat as a defensive rebound.
+    if rebounder is None:
+        logging.warning("resolve_offensive_rebound called with no rebounder; treating as defensive rebound")
+        return {
+            "event_type": "DEFENSIVE_REBOUND",
+            "rebounderId": None,
+            "timeElapsed": 0,
+            "possession_flips": True,
+        }
+
     if random.random() < 0.65:  # putback attempt
         attrs = rebounder.attributes
         shot_score = (
@@ -193,8 +204,12 @@ def calculate_screen_score(screen_attrs):
     return base_score * random.randint(1, 6)
 
 def choose_rebounder(rebounders, side):
-    players = list(rebounders[side].keys())
-    weights = list(rebounders[side].values())
+    pool = rebounders.get(side, {})
+    if not pool:
+        logging.warning("choose_rebounder called with empty pool for %s", side)
+        return None
+    players = list(pool.keys())
+    weights = list(pool.values())
     return random.choices(players, weights=weights, k=1)[0]
 
 def generate_pass_chain(game, shooter_pos):

--- a/tests/test_rebounder_empty_pool.py
+++ b/tests/test_rebounder_empty_pool.py
@@ -1,0 +1,16 @@
+import logging
+from BackEnd.utils.shared import choose_rebounder, resolve_offensive_rebound
+from tests.test_utils import build_mock_game
+
+
+def test_choose_rebounder_empty_pool_returns_none_and_no_indexerror(caplog):
+    rebounders = {"offense": {}, "defense": {}}
+    with caplog.at_level(logging.WARNING):
+        result = choose_rebounder(rebounders, "offense")
+    assert result is None
+    assert "empty pool" in caplog.text
+
+    game = build_mock_game()
+    event = resolve_offensive_rebound(game, result)
+    assert event["event_type"] == "DEFENSIVE_REBOUND"
+    assert event["possession_flips"] is True


### PR DESCRIPTION
## Summary
- Guard against empty rebounder pools in `choose_rebounder` with a warning and `None` return
- Treat missing offensive rebounder as defensive board in `resolve_offensive_rebound`
- Add regression test for empty rebounder pool

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5d719b9a0832881bef77f7dd31f44