### PR TITLE
Handle missing free throw rim coords

### DIFF
--- a/FrontEnd/static/js/phaser/animation/freeThrow.js
+++ b/FrontEnd/static/js/phaser/animation/freeThrow.js
@@ -1,5 +1,6 @@
 import { gridToPixels } from "../utils/gridToPixels.js";
 import animationConfig from "./animation_config.js";
+import { HOME_RIM_COORDS, AWAY_RIM_COORDS } from "./courtConstants.js";
 
 function wait(scene, ms) {
   if (!ms) return Promise.resolve();
@@ -106,12 +107,12 @@ export async function runFreeThrowSequence(
 
     const shotStep = moves[moveIndex];
     moveIndex++;
-    const rimPx = gridToPixels(
-      shotStep.coords.x,
-      shotStep.coords.y,
-      width,
-      height
-    );
+    const rimGrid =
+      shotStep?.coords ||
+      (turnData.offense_team_id === scene.simData?.home_team_id
+        ? HOME_RIM_COORDS
+        : AWAY_RIM_COORDS);
+    const rimPx = gridToPixels(rimGrid.x, rimGrid.y, width, height);
     scene.events?.emit("ft:shotStart");
     await tween(scene, ballSprite, rimPx, {
       duration: animationConfig.freeThrow.shotMs,
@@ -147,9 +148,10 @@ export async function runFreeThrowSequence(
       } else {
         const resetStep = moves[moveIndex];
         moveIndex++;
+        const resetGrid = resetStep?.coords || rimGrid;
         const spotPx = gridToPixels(
-          resetStep.coords.x,
-          resetStep.coords.y,
+          resetGrid.x,
+          resetGrid.y,
           width,
           height
         );
@@ -168,15 +170,16 @@ export async function runFreeThrowSequence(
           playerSprites,
           animations: [],
           rebounderId: null,
-          ballSpot: shotStep.coords,
+          ballSpot: rimGrid,
           shooterId: turnData.shooter_id,
         });
       } else {
         const resetStep = moves[moveIndex];
         moveIndex++;
+        const resetGrid = resetStep?.coords || rimGrid;
         const spotPx = gridToPixels(
-          resetStep.coords.x,
-          resetStep.coords.y,
+          resetGrid.x,
+          resetGrid.y,
           width,
           height
         );

--- a/tests/js/runFreeThrowSequence.mjs
+++ b/tests/js/runFreeThrowSequence.mjs
@@ -128,5 +128,46 @@ const awayResult = {
   inboundCalled: inboundCalled2,
   reboundCalled: reboundCalled2,
 };
+const sceneFallback = makeScene();
+const playerSpritesFallback = createPlayers();
+sceneFallback.playerInfo = createInfo();
+const ballSpriteFallback = makeBall();
+let reboundCalled3 = false;
+let reboundSpot3;
+await runFreeThrowSequence(sceneFallback, {
+  playerSprites: playerSpritesFallback,
+  ballSprite: ballSpriteFallback,
+  turnData: {
+    result_type: 'FREE_THROW',
+    offense_team_id: 'HOME',
+    shooter_id: 'pg',
+    shooter_pos: 'PG',
+    attempts: ['MISS'],
+    animations: [
+      { playerId: 'pg', movement: [ { timestamp:0, coords:{x:0,y:0} }, { timestamp:800, coords:{x:74,y:25} } ], duration:800 },
+      { playerId: 'ball', movement: [ { timestamp:0, coords:{x:74,y:25} } ], duration:500 }
+    ]
+  },
+  helpers: {
+    tweenBallTo: (scene, ball, target, opts) => { ball.x = target.x; ball.y = target.y; return Promise.resolve(); },
+    runInboundSetup: () => Promise.resolve(),
+    animateRebound: ({ ballSpot }) => { reboundCalled3 = true; reboundSpot3 = ballSpot; return Promise.resolve(); },
+    attachBallToPlayer: () => {},
+    detachBall: () => {},
+  }
+});
 
-console.log(JSON.stringify({ home: homeResult, away: awayResult, expected: { pgDest, sgDest, dPgDest } }));
+const fallbackResult = {
+  reboundCalled: reboundCalled3,
+  ballSpot: reboundSpot3,
+  ballPos: { x: ballSpriteFallback.x, y: ballSpriteFallback.y },
+};
+
+console.log(
+  JSON.stringify({
+    home: homeResult,
+    away: awayResult,
+    fallback: fallbackResult,
+    expected: { pgDest, sgDest, dPgDest },
+  })
+);

--- a/tests/test_frontend_free_throw_sequence.py
+++ b/tests/test_frontend_free_throw_sequence.py
@@ -1,0 +1,18 @@
+import json
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def run_node(loader, script):
+    cmd = ["node", "--loader", str(ROOT / loader), str(ROOT / script)]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return json.loads(completed.stdout.strip().splitlines()[-1])
+
+
+def test_free_throw_sequence_defaults_to_rim():
+    result = run_node("tests/js/httpsLoaderNoStubBall.mjs", "tests/js/runFreeThrowSequence.mjs")
+    assert result["fallback"]["reboundCalled"] is True
+    assert result["fallback"]["ballSpot"] == {"x": 91, "y": 25}
+    assert result["fallback"]["ballPos"] == {"x": 91, "y": 25}


### PR DESCRIPTION
## Summary
- default free throw rim target to home/away constants when movement data is missing
- safeguard reset ball movement with the rim fallback
- cover missing-rim animation case in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5eedf28e08328adeb3dcbda8baf84