### PR TITLE
Avoid reusing game id for new games

### DIFF
--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -78,6 +78,15 @@ if (
   }
 }
 let quarter = parseInt(urlParams.get('quarter'), 10) || 1;
+if (quarter === 1) {
+  gameId = null;
+  if (
+    typeof localStorage !== 'undefined' &&
+    typeof localStorage.removeItem === 'function'
+  ) {
+    localStorage.removeItem('game_id');
+  }
+}
 let periodLabel = urlParams.get('period') || `Q${quarter}`;
 
 const homeLineup = {};

--- a/FrontEnd/static/set-lineup.js
+++ b/FrontEnd/static/set-lineup.js
@@ -5,8 +5,12 @@ const homeId = urlParams.get('home_id');
 const awayId = urlParams.get('away_id');
 let myTeamSide = urlParams.get('my_team');
 const userTeamIdParam = urlParams.get('user_team_id');
-const gameId = urlParams.get('game_id') || localStorage.getItem('game_id');
 const quarter = parseInt(urlParams.get('quarter'), 10) || 1;
+const gameId =
+  quarter > 1 ? urlParams.get('game_id') || localStorage.getItem('game_id') : null;
+if (quarter === 1 && typeof localStorage !== 'undefined') {
+  localStorage.removeItem('game_id');
+}
 const periodLabel = urlParams.get('period') || `Q${quarter}`;
 let teamName = '';
 
@@ -202,7 +206,7 @@ async function init() {
         const id = lineup[pos];
         if (id) params.set(`${myTeamSide}_${pos.toLowerCase()}`, id);
       });
-      if (gameId) params.set('game_id', gameId);
+      if (gameId !== null) params.set('game_id', gameId);
       console.log('🔀 Redirecting to court.html with', { quarter, gameId });
       window.location.href = `/court.html?${params.toString()}`;
     });


### PR DESCRIPTION
## Summary
- Only retain game ID after the first quarter; drop or clear for new games
- Remove stored game ID when launching quarter 1 simulations
- Include game ID in lineup redirect only when available

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5ca13d80883289d29e40c8ceea250