### PR TITLE
Handle empty offense lineups in free throw animation

### DIFF
--- a/BackEnd/models/animator.py
+++ b/BackEnd/models/animator.py
@@ -149,6 +149,13 @@ class Animator:
         offense_team = game.offense_team
         defense_team = game.defense_team
         shooter_pos = get_player_position(offense_team.lineup, shooter)
+        if not shooter_pos:
+            logging.warning(
+                "capture_free_throw_animation: shooter %s not found in lineup",
+                getattr(shooter, "player_id", shooter),
+            )
+            self.latest_packet = []
+            return []
 
         HOME_CFG = {
             "shooterSpot": {"x": 74, "y": 25},
@@ -197,7 +204,7 @@ class Animator:
         if not no_lane:
             o_destinations = {shooter_pos: shooter_spot}
             other_positions = [p for p in position_list if p != shooter_pos]
-            for i, pos in enumerate(other_positions):
+            for i, pos in enumerate(other_positions[: len(cfg["offenseAlignList"]) ]):
                 o_destinations[pos] = cfg["offenseAlignList"][i]
 
             for pos, player in offense_team.lineup.items():

--- a/tests/test_free_throw_logic.py
+++ b/tests/test_free_throw_logic.py
@@ -2,6 +2,7 @@ import pytest
 from fastapi import HTTPException
 from tests.test_utils import build_mock_game
 from BackEnd.engine.phase_resolution import resolve_free_throw_logic
+from BackEnd.models.animator import Animator
 
 
 def _setup_game(one_and_one: bool):
@@ -60,3 +61,17 @@ def test_missing_shooter_returns_400():
         resolve_free_throw_logic(game)
 
     assert excinfo.value.status_code == 400
+
+
+def test_free_throw_animation_empty_offense_lineup():
+    game = build_mock_game()
+    shooter = game.offense_team.lineup["PG"]
+    game.offense_team.lineup = {}
+    animator = Animator(game)
+    packet = animator.capture_free_throw_animation(
+        game,
+        shooter,
+        attempts=["MAKE"],
+        offense_is_home=True,
+    )
+    assert packet == []


### PR DESCRIPTION
## Summary
- Safely bail from free throw animations when shooter missing from lineup
- Limit offense alignment iteration to available spots
- Cover free throw animation edge case with empty offense lineup

## Testing
- `pytest tests/test_free_throw_logic.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5dd07ac3883288d971539dd938519