### PR TITLE
Normalize player ID handling in Phaser scenes

### DIFF
--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -120,11 +120,12 @@ export function createGameScene(Phaser) {
       const quarterEl = document.getElementById('quarter');
 
       const positions = ["PG","SG","SF","PF","C"];
-      this.nameToId = Object.fromEntries(simData.players.map(p => [p.name, p.playerId]));
-      this.playerInfo = Object.fromEntries(simData.players.map(p => [p.playerId, { name: p.name, team: p.team, pos: p.pos }]));
+      this.nameToId = Object.fromEntries(simData.players.map(p => [p.name, p.playerId ?? p.player_id]));
+      this.playerInfo = Object.fromEntries(simData.players.map(p => [p.playerId ?? p.player_id, { name: p.name, team: p.team, pos: p.pos }]));
       this.playerStats = {};
       simData.players.forEach(p => {
-        this.playerStats[p.playerId] = { PTS: 0, REB: 0, AST: 0 };
+        const id = p.playerId ?? p.player_id;
+        this.playerStats[id] = { PTS: 0, REB: 0, AST: 0 };
       });
       this.rowRefs = { home: {}, away: {} };
       this.currentLineup = { home: {}, away: {} };
@@ -142,7 +143,7 @@ export function createGameScene(Phaser) {
       const initTeamTable = (teamKey, bodyEl) => {
         positions.forEach(pos => {
           const player = simData.players.find(p => p.team === teamKey && p.pos === pos);
-          const playerId = player?.playerId;
+          const playerId = player?.playerId ?? player?.player_id;
           const tr = document.createElement('tr');
           const nameTd = document.createElement('td');
           const ptsTd = document.createElement('td');
@@ -394,12 +395,12 @@ export function createGameScene(Phaser) {
         const startAnimation = async () => {
           this.playerSprites = loadPhaserPlayers(this, simData.players, {
             home: {
-              player_ids: simData.players.filter(p => p.team === "home").map(p => p.playerId),
+              player_ids: simData.players.filter(p => p.team === "home").map(p => p.playerId ?? p.player_id),
               primary_color: simData.home_team_colors.primary_color,
               secondary_color: simData.home_team_colors.secondary_color
             },
             away: {
-              player_ids: simData.players.filter(p => p.team === "away").map(p => p.playerId),
+              player_ids: simData.players.filter(p => p.team === "away").map(p => p.playerId ?? p.player_id),
               primary_color: simData.away_team_colors.primary_color,
               secondary_color: simData.away_team_colors.secondary_color
             }

--- a/FrontEnd/static/js/phaser/setup/loadPhaserPlayers.js
+++ b/FrontEnd/static/js/phaser/setup/loadPhaserPlayers.js
@@ -12,7 +12,8 @@ export function loadPhaserPlayers(scene, allPlayers, teamInfo, Phaser) {
   const playerSprites = {};
 
   for (const player of allPlayers) {
-    const isHome = teamInfo.home.player_ids.includes(player.playerId);
+    const id = player.playerId ?? player.player_id;
+    const isHome = teamInfo.home.player_ids.includes(id);
     const teamColors = isHome ? teamInfo.home : teamInfo.away;
     
     const sprite = createPhaserPlayer({
@@ -28,8 +29,9 @@ export function loadPhaserPlayers(scene, allPlayers, teamInfo, Phaser) {
     // ✅ Attach team metadata for later logic
     sprite.team_id = player.team_id; // e.g., "MORRISTOWN"
     sprite.team = player.team;       // e.g., "home" or "away"
-    
-    playerSprites[player.playerId] = sprite;
+    sprite.playerId = id;
+
+    playerSprites[id] = sprite;
   }
   // console.log("👾 playerSprites keys:", Object.keys(playerSprites));
 


### PR DESCRIPTION
## Summary
- Normalize player IDs when loading Phaser players to support `player_id`
- Resolve player ID lookups in `gameScene` using `playerId ?? player_id`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5b7a7be2883288111abe2d0cd3f13