### PR TITLE
Validate game_id before quarter sim and propagate to frontend

### DIFF
--- a/BackEnd/api/api.py
+++ b/BackEnd/api/api.py
@@ -173,8 +173,24 @@ def simulate_quarter_endpoint(request: QuarterSimulationRequest):
         list((request.home_lineup or {}).keys()),
         list((request.away_lineup or {}).keys()),
     )
-    if game_id and game_id in ongoing_games:
-        gm = ongoing_games[game_id]
+    if game_id:
+        gm = ongoing_games.get(game_id)
+        if gm is None:
+            logging.warning("simulate_quarter_endpoint unknown game_id: %s", game_id)
+            saved = games_collection.find_one({"_id": game_id}) if games_collection else None
+            if saved:
+                try:
+                    home = saved.get("home_team") or saved.get("homeTeam", {}).get("name")
+                    away = saved.get("away_team") or saved.get("awayTeam", {}).get("name")
+                    if home and away:
+                        gm = GameManager(home, away)
+                        gm.game_state = saved.get("game_state", {})
+                        gm.quarter = saved.get("quarter", 1)
+                        ongoing_games[game_id] = gm
+                except Exception:
+                    logging.exception("Failed to load game state for %s", game_id)
+            if gm is None:
+                raise HTTPException(status_code=400, detail="Unknown game_id")
     else:
         gm = GameManager(request.home_team, request.away_team)
         game_id = str(uuid.uuid4())

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -25,7 +25,7 @@ export function createGameScene(Phaser) {
         this.homeLineup = data.homeLineup || {};
         this.awayLineup = data.awayLineup || {};
         this.periodLabel = data.periodLabel;
-        this.gameId = data.gameId;
+        this.gameId = data.gameId || localStorage.getItem('game_id');
         this.quarter = data.quarter || 1;
 
         console.log("🧠 Game initialized with:", {
@@ -60,14 +60,15 @@ export function createGameScene(Phaser) {
       const homeTeam = this.rosters.homeRoster.team_name;
       const awayTeam = this.rosters.awayRoster.team_name;
 
-    console.log("📨 Sending /api/simulate-quarter request for:", homeTeam, "vs", awayTeam);
+      const storedGameId = this.gameId || localStorage.getItem('game_id');
+      console.log("📨 Sending /api/simulate-quarter request for:", homeTeam, "vs", awayTeam);
+      console.log("🔢 Quarter:", this.quarter, "Game ID:", storedGameId);
 
-      const payload = { home_team: homeTeam, away_team: awayTeam };
-      if (this.gameId) payload.game_id = this.gameId;
-      payload.quarter = this.quarter;
+      const payload = { home_team: homeTeam, away_team: awayTeam, quarter: this.quarter };
+      if (storedGameId) payload.game_id = storedGameId;
       if (Object.keys(this.homeLineup).length) payload.home_lineup = this.homeLineup;
       if (Object.keys(this.awayLineup).length) payload.away_lineup = this.awayLineup;
-      const url = this.gameId || this.quarter > 1 ? '/api/simulate-quarter' : '/api/simulate-quarter';
+      const url = storedGameId || this.quarter > 1 ? '/api/simulate-quarter' : '/api/simulate-quarter';
       const res = await fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -100,7 +101,8 @@ export function createGameScene(Phaser) {
       console.log("📦 simData received:", simData);
       const logHome = simData.homeTeam?.name || simData.home_team;
       const logAway = simData.awayTeam?.name || simData.away_team;
-      this.gameId = simData.game_id || this.gameId;
+      this.gameId = simData.game_id || storedGameId;
+      if (this.gameId) localStorage.setItem('game_id', this.gameId);
       this.isFinal = simData.is_final;
       console.log(
         `✅ Simulated matchup: ${logHome} vs ${logAway}`

--- a/FrontEnd/static/set-lineup.js
+++ b/FrontEnd/static/set-lineup.js
@@ -5,7 +5,7 @@ const homeId = urlParams.get('home_id');
 const awayId = urlParams.get('away_id');
 let myTeamSide = urlParams.get('my_team');
 const userTeamIdParam = urlParams.get('user_team_id');
-const gameId = urlParams.get('game_id');
+const gameId = urlParams.get('game_id') || localStorage.getItem('game_id');
 const quarter = parseInt(urlParams.get('quarter'), 10) || 1;
 const periodLabel = urlParams.get('period') || `Q${quarter}`;
 let teamName = '';
@@ -202,6 +202,8 @@ async function init() {
         const id = lineup[pos];
         if (id) params.set(`${myTeamSide}_${pos.toLowerCase()}`, id);
       });
+      if (gameId) params.set('game_id', gameId);
+      console.log('🔀 Redirecting to court.html with', { quarter, gameId });
       window.location.href = `/court.html?${params.toString()}`;
     });
   }


### PR DESCRIPTION
## Summary
- verify simulate-quarter requests reference a known `game_id`, attempting MongoDB reloads when missing and erroring if unknown
- persist `game_id` across frontend pages and include it in quarter simulation payloads, with extra logging for quarter and gameId
- append stored `game_id` to lineup and court redirects

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5e98a4d0083289b00ec43c1b9e46d