### PR TITLE
validate teams for simulate_quarter endpoint

### DIFF
--- a/BackEnd/api/api.py
+++ b/BackEnd/api/api.py
@@ -185,6 +185,22 @@ def simulate_quarter_endpoint(request: QuarterSimulationRequest):
     source = "resume"
     if game_id:
         gm = ongoing_games.get(game_id)
+        if gm is not None and (
+            request.home_team != gm.home_team.name
+            or request.away_team != gm.away_team.name
+        ):
+            logging.debug(
+                "simulate_quarter_endpoint team mismatch: game_id=%s expected=%s vs %s got=%s vs %s",
+                game_id,
+                gm.home_team.name,
+                gm.away_team.name,
+                request.home_team,
+                request.away_team,
+            )
+            raise HTTPException(
+                status_code=400,
+                detail="game_id belongs to a different matchup",
+            )
         if gm is None:
             logging.warning(
                 "simulate_quarter_endpoint unknown game_id=%s; active=%s",

--- a/tests/test_simulate_quarter_endpoint.py
+++ b/tests/test_simulate_quarter_endpoint.py
@@ -173,3 +173,43 @@ def test_simulate_quarter_sequential_game_id(monkeypatch):
     assert res2.status_code == 200
     data2 = res2.json()
     assert data2["game_id"] == gid
+
+
+def test_simulate_quarter_mismatched_game_id(monkeypatch):
+    class DummyTeam:
+        def __init__(self, name: str):
+            self.name = name
+            self.points_by_quarter = [0, 0, 0, 0]
+
+    class DummyGM:
+        def __init__(self, home: str, away: str):
+            self.home_team = DummyTeam(home)
+            self.away_team = DummyTeam(away)
+            self.quarter = 1
+            self.game_state = {"start_box_score": {}, "score": {home: 0, away: 0}}
+            self.score = self.game_state["score"]
+
+    def fake_simulate_quarter(gm, home_lineup, away_lineup, game_id):
+        gm.quarter += 1
+
+    def fake_summarize_game_state(gm):
+        return {"score": gm.score}
+
+    monkeypatch.setattr(api, "GameManager", DummyGM)
+    monkeypatch.setattr(api, "simulate_quarter", fake_simulate_quarter)
+    monkeypatch.setattr(api, "summarize_game_state", fake_summarize_game_state)
+
+    api.ongoing_games.clear()
+
+    res1 = client.post(
+        "/api/simulate-quarter", json={"home_team": "Home", "away_team": "Away"}
+    )
+    assert res1.status_code == 200
+    gid = res1.json()["game_id"]
+
+    res2 = client.post(
+        "/api/simulate-quarter",
+        json={"home_team": "Different", "away_team": "Away", "quarter": 2, "game_id": gid},
+    )
+    assert res2.status_code == 400
+    assert res2.json()["detail"] == "game_id belongs to a different matchup"


### PR DESCRIPTION
## Summary
- ensure `/api/simulate-quarter` validates that the provided home/away teams match the existing game
- log mismatches and raise an HTTP 400 error when a `game_id` refers to different teams
- add regression test covering mismatched team scenario

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6446b449c832881f2eade8dcc3d3a