### PR TITLE
Use config values for kickout reset timing

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -572,11 +572,13 @@ export function animateKickoutReset(
   const width = scene.game.config.width;
   const height = scene.game.config.height;
   const cfg = animationConfig.kickout;
+  const raw = duration ?? pass.duration;
+  const usedDuration = raw != null && raw >= cfg.duration ? raw : cfg.duration;
 
   const opts = {
     fromId: rebounderId,
     toId: pgId,
-    duration: duration ?? pass.duration ?? cfg.duration,
+    duration: usedDuration,
     easing: cfg.easing
   };
 

--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -1096,8 +1096,7 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
                       ballSprite,
                       evt.rebounder_player_id || evt.rebounderId,
                       evt.pgId,
-                      evt.pass,
-                      evt.pass?.duration
+                      evt.pass
                     );
                     if (typeof scene.startNextHalfCourtOffense === "function") {
                       scene.startNextHalfCourtOffense();
@@ -1151,8 +1150,7 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
           ballSprite,
           evt.rebounder_player_id || evt.rebounderId,
           evt.pgId,
-          evt.pass,
-          evt.pass?.duration
+          evt.pass
         );
         if (typeof scene.startNextHalfCourtOffense === "function") {
           scene.startNextHalfCourtOffense();


### PR DESCRIPTION
## Summary
- Ensure kickout reset pass duration never falls below configured baseline
- Simplify kickout reset call sites by deriving duration internally

## Testing
- `pytest tests/test_frontend_rebound_animation.py tests/test_run_pass_tween_flag.py`

------
https://chatgpt.com/codex/tasks/task_e_68b5e8a857988328aff726fbc3b73693