### PR TITLE
Add guard for missing player sprites in ball ownership

### DIFF
--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -54,7 +54,11 @@ function updateBallOwnership({ scene, ballSprite, animations, playerSprites, ste
     if (scene.skipToEnd) break;
     const sprite = playerSprites[anim.playerId];
     const hasBall = anim.hasBallAtStep?.[stepIndex];
-    if (hasBall && ballSprite?.setPosition) {
+    if (hasBall && !sprite) {
+      console.warn(`Missing sprite for player ${anim.playerId}`);
+      continue;
+    }
+    if (hasBall && sprite && ballSprite?.setPosition) {
       ballSprite.setPosition(sprite.x, sprite.y);
       ballSprite.setVisible(true);
       if (currentBallOwnerRef) currentBallOwnerRef.value = sprite;


### PR DESCRIPTION
## Summary
- Avoid crashes by logging missing player sprites when assigning ball ownership

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b5b943c0b08328b6a4b334fe5b8530