### PR TITLE
Generate new game ID for new matchups

### DIFF
--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -81,19 +81,9 @@ if (weekParam && !Number.isNaN(weekParam) && typeof localStorage !== 'undefined'
 }
 const mode = urlParams.get('mode') || getMode({ tournamentId, franchiseId });
 let quarter = parseInt(urlParams.get('quarter'), 10) || 1;
-let gameId = null;
-if (quarter > 1) {
-  gameId =
-    urlParams.get('game_id') ||
-    (typeof localStorage !== 'undefined'
-      ? localStorage.getItem('game_id')
-      : null);
-} else if (
-  typeof localStorage !== 'undefined' &&
-  typeof localStorage.removeItem === 'function'
-) {
-  localStorage.removeItem('game_id');
-}
+let gameId =
+  urlParams.get('game_id') ||
+  (typeof localStorage !== 'undefined' ? localStorage.getItem('game_id') : null);
 let periodLabel = urlParams.get('period') || `Q${quarter}`;
 
 const homeLineup = {};

--- a/FrontEnd/static/set-lineup.js
+++ b/FrontEnd/static/set-lineup.js
@@ -11,20 +11,36 @@ const tournamentId = urlParams.get('tournament_id');
 const modeParam = urlParams.get('mode');
 const DEBUG = urlParams.has('debug');
 const quarter = parseInt(urlParams.get('quarter'), 10) || 1;
-const gameId =
-  quarter > 1 ? urlParams.get('game_id') || localStorage.getItem('game_id') : null;
-if (quarter === 1 && typeof localStorage !== 'undefined') {
-  localStorage.removeItem('game_id');
-}
-const periodLabel = urlParams.get('period') || `Q${quarter}`;
-
-if ((quarter > 1 || urlParams.has('game_id')) &&
-    typeof history !== 'undefined' && history.replaceState) {
+let gameId = urlParams.get('game_id') ||
+  (typeof localStorage !== 'undefined' ? localStorage.getItem('game_id') : null);
+const storedHome = typeof localStorage !== 'undefined' ? localStorage.getItem('game_home') : null;
+const storedAway = typeof localStorage !== 'undefined' ? localStorage.getItem('game_away') : null;
+const isNewMatchup = !urlParams.get('game_id') || storedHome !== homeTeam || storedAway !== awayTeam;
+if (isNewMatchup) {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    gameId = crypto.randomUUID();
+  } else {
+    gameId = Math.random().toString(36).slice(2);
+  }
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem('game_id', gameId);
+    localStorage.setItem('game_home', homeTeam || '');
+    localStorage.setItem('game_away', awayTeam || '');
+  }
+  if (typeof history !== 'undefined' && history.replaceState) {
+    const clean = new URLSearchParams(urlParams);
+    ['quarter', 'period', 'game_id'].forEach(k => clean.delete(k));
+    const qs = clean.toString();
+    history.replaceState(null, '', `${window.location.pathname}${qs ? `?${qs}` : ''}`);
+  }
+} else if ((quarter > 1 || urlParams.has('game_id')) &&
+           typeof history !== 'undefined' && history.replaceState) {
   const clean = new URLSearchParams(urlParams);
   ['quarter', 'period', 'game_id'].forEach(k => clean.delete(k));
   const qs = clean.toString();
   history.replaceState(null, '', `${window.location.pathname}${qs ? `?${qs}` : ''}`);
 }
+const periodLabel = urlParams.get('period') || `Q${quarter}`;
 let teamName = '';
 
 let roster = [];
@@ -222,8 +238,9 @@ async function init() {
       if (weekParam) params.set('week', weekParam);
       if (tournamentId) params.set('tournament_id', tournamentId);
       if (modeParam) params.set('mode', modeParam);
-      params.set('quarter', '1');
-      params.set('period', 'Q1');
+      params.set('quarter', String(quarter));
+      params.set('period', periodLabel);
+      if (quarter > 1 && gameId) params.set('game_id', gameId);
       ['PG','SG','SF','PF','C'].forEach(pos => {
         const id = lineup[pos];
         if (id) params.set(`${myTeamSide}_${pos.toLowerCase()}`, id);

--- a/tests/test_simulate_quarter_endpoint.py
+++ b/tests/test_simulate_quarter_endpoint.py
@@ -132,3 +132,44 @@ def test_simulate_quarter_unknown_id_quarter1(monkeypatch):
     summary = api.simulate_quarter_endpoint(request)
     assert summary["game_id"] != "unknown"
     assert summary["quarter"] == 1
+
+
+def test_simulate_quarter_sequential_game_id(monkeypatch):
+    class DummyTeam:
+        def __init__(self, name: str):
+            self.name = name
+            self.points_by_quarter = [0, 0, 0, 0]
+
+    class DummyGM:
+        def __init__(self, home: str, away: str):
+            self.home_team = DummyTeam(home)
+            self.away_team = DummyTeam(away)
+            self.quarter = 1
+            self.game_state = {"start_box_score": {}, "score": {home: 0, away: 0}}
+            self.score = self.game_state["score"]
+
+    def fake_simulate_quarter(gm, home_lineup, away_lineup, game_id):
+        gm.quarter += 1
+
+    def fake_summarize_game_state(gm):
+        return {"score": gm.score}
+
+    monkeypatch.setattr(api, "GameManager", DummyGM)
+    monkeypatch.setattr(api, "simulate_quarter", fake_simulate_quarter)
+    monkeypatch.setattr(api, "summarize_game_state", fake_summarize_game_state)
+
+    api.ongoing_games.clear()
+
+    res1 = client.post(
+        "/api/simulate-quarter", json={"home_team": "Home", "away_team": "Away"}
+    )
+    assert res1.status_code == 200
+    gid = res1.json()["game_id"]
+
+    res2 = client.post(
+        "/api/simulate-quarter",
+        json={"home_team": "Home", "away_team": "Away", "quarter": 2, "game_id": gid},
+    )
+    assert res2.status_code == 200
+    data2 = res2.json()
+    assert data2["game_id"] == gid


### PR DESCRIPTION
## Summary
- Generate a fresh UUID whenever starting a new matchup and keep it in localStorage with the participating teams
- Only persist and send the game ID for later quarters while cleaning stale IDs from redirects
- Ensure BootGame reads stored IDs even in the first quarter and add a test verifying quarter 2 requests include the correct game ID

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b64180d3288328aca673745a7ac17f