### PR TITLE
Log active game IDs when quarter simulation receives unknown game_id

### DIFF
--- a/BackEnd/api/api.py
+++ b/BackEnd/api/api.py
@@ -176,7 +176,11 @@ def simulate_quarter_endpoint(request: QuarterSimulationRequest):
     if game_id:
         gm = ongoing_games.get(game_id)
         if gm is None:
-            logging.warning("simulate_quarter_endpoint unknown game_id: %s", game_id)
+            logging.warning(
+                "simulate_quarter_endpoint unknown game_id=%s; active=%s",
+                game_id,
+                list(ongoing_games.keys()),
+            )
             if games_collection is not None:
                 logging.info(
                     "simulate_quarter_endpoint querying DB for game_id=%s", game_id


### PR DESCRIPTION
## Summary
- expose currently tracked game IDs when simulate-quarter endpoint receives an unknown id

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5caeec384832891d3d21a779d215d