### PR TITLE
Add debugging flags for team setup and serialization

### DIFF
--- a/BackEnd/models/player.py
+++ b/BackEnd/models/player.py
@@ -2,6 +2,10 @@
 
 from BackEnd.constants import ALL_ATTRS, BOX_SCORE_KEYS, MALLEABLE_ATTRS
 import uuid
+import os
+
+
+DEBUG_SERIALIZATION = os.getenv("DEBUG_SERIALIZATION")
 
 
 class Player:
@@ -116,11 +120,14 @@ def player_to_dict(player):
         return None
     team = getattr(player, "team", None)
     team_name = getattr(team, "name", team)
-    return {
+    data = {
         "player_id": getattr(player, "player_id", None),
         "name": getattr(player, "name", None),
         "team": team_name,
     }
+    if DEBUG_SERIALIZATION:
+        print(f"[DEBUG_SERIALIZATION] player_to_dict keys: {list(data.keys())}")
+    return data
 
     
     

--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -4,8 +4,18 @@ import { setCourtOffsets } from './utils/gridToPixels.js';
 import { on, emit } from './utils/eventBus.js';
 import { finalizeGame } from './finalizeGame.js';
 
-const DEBUG_GAME_ID = window.DEBUG_GAME_ID || false;
-const DEBUG_TEAMS = window.DEBUG_TEAMS || false;
+const DEBUG_GAME_ID =
+  (typeof window !== 'undefined' && window.DEBUG_GAME_ID) ||
+  (typeof process !== 'undefined' && process.env.DEBUG_GAME_ID) ||
+  false;
+const DEBUG_TEAMS =
+  (typeof window !== 'undefined' && window.DEBUG_TEAMS) ||
+  (typeof process !== 'undefined' && process.env.DEBUG_TEAMS) ||
+  false;
+const DEBUG_SERIALIZATION =
+  (typeof window !== 'undefined' && window.DEBUG_SERIALIZATION) ||
+  (typeof process !== 'undefined' && process.env.DEBUG_SERIALIZATION) ||
+  false;
 
 if (typeof window !== 'undefined') {
   window.TEXT_SCROLL_ENABLED =

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -5,8 +5,18 @@ import { finalizeGame } from './finalizeGame.js';
 import { emit } from './utils/eventBus.js';
 import { appendToTextScroll } from './utils/textScroll.js';
 
-const DEBUG_SIM_PAYLOAD = window.DEBUG_SIM_PAYLOAD || false;
-const DEBUG_TEAMS = window.DEBUG_TEAMS || false;
+const DEBUG_SIM_PAYLOAD =
+  (typeof window !== 'undefined' && window.DEBUG_SIM_PAYLOAD) ||
+  (typeof process !== 'undefined' && process.env.DEBUG_SIM_PAYLOAD) ||
+  false;
+const DEBUG_TEAMS =
+  (typeof window !== 'undefined' && window.DEBUG_TEAMS) ||
+  (typeof process !== 'undefined' && process.env.DEBUG_TEAMS) ||
+  false;
+const DEBUG_SERIALIZATION =
+  (typeof window !== 'undefined' && window.DEBUG_SERIALIZATION) ||
+  (typeof process !== 'undefined' && process.env.DEBUG_SERIALIZATION) ||
+  false;
 
 export function createGameScene(Phaser) {
   return class GameScene extends Phaser.Scene {
@@ -117,6 +127,16 @@ export function createGameScene(Phaser) {
       console.log("📦 simData received:", simData);
       const logHome = simData.homeTeam?.name || simData.home_team;
       const logAway = simData.awayTeam?.name || simData.away_team;
+      const homeId = simData.home_team_id || simData.homeTeam?.team_id;
+      const awayId = simData.away_team_id || simData.awayTeam?.team_id;
+      if (DEBUG_TEAMS) {
+        console.log('Resolved team IDs:', { home_team_id: homeId, away_team_id: awayId });
+        console.log('Team colors from simData:', {
+          mode: this.mode,
+          home: simData.home_team_colors,
+          away: simData.away_team_colors,
+        });
+      }
       this.gameId = simData.game_id || this.gameId;
       if (this.gameId && typeof localStorage !== 'undefined') {
         localStorage.setItem('game_id', this.gameId);
@@ -425,6 +445,9 @@ export function createGameScene(Phaser) {
           }, Phaser);
 
           const spriteKeys = Object.keys(this.playerSprites || {});
+          if (DEBUG_TEAMS) {
+            console.log('playerSprites keys:', spriteKeys);
+          }
           const turnIds = Array.from(new Set((simData.turns || []).flatMap(t => {
             const ids = [];
             if (t.playerId) ids.push(t.playerId);
@@ -437,7 +460,6 @@ export function createGameScene(Phaser) {
             }
             return ids;
           })));
-          console.log('playerSprites keys:', spriteKeys);
           console.log('IDs in turns:', turnIds);
 
           if (DEBUG_TEAMS) {


### PR DESCRIPTION
## Summary
- Add env/window-based DEBUG flags for game boot and scene logic
- Log resolved team IDs, team colors, and sprite map keys during scene creation
- Emit serialized player key logs when DEBUG_SERIALIZATION is enabled

## Testing
- `pytest`
- `node --input-type=module tests/js/verifyColors.mjs` *(manual script to check logs)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ed092c6083289b0624700a6bd84d