### PR TITLE
Handle rebound events in halfcourt animations

### DIFF
--- a/BackEnd/models/animator.py
+++ b/BackEnd/models/animator.py
@@ -331,6 +331,15 @@ class Animator:
         # Determine which offensive player has the ball at each step
         ball_actions = {"handle_ball", "receive", "shoot"}
         ball_owner_by_step = []
+        # Map all players by their ID for quick lookup on events
+        players_by_id = {
+            getattr(p, "player_id", str(id(p))): p for p in off_lineup.values()
+        }
+        players_by_id.update(
+            {getattr(p, "player_id", str(id(p))): p for p in def_lineup.values()}
+        )
+
+        rebounder = None
         for step in steps:
             owner = None
             for pos_key, action_info in step["pos_actions"].items():
@@ -347,7 +356,20 @@ class Animator:
                         owner = off_lineup.get(event.get("by"))
                         if owner:
                             break
+                    elif event.get("event_type") in {"offReb", "defReb"}:
+                        owner = players_by_id.get(event.get("rebounderId"))
+                        rebounder = owner or rebounder
+                        if owner:
+                            break
             ball_owner_by_step.append(owner)
+
+        # Extend ball ownership to cover any additional timeline steps
+        max_timeline_len = max(
+            [len(tl) for tl in action_timeline.values()] + [len(ball_owner_by_step)]
+        )
+        if len(ball_owner_by_step) < max_timeline_len:
+            filler = rebounder or (ball_owner_by_step[-1] if ball_owner_by_step else None)
+            ball_owner_by_step.extend([filler] * (max_timeline_len - len(ball_owner_by_step)))
 
         for idx, owner in enumerate(ball_owner_by_step):
             if owner is None:
@@ -416,7 +438,7 @@ class Animator:
             def_coords = None
             action_type = ACTIONS["GUARD_OFFBALL"]
 
-            hasBallAtStep = [False for _ in ball_owner_by_step]
+            hasBallAtStep = [ball_owner_by_step[i] is defender for i in range(len(ball_owner_by_step))]
 
             if pos == bh_pos:
                 bh_timeline = action_timeline.get(ball_handler, [])

--- a/BackEnd/models/shot_manager.py
+++ b/BackEnd/models/shot_manager.py
@@ -179,6 +179,11 @@ class ShotManager:
                         text += f" {get_name_safe(rebounder)} kicks it out to reset." 
                         possession_flips = rebound_event.get("possession_flips", possession_flips)
                 else:
+                    events.append({
+                        "event_type": "defReb",
+                        "rebounderId": getattr(rebounder, "player_id", None),
+                    })
+                    self.game.turn_manager.logger.log("defReb")
                     self.game_state["last_rebounder"] = rebounder
                     self.game_state["offensive_state"] = (
                         "FAST_BREAK" if random.random() < get_fast_break_chance(self.game) else "HCO"

--- a/tests/test_animation_rebound_possession.py
+++ b/tests/test_animation_rebound_possession.py
@@ -1,0 +1,68 @@
+import pytest
+from tests.test_utils import build_mock_game
+from BackEnd.models.animator import Animator
+
+
+def extract_ball_owners(animations, step_count):
+    owners = [None] * step_count
+    for anim in animations:
+        for idx, has in enumerate(anim.get("hasBallAtStep", [])):
+            if idx < step_count and has:
+                owners[idx] = anim["playerId"]
+    return owners
+
+
+@pytest.mark.parametrize("event_type", ["offReb", "defReb"])
+def test_rebounder_holds_ball_final_step(event_type):
+    game = build_mock_game()
+    off_lineup = game.offense_team.lineup
+    def_lineup = game.defense_team.lineup
+
+    pg = off_lineup["PG"]
+    pf = off_lineup["PF"]
+    def_c = def_lineup["C"]
+
+    rebounder = pf if event_type == "offReb" else def_c
+
+    steps = [
+        {"timestamp": 0, "pos_actions": {"PG": {"action": "handle_ball", "spot": "key"}}, "events": []},
+        {
+            "timestamp": 1,
+            "pos_actions": {"PG": {"action": "shoot", "spot": "key"}},
+            "events": [{"type": "shot", "by": "PG"}],
+        },
+        {
+            "timestamp": 2,
+            "pos_actions": {},
+            "events": [
+                {
+                    "event_type": event_type,
+                    "rebounderId": getattr(rebounder, "player_id", None),
+                }
+            ],
+        },
+    ]
+
+    action_timeline = {
+        pg: [(0, "handle_ball", "key"), (1, "shoot", "key")],
+        pf: [
+            (0, "move", "block"),
+            (2, "rebound", "block"),
+            (3, "hold", "block"),
+            (4, "hold", "block"),
+        ],
+    }
+
+    roles = {
+        "steps": steps,
+        "action_timeline": action_timeline,
+        "shooter": pg,
+        "ball_handler": pg,
+    }
+
+    animator = Animator(game)
+    animations = animator.capture_halfcourt_animation(roles)
+
+    max_len = max(len(tl) for tl in action_timeline.values())
+    owners = extract_ball_owners(animations, max_len)
+    assert owners[-1] == getattr(rebounder, "player_id", None)


### PR DESCRIPTION
## Summary
- recognize offensive and defensive rebound events during halfcourt animations and carry rebounder ownership forward
- emit `defReb` events with `rebounderId` to match offensive rebounds
- add regression test ensuring rebounders retain ball ownership in animations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a61a230d18832890e2fd994964555e