### PR TITLE
Add DEBUG_TEAMS flag for team logging

### DIFF
--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -5,6 +5,7 @@ import { on, emit } from './utils/eventBus.js';
 import { finalizeGame } from './finalizeGame.js';
 
 const DEBUG_GAME_ID = window.DEBUG_GAME_ID || false;
+const DEBUG_TEAMS = window.DEBUG_TEAMS || false;
 
 if (typeof window !== 'undefined') {
   window.TEXT_SCROLL_ENABLED =
@@ -222,6 +223,9 @@ async function handleButtonClick(animate) {
   if (sim4Btn) sim4Btn.style.display = 'none';
 
   try {
+    if (DEBUG_TEAMS) {
+      console.log('Fetching rosters for teams:', { homeTeam, awayTeam });
+    }
     const [homeRoster, awayRoster] = await Promise.all([
       fetchTeamRoster(homeTeam),
       fetchTeamRoster(awayTeam),
@@ -263,6 +267,12 @@ async function handleSimToFourth() {
       if (currentQ === quarter) {
         if (Object.keys(homeLineup).length) payload.home_lineup = homeLineup;
         if (Object.keys(awayLineup).length) payload.away_lineup = awayLineup;
+      }
+      if (DEBUG_TEAMS) {
+        console.log('/api/simulate-quarter payload teams:', {
+          home: payload.home_team,
+          away: payload.away_team,
+        });
       }
       const res = await fetch('/api/simulate-quarter', {
         method: 'POST',
@@ -326,6 +336,12 @@ async function handleSimFullGame() {
       if (currentQ === quarter) {
         if (Object.keys(homeLineup).length) payload.home_lineup = homeLineup;
         if (Object.keys(awayLineup).length) payload.away_lineup = awayLineup;
+      }
+      if (DEBUG_TEAMS) {
+        console.log('/api/simulate-quarter payload teams:', {
+          home: payload.home_team,
+          away: payload.away_team,
+        });
       }
       const res = await fetch('/api/simulate-quarter', {
         method: 'POST',

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -6,6 +6,7 @@ import { emit } from './utils/eventBus.js';
 import { appendToTextScroll } from './utils/textScroll.js';
 
 const DEBUG_SIM_PAYLOAD = window.DEBUG_SIM_PAYLOAD || false;
+const DEBUG_TEAMS = window.DEBUG_TEAMS || false;
 
 export function createGameScene(Phaser) {
   return class GameScene extends Phaser.Scene {
@@ -65,11 +66,19 @@ export function createGameScene(Phaser) {
       const homeTeam = this.rosters.homeRoster.team_name;
       const awayTeam = this.rosters.awayRoster.team_name;
 
-      console.log("📨 Sending /api/simulate-quarter request for:", homeTeam, "vs", awayTeam);
-      console.log("🔢 Quarter:", this.quarter, "Game ID:", this.gameId);
+      if (DEBUG_TEAMS) {
+        console.log("📨 Sending /api/simulate-quarter request for:", homeTeam, "vs", awayTeam);
+        console.log("🔢 Quarter:", this.quarter, "Game ID:", this.gameId);
+      }
 
       const payload = { home_team: homeTeam, away_team: awayTeam, quarter: this.quarter };
       if (this.gameId) payload.game_id = this.gameId;
+      if (DEBUG_TEAMS) {
+        console.log('/api/simulate-quarter payload teams:', {
+          home: payload.home_team,
+          away: payload.away_team,
+        });
+      }
       if (DEBUG_SIM_PAYLOAD) {
         console.debug('Sim payload teams:', homeTeam, awayTeam, 'gameId:', this.gameId);
       }
@@ -414,6 +423,12 @@ export function createGameScene(Phaser) {
               secondary_color: simData.away_team_colors.secondary_color
             }
           }, Phaser);
+
+          if (DEBUG_TEAMS) {
+            simData.players.forEach(p => {
+              console.log(`Sprite initialized: ${p.name} -> ${p.team}`);
+            });
+          }
 
           this.ballSprite = this.add.image(0, 0, "ball").setVisible(true).setDepth(1000).setScale(1);
 


### PR DESCRIPTION
## Summary
- add `window.DEBUG_TEAMS` flag
- log selected rosters and `/api/simulate-quarter` payload teams when debugging
- report player sprite initialization by name and team

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5bb2b44bc8328acaf5e12026c1942