### PR TITLE
Gracefully start first-quarter games without game_id

### DIFF
--- a/BackEnd/api/api.py
+++ b/BackEnd/api/api.py
@@ -173,6 +173,7 @@ def simulate_quarter_endpoint(request: QuarterSimulationRequest):
         list((request.home_lineup or {}).keys()),
         list((request.away_lineup or {}).keys()),
     )
+    source = "resume"
     if game_id:
         gm = ongoing_games.get(game_id)
         if gm is None:
@@ -208,11 +209,29 @@ def simulate_quarter_endpoint(request: QuarterSimulationRequest):
                 except Exception:
                     logging.exception("Failed to load game state for %s", game_id)
             if gm is None:
-                raise HTTPException(status_code=400, detail="Unknown game_id")
+                if request.quarter == 1:
+                    gm = GameManager(request.home_team, request.away_team)
+                    game_id = str(uuid.uuid4())
+                    ongoing_games[game_id] = gm
+                    source = "new"
+                else:
+                    raise HTTPException(status_code=400, detail="Unknown game_id")
     else:
         gm = GameManager(request.home_team, request.away_team)
         game_id = str(uuid.uuid4())
         ongoing_games[game_id] = gm
+        source = "new"
+
+    logging.info(
+        {
+            "event": "simulate-quarter:start",
+            "game_id": game_id,
+            "home_team": request.home_team,
+            "away_team": request.away_team,
+            "quarter": request.quarter,
+            "source": source,
+        }
+    )
 
     # If the requested quarter has already been simulated, return the existing state
     if request.quarter < gm.quarter:

--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -66,26 +66,19 @@ if (weekParam && !Number.isNaN(weekParam) && typeof localStorage !== 'undefined'
   localStorage.setItem('franchise_week', weekParam);
 }
 const mode = urlParams.get('mode') || getMode({ tournamentId, franchiseId });
-let gameId = urlParams.get('game_id');
-if (
-  !gameId &&
+let quarter = parseInt(urlParams.get('quarter'), 10) || 1;
+let gameId = null;
+if (quarter > 1) {
+  gameId =
+    urlParams.get('game_id') ||
+    (typeof localStorage !== 'undefined'
+      ? localStorage.getItem('game_id')
+      : null);
+} else if (
   typeof localStorage !== 'undefined' &&
   typeof localStorage.removeItem === 'function'
 ) {
   localStorage.removeItem('game_id');
-  if (DEBUG_GAME_ID) {
-    console.log('Cleared stored game_id from localStorage');
-  }
-}
-let quarter = parseInt(urlParams.get('quarter'), 10) || 1;
-if (quarter === 1) {
-  gameId = null;
-  if (
-    typeof localStorage !== 'undefined' &&
-    typeof localStorage.removeItem === 'function'
-  ) {
-    localStorage.removeItem('game_id');
-  }
 }
 let periodLabel = urlParams.get('period') || `Q${quarter}`;
 
@@ -265,14 +258,14 @@ async function handleSimToFourth() {
     let currentQ = quarter;
     let gId = gameId;
     let lastSummary;
-    while (currentQ <= 3) {
-      showStatus(`Simulating Q${currentQ}...`);
+      while (currentQ <= 3) {
+        showStatus(`Simulating Q${currentQ}...`);
       const payload = {
         home_team: homeTeam,
         away_team: awayTeam,
         quarter: currentQ,
-        game_id: gId,
       };
+      if (gId) payload.game_id = gId;
       if (currentQ === quarter) {
         if (Object.keys(homeLineup).length) payload.home_lineup = homeLineup;
         if (Object.keys(awayLineup).length) payload.away_lineup = awayLineup;
@@ -283,6 +276,7 @@ async function handleSimToFourth() {
           away: payload.away_team,
         });
       }
+      console.log({event:'simulate-quarter:request', mode, homeTeam, awayTeam, quarter: currentQ, gameId: gId});
       const res = await fetch('/api/simulate-quarter', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -340,8 +334,8 @@ async function handleSimFullGame() {
         home_team: homeTeam,
         away_team: awayTeam,
         quarter: currentQ,
-        game_id: gId,
       };
+      if (gId) payload.game_id = gId;
       if (currentQ === quarter) {
         if (Object.keys(homeLineup).length) payload.home_lineup = homeLineup;
         if (Object.keys(awayLineup).length) payload.away_lineup = awayLineup;
@@ -352,6 +346,7 @@ async function handleSimFullGame() {
           away: payload.away_team,
         });
       }
+      console.log({event:'simulate-quarter:request', mode, homeTeam, awayTeam, quarter: currentQ, gameId: gId});
       const res = await fetch('/api/simulate-quarter', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/tests/test_simulate_quarter_endpoint.py
+++ b/tests/test_simulate_quarter_endpoint.py
@@ -94,3 +94,41 @@ def test_simulate_quarter_endpoint_handles_none_games_collection(monkeypatch):
 
     summary = api.simulate_quarter_endpoint(request)
     assert summary["game_id"] == "gid"
+
+
+def test_simulate_quarter_unknown_id_quarter1(monkeypatch):
+    class DummyTeam:
+        def __init__(self, name: str):
+            self.name = name
+            self.points_by_quarter = [0, 0, 0, 0]
+
+    class DummyGM:
+        def __init__(self, home, away):
+            self.home_team = DummyTeam(home)
+            self.away_team = DummyTeam(away)
+            self.quarter = 1
+            self.game_state = {"start_box_score": {}, "score": {home: 0, away: 0}}
+            self.score = self.game_state["score"]
+
+    def fake_simulate_quarter(gm, home_lineup, away_lineup, game_id):
+        gm.quarter += 1
+
+    def fake_summarize_game_state(gm):
+        return {"score": gm.score}
+
+    monkeypatch.setattr(api, "GameManager", DummyGM)
+    monkeypatch.setattr(api, "simulate_quarter", fake_simulate_quarter)
+    monkeypatch.setattr(api, "summarize_game_state", fake_summarize_game_state)
+
+    api.ongoing_games.clear()
+
+    request = api.QuarterSimulationRequest(
+        game_id="unknown",
+        home_team="Home",
+        away_team="Away",
+        quarter=1,
+    )
+
+    summary = api.simulate_quarter_endpoint(request)
+    assert summary["game_id"] != "unknown"
+    assert summary["quarter"] == 1


### PR DESCRIPTION
## Summary
- Read `gameId` only for later quarters and log outgoing simulate-quarter requests
- Allow `/api/simulate-quarter` to create a new game when an unknown `game_id` is provided for quarter one
- Add regression test for new-game behavior when `game_id` is missing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5cf10b42083289d52720a52dcb51c