### PR TITLE
Log game animation parameters and gate debug skip

### DIFF
--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -254,6 +254,7 @@ async function handleButtonClick(animate) {
       fetchTeamRoster(homeTeam),
       fetchTeamRoster(awayTeam),
     ]);
+    console.log('startGame animate:', animate);
     const finalScore = await startGame({ homeRoster, awayRoster, animate });
     showPopup(finalScore);
   } catch (err) {

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -21,6 +21,10 @@ const DEBUG_FLOW =
   (typeof window !== 'undefined' && window.DEBUG_FLOW) ||
   (typeof process !== 'undefined' && process.env.DEBUG_FLOW) ||
   false;
+const DEBUG_SKIP =
+  (typeof window !== 'undefined' && window.DEBUG_SKIP) ||
+  (typeof process !== 'undefined' && process.env.DEBUG_SKIP) ||
+  false;
 
 export function createGameScene(Phaser) {
   return class GameScene extends Phaser.Scene {
@@ -437,7 +441,7 @@ export function createGameScene(Phaser) {
           }
         });
       }
-      if (skipBtn) {
+      if (skipBtn && DEBUG_SKIP) {
         skipBtn.addEventListener('click', async () => {
           if (this.isSkipping) return;
           this.skipToEnd = true;
@@ -550,9 +554,15 @@ export function createGameScene(Phaser) {
             params.set('game_id', this.gameId);
             params.set('quarter', nextQ);
             params.set('period', `Q${nextQ}`);
+            console.log('skipToEnd at navigation:', this.skipToEnd);
             window.location.href = `/static/set-lineup.html?${params.toString()}`;
             return;
           }
+        };
+
+        const logAndStart = () => {
+          console.log('skipToEnd before startAnimation:', this.skipToEnd);
+          startAnimation();
         };
 
         if (this.textures.exists(courtKey)) {
@@ -560,14 +570,14 @@ export function createGameScene(Phaser) {
               .setOrigin(0)
               .setDisplaySize(this.game.config.width, this.game.config.height)
               .setDepth(0);
-          startAnimation();
+          logAndStart();
         } else {
           this.load.once("complete", () => {
               this.add.image(0, 0, courtKey)
               .setOrigin(0)
               .setDisplaySize(this.game.config.width, this.game.config.height)
               .setDepth(0);
-              startAnimation();
+              logAndStart();
           });
           this.load.start();
         }
@@ -580,6 +590,7 @@ export function createGameScene(Phaser) {
           params.set('game_id', this.gameId);
           params.set('quarter', nextQ);
           params.set('period', `Q${nextQ}`);
+          console.log('skipToEnd at navigation:', this.skipToEnd);
           window.location.href = `/static/set-lineup.html?${params.toString()}`;
         }
       }


### PR DESCRIPTION
## Summary
- log animate flag when starting a game
- add DEBUG_SKIP gate around skip-to-end logic
- trace skipToEnd status before animations begin and upon navigation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b61b1be08083289b33b2cbbd1315a6