### PR TITLE
Log quarter transitions in game startup

### DIFF
--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -16,6 +16,10 @@ const DEBUG_SERIALIZATION =
   (typeof window !== 'undefined' && window.DEBUG_SERIALIZATION) ||
   (typeof process !== 'undefined' && process.env.DEBUG_SERIALIZATION) ||
   false;
+const DEBUG =
+  (typeof window !== 'undefined' && window.DEBUG) ||
+  (typeof process !== 'undefined' && process.env.DEBUG) ||
+  false;
 
 if (typeof window !== 'undefined') {
   window.TEXT_SCROLL_ENABLED =
@@ -164,6 +168,7 @@ async function fetchTeamRoster(teamName) {
 }
 
 async function startGame({ homeRoster, awayRoster, animate = true }) {
+  DEBUG && console.log('[bootGame] startGame', { quarter, animate });
   if (!game) {
     game = new Phaser.Game({
       type: Phaser.AUTO,

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -145,6 +145,7 @@ export function createGameScene(Phaser) {
         const turnsLen = Array.isArray(simData.turns) ? simData.turns.length : 0;
         console.log('🔄 Sim response arrived', { turns: turnsLen });
       }
+      DEBUG_FLOW && console.log('[gameScene] quarters', { requested: this.quarter, sim: simData.quarter });
       const logHome = simData.homeTeam?.name || simData.home_team;
       const logAway = simData.awayTeam?.name || simData.away_team;
       const homeId = simData.home_team_id || simData.homeTeam?.team_id;

--- a/FrontEnd/static/set-lineup.js
+++ b/FrontEnd/static/set-lineup.js
@@ -231,6 +231,7 @@ async function init() {
       if (DEBUG) {
         console.debug('🔀 Redirecting to court.html', { home: homeTeam, away: awayTeam, gameId });
       }
+      DEBUG && console.log('[lineup] launching quarter', quarter);
       window.location.href = `/court.html?${params.toString()}`;
     });
   }


### PR DESCRIPTION
## Summary
- log quarter before redirecting from lineup screen
- report quarter and animation flag when booting game
- show requested vs simulated quarter in game scene create

## Testing
- `pytest -q`
- `python run_quarter.py > quarter.log 2>&1` *(Q1 succeeded, Q2 returned 500: KeyError 'stats')*

------
https://chatgpt.com/codex/tasks/task_e_68b61b0892c4832884cb06e304d309b2