### PR TITLE
Ensure lineups cover all positions before quarter simulation

### DIFF
--- a/BackEnd/main.py
+++ b/BackEnd/main.py
@@ -92,6 +92,35 @@ def _initialize_game_stats(gm: GameManager, game_id: str | None = None) -> None:
     print(f"[DEV] Initialized game stats for players: {affected}")
 
 
+def _ensure_complete_lineup(team) -> None:
+    """Ensure a team has players at all required positions.
+
+    If any position from ``POSITION_LIST`` is missing, attempt to build a
+    complete lineup from the team's roster.  Raises ``ValueError`` when the
+    roster cannot supply the missing positions.
+    """
+
+    missing = [pos for pos in POSITION_LIST if not team.lineup.get(pos)]
+    if not missing:
+        return
+
+    try:
+        auto = build_lineup_from_mongo(team)
+    except ValueError as exc:
+        raise ValueError(
+            f"Team '{team.name}' lineup missing positions {missing}: {exc}"
+        ) from exc
+
+    for pos in POSITION_LIST:
+        team.lineup.setdefault(pos, auto[pos])
+
+    remaining = [pos for pos in POSITION_LIST if not team.lineup.get(pos)]
+    if remaining:
+        raise ValueError(
+            f"Team '{team.name}' lineup incomplete; missing positions: {remaining}"
+        )
+
+
 def simulate_quarter(
     gm: GameManager,
     home_lineup_ids=None,
@@ -120,6 +149,10 @@ def simulate_quarter(
         gm.away_team.lineup = assign_lineup_from_ids(gm.away_team, away_lineup_ids)
     elif not gm.away_team.lineup:
         gm.away_team.lineup = build_lineup_from_mongo(gm.away_team)
+
+    # Validate that both lineups contain all required positions
+    _ensure_complete_lineup(gm.home_team)
+    _ensure_complete_lineup(gm.away_team)
 
     # Zero per-game stats exactly once per game before the opening tip.
     _initialize_game_stats(gm, game_id)

--- a/tests/test_simulate_quarter.py
+++ b/tests/test_simulate_quarter.py
@@ -48,3 +48,45 @@ def test_simulate_quarter_advances_game(monkeypatch):
     assert gm.game_state["team_fouls"][gm.home_team.name] == 0
     assert gm.game_state["team_fouls"][gm.away_team.name] == 0
 
+
+def test_simulate_quarter_autofills_missing_positions(monkeypatch):
+    """Lineups missing positions are automatically completed from the roster."""
+
+    def fake_load_roster(team_name):
+        players = []
+        for i, pos in enumerate(["PG", "SG", "SF", "PF", "C"]):
+            players.append(
+                {
+                    "_id": f"{team_name}_{i}",
+                    "first_name": f"{team_name}{i}",
+                    "last_name": pos,
+                    "team": team_name,
+                    "attributes": {},
+                }
+            )
+        return {"name": team_name}, players
+
+    def roster_build_lineup(team):
+        roster = list(team.players.values())
+        positions = ["PG", "SG", "SF", "PF", "C"]
+        return {pos: roster[i] for i, pos in enumerate(positions)}
+
+    monkeypatch.setattr(GameManager, "simulate_macro_turn", fake_simulate_macro_turn)
+    monkeypatch.setattr("BackEnd.models.team_manager.load_roster", fake_load_roster)
+    monkeypatch.setattr(main, "build_lineup_from_mongo", roster_build_lineup)
+
+    gm = GameManager("Lancaster", "Bentley-Truman")
+
+    partial_home = {
+        "PG": "Lancaster_0",
+        "SG": "Lancaster_1",
+        "SF": "Lancaster_2",
+        "PF": "Lancaster_3",
+    }
+
+    main.simulate_quarter(gm, home_lineup_ids=partial_home)
+
+    assert set(gm.home_team.lineup.keys()) == set(["PG", "SG", "SF", "PF", "C"])
+    assert gm.home_team.lineup["PG"].player_id == "Lancaster_0"
+    assert gm.home_team.lineup["C"].player_id == "Lancaster_4"
+


### PR DESCRIPTION
## Summary
- Validate that team lineups include all five positions
- Auto-fill missing lineup slots from roster or raise a clear error
- Test that partial lineups are completed automatically

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a62546fee88328b0de8aa777d09a79