### PR TITLE
Fix quarter flow and game_id persistence

### DIFF
--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -232,7 +232,11 @@ function showPopup(score) {
 
 async function handleButtonClick(animate) {
   if (isSimulating) return;
-  resetGameContext();
+  const startingFresh = !gameId || quarter <= 1;
+  if (startingFresh) {
+    resetGameContext();
+  }
+  DEBUG && console.log('[handleButtonClick]', { startingFresh, quarter, gameId });
   isSimulating = true;
   const playBtn = document.querySelector('.play-button');
   const simFullBtn = document.querySelector('.sim-full-game-button');

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -556,6 +556,7 @@ export function createGameScene(Phaser) {
             params.set('game_id', this.gameId);
             params.set('quarter', nextQ);
             params.set('period', `Q${nextQ}`);
+            DEBUG_FLOW && console.log('➡️ Advancing to lineup', { nextQ, gameId: this.gameId });
             console.log('skipToEnd at navigation:', this.skipToEnd);
             window.location.href = `/static/set-lineup.html?${params.toString()}`;
             return;
@@ -592,6 +593,7 @@ export function createGameScene(Phaser) {
           params.set('game_id', this.gameId);
           params.set('quarter', nextQ);
           params.set('period', `Q${nextQ}`);
+          DEBUG_FLOW && console.log('➡️ Advancing to lineup', { nextQ, gameId: this.gameId });
           console.log('skipToEnd at navigation:', this.skipToEnd);
           window.location.href = `/static/set-lineup.html?${params.toString()}`;
         }


### PR DESCRIPTION
## Summary
- avoid resetting game context when simulating later quarters so the same `game_id` is reused
- add debugging log when advancing to next lineup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6ef949e8c83288f39dc15cabc0a2e