### PR TITLE
Add debug logging for turn step durations and backend timestamps

### DIFF
--- a/BackEnd/models/animator.py
+++ b/BackEnd/models/animator.py
@@ -17,6 +17,12 @@ class Animator:
         self.game = game
         self.latest_packet = []
 
+    def _log_step_timestamps(self, animations):
+        for anim in animations:
+            movement = anim.get("movement", [])
+            timestamps = [step.get("timestamp") for step in movement]
+            logging.debug("Animator timestamps for %s: %s", anim.get("playerId"), timestamps)
+
     def capture_fast_break_animation(
         self,
         fb_roles,
@@ -121,7 +127,7 @@ class Animator:
         ]
         for o in non_bh_offense:
             build_movement(o, half_court_spot())
-
+        self._log_step_timestamps(animations)
         self.latest_packet = animations
         return animations
 
@@ -293,7 +299,7 @@ class Animator:
                 "duration": time,
             }
         )
-
+        self._log_step_timestamps(animations)
         self.latest_packet = animations
         return animations
 
@@ -571,6 +577,7 @@ class Animator:
         #     })
 
 
+        self._log_step_timestamps(animations)
         self.latest_packet = animations
         logging.debug("Generated %d animations", len(animations))
 

--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -16,6 +16,10 @@ import { HOME_RIM_COORDS, AWAY_RIM_COORDS, HOME_TOP_KEY, AWAY_TOP_KEY } from "./
 // Cap the time spent on any single movement step. Large timestamp gaps can
 // otherwise produce multi‑second tweens that appear as animation stalls.
 const MAX_STEP_DURATION = 1000; // ms
+const DEBUG =
+  (typeof window !== 'undefined' && window.DEBUG) ||
+  (typeof process !== 'undefined' && process.env.DEBUG) ||
+  false;
 
 
 /**
@@ -949,17 +953,28 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
 
       const prev = movement[stepIndex - 1];
       const curr = movement[stepIndex];
-      const rawDuration = (curr.timestamp - prev.timestamp) * 3;
+      const step = prev;
+      const nextStep = curr;
+      const rawDuration = (nextStep.timestamp - step.timestamp) * 3;
       const duration = Math.min(MAX_STEP_DURATION, rawDuration);
 
-      if (curr.action === "shoot") {
-        shotInfo = { step: curr, playerId: anim.playerId, stepIndex };
+      DEBUG && console.log('[turn]', turnData?.id, step.timestamp, nextStep.timestamp, duration);
+      if (duration <= 0) {
+        console.warn('[turn] Non-positive duration', { turnId: turnData?.id, step, nextStep });
+        if (typeof window !== 'undefined') {
+          window.__badStepPayloads = window.__badStepPayloads || [];
+          window.__badStepPayloads.push({ turnId: turnData?.id, step, nextStep });
+        }
+      }
+
+      if (nextStep.action === "shoot") {
+        shotInfo = { step: nextStep, playerId: anim.playerId, stepIndex };
       }
 
       const promise = animateStep({
         scene,
         sprite,
-        step: curr,
+        step: nextStep,
         duration,
         ballSprite,
         currentBallOwnerRef,


### PR DESCRIPTION
## Summary
- log per-step turn durations and warn when non-positive
- stash invalid step payloads for analysis
- instrument backend Animator to log step timestamps when generating animations

## Testing
- `node tests/js/runPlayTurnAnimation.mjs` *(fails: ERR_UNSUPPORTED_ESM_URL_SCHEME)*
- `node tests/js/runReboundAnimation.mjs` *(fails: ERR_UNSUPPORTED_ESM_URL_SCHEME)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b61b1cdda08328b8479dba5a2126b7