### PR TITLE
Preserve debug state through set-lineup redirect

### DIFF
--- a/FrontEnd/static/set-lineup.js
+++ b/FrontEnd/static/set-lineup.js
@@ -229,6 +229,10 @@ async function init() {
         if (id) params.set(`${myTeamSide}_${pos.toLowerCase()}`, id);
       });
       if (DEBUG) {
+        params.set('debug', '1');
+        // optional: params.set('debug_flow', '1');
+      }
+      if (DEBUG) {
         console.debug('🔀 Redirecting to court.html', { home: homeTeam, away: awayTeam, gameId });
       }
       DEBUG && console.log('[lineup] launching quarter', quarter);


### PR DESCRIPTION
## Summary
- Ensure debug mode persists when redirecting from set-lineup to court

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b63d6754c08328b2e031bb915ee055