### PR TITLE
Add debugging for turn animations

### DIFF
--- a/BackEnd/api/api.py
+++ b/BackEnd/api/api.py
@@ -34,6 +34,8 @@ from typing import Optional
 import logging
 from BackEnd.models.player import Player
 
+logger = logging.getLogger(__name__)
+
 app = FastAPI()
 app.include_router(tournament_router)
 app.include_router(training_router)
@@ -319,7 +321,12 @@ def simulate_quarter_endpoint(request: QuarterSimulationRequest):
         # Scrimmage simulations should not generate aggregate stats.
         # Finalizing with ``mode="scrimmage"`` is a no-op but documents intent.
         stat_updater.finalize_game(game_id, mode="scrimmage")
-
+    turns = summary.get("turns", [])
+    logger.debug(
+        "simulate_quarter_endpoint turns len=%s first=%s",
+        len(turns),
+        turns[0] if turns else None,
+    )
     return summary
 
 

--- a/BackEnd/models/animator.py
+++ b/BackEnd/models/animator.py
@@ -123,6 +123,11 @@ class Animator:
             build_movement(o, half_court_spot())
 
         self.latest_packet = animations
+        logging.debug(
+            "capture_fast_break_animation generated %d animations first=%s",
+            len(animations),
+            animations[0] if animations else None,
+        )
         return animations
 
     def capture_free_throw_animation(
@@ -295,6 +300,11 @@ class Animator:
         )
 
         self.latest_packet = animations
+        logging.debug(
+            "capture_free_throw_animation generated %d animations first=%s",
+            len(animations),
+            animations[0] if animations else None,
+        )
         return animations
 
     def capture_halfcourt_animation(self, roles, event_step=None):
@@ -572,7 +582,11 @@ class Animator:
 
 
         self.latest_packet = animations
-        logging.debug("Generated %d animations", len(animations))
+        logging.debug(
+            "capture_halfcourt_animation generated %d animations first=%s",
+            len(animations),
+            animations[0] if animations else None,
+        )
 
         return animations
 

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -140,6 +140,7 @@ export function createGameScene(Phaser) {
       }
 
       const simData = await res.json();
+      DEBUG && console.log('[gameScene] simData.turns', simData.turns.length, simData.turns[0]);
       if (DEBUG_FLOW) {
         console.log("📦 simData received:", simData);
         const turnsLen = Array.isArray(simData.turns) ? simData.turns.length : 0;


### PR DESCRIPTION
## Summary
- log turn count and first turn from `simulate_quarter_endpoint`
- emit frontend debug for `simData.turns`
- trace animation generation in Animator methods

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b61b1cd91c8328b55b7ceaf4b47f69