### PR TITLE
feat: add debug flow logging and safe turn filtering

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animateGameTurns.js
+++ b/FrontEnd/static/js/phaser/animation/animateGameTurns.js
@@ -5,6 +5,11 @@ import animationConfig from "./animation_config.js";
 import runFreeThrowSequence from "./freeThrow.js";
 import runFastBreakSequence from "./fastBreak.js";
 
+const DEBUG_FLOW =
+  (typeof window !== 'undefined' && window.DEBUG_FLOW) ||
+  (typeof process !== 'undefined' && process.env.DEBUG_FLOW) ||
+  false;
+
 /**
  * Animate all turns from simData.turns using real backend structure.
  */
@@ -17,6 +22,16 @@ export async function animateGameTurns({ //hasBallAtStep
 }) {
   const turns = simData.turns || [];
   const allPlayers = simData.players || [];
+  if (DEBUG_FLOW) {
+    const stepCount = turns.reduce((acc, t) => {
+      const turnSteps = (t.animations || []).reduce(
+        (sum, a) => sum + (a.movement?.length || 0),
+        0
+      );
+      return acc + turnSteps;
+    }, 0);
+    console.log(`🟢 animateGameTurns start: ${turns.length} turns, ${stepCount} steps`);
+  }
 
   const handlePossessionFlip = (payload = {}) => {
     if (scene.fastBreakInProgress) return;
@@ -34,7 +49,7 @@ export async function animateGameTurns({ //hasBallAtStep
     const turn = turns[i];
     turn.index = i;
     if (scene.skipToEnd) break;
-    console.log(`🔁 Turn ${i + 1}`, turn);
+    if (DEBUG_FLOW) console.log(`🔁 Turn ${i + 1}`, turn);
 
     if (turn.result_type === "FREE_THROW") {
       await runFreeThrowSequence(scene, { playerSprites, ballSprite, turnData: turn, onUpdate });
@@ -90,7 +105,7 @@ export async function animateGameTurns({ //hasBallAtStep
       turnData: turn,
       ballSprite,
       onAction: async (action, sprite, timestamp) => {
-        console.log(`🎬 Action "${action}" fired at ${timestamp}ms for sprite:`, sprite);
+        if (DEBUG_FLOW) console.log(`🎬 Action "${action}" fired at ${timestamp}ms for sprite:`, sprite);
         onAction(action, sprite, timestamp);
 
         const playerId = Object.keys(playerSprites).find(
@@ -117,7 +132,7 @@ export async function animateGameTurns({ //hasBallAtStep
           );
 
           if (passStep && receiveStep && receiverAnim?.playerId != null) {
-            console.log("📤 Pass triggered");
+            if (DEBUG_FLOW) console.log("📤 Pass triggered");
             const receiverSprite = playerSprites[receiverAnim.playerId];
             const endCoords = receiverSprite
               ? { x: receiverSprite.x, y: receiverSprite.y }
@@ -125,18 +140,20 @@ export async function animateGameTurns({ //hasBallAtStep
 
             const delta = receiveStep.timestamp - timestamp;
             const duration = delta > 0 ? delta : animationConfig.pass.duration;
-            console.log(`⏱️ Resolved pass duration: ${duration}ms (delta=${delta})`);
+            if (DEBUG_FLOW) console.log(`⏱️ Resolved pass duration: ${duration}ms (delta=${delta})`);
 
-            scene.events?.once('passStart', () => console.log('passStart'));
-            scene.events?.once('tweenStart', () => console.log('tweenStart'));
-            scene.events?.once('tweenEnd', () => console.log('tweenEnd'));
-            scene.events?.once('ballAttached', () => console.log('ballAttached'));
-            scene.events?.once('passEnd', () => console.log('passEnd'));
+            if (DEBUG_FLOW) {
+              scene.events?.once('passStart', () => console.log('passStart'));
+              scene.events?.once('tweenStart', () => console.log('tweenStart'));
+              scene.events?.once('tweenEnd', () => console.log('tweenEnd'));
+              scene.events?.once('ballAttached', () => console.log('ballAttached'));
+              scene.events?.once('passEnd', () => console.log('passEnd'));
+            }
 
             if (scene.__activePass) {
-              console.warn(
-                'Active pass tween detected before runPass call; cancelling previous tween'
-              );
+          console.warn(
+            'Active pass tween detected before runPass call; cancelling previous tween'
+          );
             }
 
             await runPass(scene, {
@@ -168,7 +185,7 @@ export async function animateGameTurns({ //hasBallAtStep
       if (ballHandlerId != null && stealerId != null) {
         const cfg = animationConfig.steal || {};
         if (scene.__activePass) {
-          console.warn('Active pass tween detected before steal; cancelling previous tween');
+            console.warn('Active pass tween detected before steal; cancelling previous tween');
         }
         await runPass(scene, {
           fromId: ballHandlerId,
@@ -202,6 +219,9 @@ export async function animateGameTurns({ //hasBallAtStep
         }
       }
       break;
+    }
+    if (DEBUG_FLOW && i === turns.length - 1) {
+      console.log('🔚 animateGameTurns last turn complete');
     }
   }
 

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -17,6 +17,10 @@ const DEBUG_SERIALIZATION =
   (typeof window !== 'undefined' && window.DEBUG_SERIALIZATION) ||
   (typeof process !== 'undefined' && process.env.DEBUG_SERIALIZATION) ||
   false;
+const DEBUG_FLOW =
+  (typeof window !== 'undefined' && window.DEBUG_FLOW) ||
+  (typeof process !== 'undefined' && process.env.DEBUG_FLOW) ||
+  false;
 
 export function createGameScene(Phaser) {
   return class GameScene extends Phaser.Scene {
@@ -44,20 +48,22 @@ export function createGameScene(Phaser) {
         }
         this.quarter = data.quarter || 1;
 
-        console.log("🧠 Game initialized with:", {
-          rosters: this.rosters,
-          tournamentId: this.tournamentId,
-          franchiseId: this.franchiseId,
-          homeTeam: this.homeTeam,
-          awayTeam: this.awayTeam,
-          mode: this.mode,
-          periodLabel: this.periodLabel,
-        });
+        if (DEBUG_FLOW) {
+          console.log("🧠 Game initialized with:", {
+            rosters: this.rosters,
+            tournamentId: this.tournamentId,
+            franchiseId: this.franchiseId,
+            homeTeam: this.homeTeam,
+            awayTeam: this.awayTeam,
+            mode: this.mode,
+            periodLabel: this.periodLabel,
+          });
+        }
       }
-      
+
 
     async preload() {
-      console.log("✅ GameScene preloaded");
+      if (DEBUG_FLOW) console.log("✅ GameScene preloaded");
       if (this.animate) {
         this.load.image("ball", "/static/images/ball.png");
         const normalizeTeamName = (name) => name.toLowerCase().replace(/[\s\-]/g, '_');
@@ -68,7 +74,7 @@ export function createGameScene(Phaser) {
     }
 
     async create() {
-      console.log("🎬 GameScene created");
+      if (DEBUG_FLOW) console.log("🎬 GameScene created");
 
       const homeStatsEl = document.getElementById('home-stats-body');
       const awayStatsEl = document.getElementById('away-stats-body');
@@ -134,7 +140,11 @@ export function createGameScene(Phaser) {
       }
 
       const simData = await res.json();
-      console.log("📦 simData received:", simData);
+      if (DEBUG_FLOW) {
+        console.log("📦 simData received:", simData);
+        const turnsLen = Array.isArray(simData.turns) ? simData.turns.length : 0;
+        console.log('🔄 Sim response arrived', { turns: turnsLen });
+      }
       const logHome = simData.homeTeam?.name || simData.home_team;
       const logAway = simData.awayTeam?.name || simData.away_team;
       const homeId = simData.home_team_id || simData.homeTeam?.team_id;
@@ -152,10 +162,12 @@ export function createGameScene(Phaser) {
         localStorage.setItem('game_id', this.gameId);
       }
       this.isFinal = simData.is_final;
-      console.log(
-        `✅ Simulated matchup: ${logHome} vs ${logAway}`
-      );
-      console.log("📦 First turn:", simData.turns?.[0]);
+      if (DEBUG_FLOW) {
+        console.log(
+          `✅ Simulated matchup: ${logHome} vs ${logAway}`
+        );
+        console.log("📦 First turn:", simData.turns?.[0]);
+      }
 
       const homeLogoEl = document.getElementById('home-logo');
       const awayLogoEl = document.getElementById('away-logo');
@@ -472,7 +484,7 @@ export function createGameScene(Phaser) {
             }
             return ids;
           })));
-          console.log('IDs in turns:', turnIds);
+          if (DEBUG_FLOW) console.log('IDs in turns:', turnIds);
 
           if (DEBUG_TEAMS) {
             simData.players.forEach(p => {
@@ -491,10 +503,24 @@ export function createGameScene(Phaser) {
             ease: 'Sine.easeInOut'
           });
 
-          const quarterTurns = (simData.turns || []).filter(
-            t => t.quarter === this.quarter
-          );
+          const quarterTurns = (simData.turns || []).filter(t => {
+            const turnQ = t.quarter != null ? Number(t.quarter) : this.quarter;
+            return turnQ === this.quarter;
+          });
+          if (DEBUG_FLOW) {
+            console.log('🔢 quarterTurns length', quarterTurns.length);
+          }
+          if (quarterTurns.length === 0) {
+            const total = Array.isArray(simData.turns) ? simData.turns.length : 0;
+            console.warn(`⚠️ No turns found for quarter ${this.quarter} (total turns: ${total}). Navigation halted.`);
+            return;
+          }
 
+          let animStart;
+          if (DEBUG_FLOW) {
+            animStart = Date.now();
+            console.log('🚀 animateGameTurns start', animStart);
+          }
           await animateGameTurns({
             scene: this,
             simData: { ...simData, turns: quarterTurns },
@@ -502,8 +528,20 @@ export function createGameScene(Phaser) {
             ballSprite: this.ballSprite,
             onUpdate: updateScoreboard
           });
+          if (DEBUG_FLOW) {
+            const animEnd = Date.now();
+            console.log('🏁 animateGameTurns finish', animEnd, 'duration', animEnd - animStart);
+          }
 
-          console.log("✅ GameScene animation complete");
+          if (DEBUG_FLOW) {
+            console.log('🧭 Navigation condition', {
+              isFinal: this.isFinal,
+              quarter: this.quarter,
+              turnCount: quarterTurns.length
+            });
+          }
+
+          if (DEBUG_FLOW) console.log("✅ GameScene animation complete");
           if (this.isFinal) {
             await finalize();
           } else {


### PR DESCRIPTION
## Summary
- normalize turn quarter and warn when missing to avoid bad navigation
- add DEBUG_FLOW diagnostics for sim responses, animation timing, and navigation decisions
- trace turn and step counts inside animateGameTurns and mark last-turn completion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6164efbe883288979f662fdbbcb25