### PR TITLE
Ensure turn results contain only serializable player data

### DIFF
--- a/BackEnd/api/api.py
+++ b/BackEnd/api/api.py
@@ -32,6 +32,7 @@ import traceback
 from unidecode import unidecode
 from typing import Optional
 import logging
+from BackEnd.models.player import Player
 
 app = FastAPI()
 app.include_router(tournament_router)
@@ -145,6 +146,12 @@ def simulate_game(request: SimulationRequest):
 
     print("\n🔎 DEBUGGING SUMMARY BEFORE INSERT")
     pprint.pprint(summary)
+
+    # Log keys and ensure no Player objects remain at the top level
+    print("Summary top-level keys:", list(summary.keys()))
+    for k, v in summary.items():
+        if isinstance(v, Player):
+            raise TypeError(f"Summary key '{k}' contains a Player instance")
 
     try:
         print("🔍 About to insert summary into Mongo...")

--- a/BackEnd/models/player.py
+++ b/BackEnd/models/player.py
@@ -109,6 +109,19 @@ class Player:
     def set_coords(self, x, y):
         self.coords = {"x": x, "y": y}
 
+
+def player_to_dict(player):
+    """Return a minimal serializable representation of a Player."""
+    if player is None:
+        return None
+    team = getattr(player, "team", None)
+    team_name = getattr(team, "name", team)
+    return {
+        "player_id": getattr(player, "player_id", None),
+        "name": getattr(player, "name", None),
+        "team": team_name,
+    }
+
     
     
 

--- a/BackEnd/models/turn_manager.py
+++ b/BackEnd/models/turn_manager.py
@@ -5,7 +5,7 @@ from BackEnd.models.animator import Animator
 import random
 import json
 from BackEnd.db import players_collection, teams_collection
-from BackEnd.models.player import Player
+from BackEnd.models.player import Player, player_to_dict
 from collections import defaultdict
 from BackEnd.playcall_skeletons.inside_skeletons import INSIDE_SCENES
 from BackEnd.constants import ACTIONS
@@ -143,6 +143,16 @@ class TurnManager:
         # Increment micro turn counter
         self.game.micro_turn_count += 1
 
+        def convert_players(obj):
+            """Recursively replace Player objects with serializable dicts."""
+            if isinstance(obj, Player):
+                return player_to_dict(obj)
+            if isinstance(obj, list):
+                return [convert_players(x) for x in obj]
+            if isinstance(obj, dict):
+                return {k: convert_players(v) for k, v in obj.items()}
+            return obj
+
         # Snapshot player stats to compute deltas after the turn
         pre_stats = {}
         for team in (self.game.home_team, self.game.away_team):
@@ -199,9 +209,10 @@ class TurnManager:
                 )
             else:
                 result["animations"] = []  # No animation possible (e.g., free throw or turnover with no roles)
-
-
         result["possession_team_id"] = self.game.offense_team.team_id
+
+        if "roles" in result:
+            result["roles"] = convert_players(result["roles"])
 
         for key in [
             "ball_handler",
@@ -267,6 +278,8 @@ class TurnManager:
         result["clock"] = self.game.game_state["clock"]
         result["quarter"] = self.game.game_state["quarter"]
         result["period_label"] = self.game.game_state.get("period_label")
+        # Ensure no Player objects remain in the result payload
+        result = convert_players(result)
 
         print(f"inside run_micro_turn result: {result}")
         # print(f"result: {result}")


### PR DESCRIPTION
## Summary
- add `player_to_dict` helper to serialize player metadata
- sanitize `TurnManager.run_micro_turn` results using the helper
- verify summary payload before database insertion in API simulate function

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5eb238a288328943c4db433cacf0b