### PR TITLE
Handle missing offensive_state and merge saved game state

### DIFF
--- a/BackEnd/api/api.py
+++ b/BackEnd/api/api.py
@@ -197,7 +197,8 @@ def simulate_quarter_endpoint(request: QuarterSimulationRequest):
                     away = saved.get("away_team") or saved.get("awayTeam", {}).get("name")
                     if home and away:
                         gm = GameManager(home, away)
-                        gm.game_state = saved.get("game_state", {})
+                        gm.game_state = gm._init_game_state()
+                        gm.game_state.update(saved.get("game_state", {}))
                         gm.quarter = saved.get("quarter", 1)
                         ongoing_games[game_id] = gm
                 except Exception:

--- a/BackEnd/models/turn_manager.py
+++ b/BackEnd/models/turn_manager.py
@@ -153,13 +153,13 @@ class TurnManager:
         self.set_strategy_calls()
 
         print("*****RUN TURN*****")
-        print(f"offensive state: {self.game.game_state['offensive_state']}")
-        if self.game.game_state["offensive_state"] in ["HCO", "HALF_COURT"]:
+        state = self.game.game_state.get("offensive_state", "HCO")
+        print(f"offensive state: {state}")
+        if state in ["HCO", "HALF_COURT"]:
             print(f"{self.game.offense_team.name}: {self.game.game_state['current_playcall']}")
             print(f"{self.game.defense_team.name}: {self.game.game_state['defense_playcall']}")
 
         # STEP 3: Route based on offensive state
-        state = self.game.game_state["offensive_state"]
         if state == "FREE_THROW":
             result = self.resolve_free_throw()
         elif state == "FAST_BREAK":


### PR DESCRIPTION
## Summary
- Initialize a fresh game state when restoring a saved game and merge persisted fields instead of overwriting
- Default offensive_state lookups to `HCO` in `TurnManager.run_micro_turn` to prevent crashes when the key is absent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a62541128083289861d5faf40c4e25