### PR TITLE
Support dynamic game IDs across quarters

### DIFF
--- a/BackEnd/api/api.py
+++ b/BackEnd/api/api.py
@@ -171,7 +171,7 @@ def simulate_game(request: SimulationRequest):
 
 
 @app.post("/api/simulate-quarter")
-def simulate_quarter_endpoint(request: QuarterSimulationRequest):
+def simulate_quarter_endpoint(request: QuarterSimulationRequest, debug: bool = False):
     game_id = request.game_id
     logging.info(
         "simulate_quarter_endpoint payload: game_id=%s, home_team=%s, away_team=%s, quarter=%s, home_lineup_keys=%s, away_lineup_keys=%s",
@@ -182,6 +182,16 @@ def simulate_quarter_endpoint(request: QuarterSimulationRequest):
         list((request.home_lineup or {}).keys()),
         list((request.away_lineup or {}).keys()),
     )
+    if debug:
+        logging.debug(
+            "simulate_quarter_endpoint request detail: %s",
+            {
+                "game_id": game_id,
+                "home_team": request.home_team,
+                "away_team": request.away_team,
+                "quarter": request.quarter,
+            },
+        )
     source = "resume"
     if game_id:
         gm = ongoing_games.get(game_id)
@@ -189,14 +199,15 @@ def simulate_quarter_endpoint(request: QuarterSimulationRequest):
             request.home_team != gm.home_team.name
             or request.away_team != gm.away_team.name
         ):
-            logging.debug(
-                "simulate_quarter_endpoint team mismatch: game_id=%s expected=%s vs %s got=%s vs %s",
-                game_id,
-                gm.home_team.name,
-                gm.away_team.name,
-                request.home_team,
-                request.away_team,
-            )
+            if debug:
+                logging.debug(
+                    "simulate_quarter_endpoint team mismatch: game_id=%s expected=%s vs %s got=%s vs %s",
+                    game_id,
+                    gm.home_team.name,
+                    gm.away_team.name,
+                    request.home_team,
+                    request.away_team,
+                )
             raise HTTPException(
                 status_code=400,
                 detail="game_id belongs to a different matchup",
@@ -231,6 +242,12 @@ def simulate_quarter_endpoint(request: QuarterSimulationRequest):
                         gm.game_state.update(saved.get("game_state", {}))
                         gm.quarter = saved.get("quarter", 1)
                         ongoing_games[game_id] = gm
+                        if debug:
+                            logging.debug(
+                                "simulate_quarter_endpoint loaded from DB: %s vs %s",
+                                home,
+                                away,
+                            )
                 except Exception:
                     logging.exception("Failed to load game state for %s", game_id)
             if gm is None:
@@ -240,12 +257,21 @@ def simulate_quarter_endpoint(request: QuarterSimulationRequest):
                     ongoing_games[game_id] = gm
                     source = "new"
                 else:
+                    if debug:
+                        logging.debug("simulate_quarter_endpoint unknown game_id=%s", game_id)
                     raise HTTPException(status_code=400, detail="Unknown game_id")
     else:
         gm = GameManager(request.home_team, request.away_team)
         game_id = str(uuid.uuid4())
         ongoing_games[game_id] = gm
         source = "new"
+    if debug and gm is not None:
+        logging.debug(
+            "simulate_quarter_endpoint using matchup: %s vs %s (quarter=%s)",
+            gm.home_team.name,
+            gm.away_team.name,
+            gm.quarter,
+        )
 
     logging.info(
         {
@@ -278,6 +304,13 @@ def simulate_quarter_endpoint(request: QuarterSimulationRequest):
 
     # Prevent skipping ahead or repeating quarters unintentionally
     if request.quarter != gm.quarter:
+        if debug:
+            logging.debug(
+                "simulate_quarter_endpoint quarter mismatch: game_id=%s expected=%s got=%s",
+                game_id,
+                gm.quarter,
+                request.quarter,
+            )
         raise HTTPException(
             status_code=400,
             detail=f"Quarter mismatch. Expected {gm.quarter}, got {request.quarter}",

--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -232,7 +232,10 @@ function showPopup(score) {
 
 async function handleButtonClick(animate) {
   if (isSimulating) return;
-  const startingFresh = !gameId || quarter <= 1;
+  if (!gameId && typeof localStorage !== 'undefined') {
+    gameId = localStorage.getItem('game_id');
+  }
+  const startingFresh = !gameId;
   if (startingFresh) {
     resetGameContext();
   }
@@ -270,7 +273,12 @@ async function handleButtonClick(animate) {
 
 async function handleSimToFourth() {
   if (isSimulating || quarter >= 4) return;
-  resetGameContext();
+  if (!gameId && typeof localStorage !== 'undefined') {
+    gameId = localStorage.getItem('game_id');
+  }
+  if (!gameId) {
+    resetGameContext();
+  }
   isSimulating = true;
   const playBtn = document.querySelector('.play-button');
   const simFullBtn = document.querySelector('.sim-full-game-button');
@@ -341,7 +349,12 @@ async function handleSimToFourth() {
 
 async function handleSimFullGame() {
   if (isSimulating) return;
-  resetGameContext();
+  if (!gameId && typeof localStorage !== 'undefined') {
+    gameId = localStorage.getItem('game_id');
+  }
+  if (!gameId) {
+    resetGameContext();
+  }
   isSimulating = true;
   const playBtn = document.querySelector('.play-button');
   const simFullBtn = document.querySelector('.sim-full-game-button');

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -103,6 +103,15 @@ export function createGameScene(Phaser) {
 
       const payload = { home_team: homeTeam, away_team: awayTeam, quarter: this.quarter };
       if (this.gameId) payload.game_id = this.gameId;
+      if (DEBUG_FLOW) {
+        console.log('[gameScene] request payload', {
+          mode: this.mode,
+          home: homeTeam,
+          away: awayTeam,
+          quarter: this.quarter,
+          gameId: this.gameId,
+        });
+      }
       if (DEBUG_TEAMS) {
         console.log('/api/simulate-quarter payload teams:', {
           home: payload.home_team,
@@ -120,6 +129,9 @@ export function createGameScene(Phaser) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload)
       });
+      if (DEBUG_FLOW) {
+        console.log('[gameScene] response status', res.status);
+      }
       if (!this.constructor._loggedSimQuarter) {
         console.debug("🛠️ /api/simulate-quarter payload keys:", Object.keys(payload), "response status:", res.status);
         this.constructor._loggedSimQuarter = true;
@@ -552,19 +564,22 @@ export function createGameScene(Phaser) {
             await finalize();
           } else {
             const nextQ = this.quarter + 1;
-            const params = new URLSearchParams(window.location.search);
-            params.set('game_id', this.gameId);
-            params.set('quarter', nextQ);
-            params.set('period', `Q${nextQ}`);
-            DEBUG_FLOW && console.log('➡️ Advancing to lineup', { nextQ, gameId: this.gameId });
-            console.log('skipToEnd at navigation:', this.skipToEnd);
-            window.location.href = `/static/set-lineup.html?${params.toString()}`;
-            return;
+          const params = new URLSearchParams(window.location.search);
+          params.set('game_id', this.gameId);
+          params.set('quarter', nextQ);
+          params.set('period', `Q${nextQ}`);
+          if (this.gameId && typeof localStorage !== 'undefined') {
+            localStorage.setItem('game_id', this.gameId);
           }
-        };
+          DEBUG_FLOW && console.log('➡️ Advancing to lineup', { nextQ, gameId: this.gameId });
+          DEBUG_FLOW && console.log('skipToEnd at navigation:', this.skipToEnd);
+          window.location.href = `/static/set-lineup.html?${params.toString()}`;
+          return;
+        }
+      };
 
         const logAndStart = () => {
-          console.log('skipToEnd before startAnimation:', this.skipToEnd);
+          DEBUG_FLOW && console.log('skipToEnd before startAnimation:', this.skipToEnd);
           startAnimation();
         };
 
@@ -593,8 +608,11 @@ export function createGameScene(Phaser) {
           params.set('game_id', this.gameId);
           params.set('quarter', nextQ);
           params.set('period', `Q${nextQ}`);
+          if (this.gameId && typeof localStorage !== 'undefined') {
+            localStorage.setItem('game_id', this.gameId);
+          }
           DEBUG_FLOW && console.log('➡️ Advancing to lineup', { nextQ, gameId: this.gameId });
-          console.log('skipToEnd at navigation:', this.skipToEnd);
+          DEBUG_FLOW && console.log('skipToEnd at navigation:', this.skipToEnd);
           window.location.href = `/static/set-lineup.html?${params.toString()}`;
         }
       }

--- a/FrontEnd/static/set-lineup.js
+++ b/FrontEnd/static/set-lineup.js
@@ -17,13 +17,9 @@ const storedHome = typeof localStorage !== 'undefined' ? localStorage.getItem('g
 const storedAway = typeof localStorage !== 'undefined' ? localStorage.getItem('game_away') : null;
 const isNewMatchup = !urlParams.get('game_id') || storedHome !== homeTeam || storedAway !== awayTeam;
 if (isNewMatchup) {
-  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
-    gameId = crypto.randomUUID();
-  } else {
-    gameId = Math.random().toString(36).slice(2);
-  }
+  gameId = null;
   if (typeof localStorage !== 'undefined') {
-    localStorage.setItem('game_id', gameId);
+    localStorage.removeItem('game_id');
     localStorage.setItem('game_home', homeTeam || '');
     localStorage.setItem('game_away', awayTeam || '');
   }
@@ -227,6 +223,8 @@ async function init() {
   if (btn) {
     btn.addEventListener('click', () => {
       if (btn.classList.contains('disabled')) return;
+      const currentGameId = urlParams.get('game_id') ||
+        (typeof localStorage !== 'undefined' ? localStorage.getItem('game_id') : null);
       const params = new URLSearchParams();
       params.set('home', homeTeam);
       params.set('away', awayTeam);
@@ -240,7 +238,7 @@ async function init() {
       if (modeParam) params.set('mode', modeParam);
       params.set('quarter', String(quarter));
       params.set('period', periodLabel);
-      if (quarter > 1 && gameId) params.set('game_id', gameId);
+      if (quarter > 1 && currentGameId) params.set('game_id', currentGameId);
       ['PG','SG','SF','PF','C'].forEach(pos => {
         const id = lineup[pos];
         if (id) params.set(`${myTeamSide}_${pos.toLowerCase()}`, id);
@@ -250,7 +248,7 @@ async function init() {
         // optional: params.set('debug_flow', '1');
       }
       if (DEBUG) {
-        console.debug('🔀 Redirecting to court.html', { home: homeTeam, away: awayTeam, gameId });
+        console.debug('🔀 Redirecting to court.html', { home: homeTeam, away: awayTeam, gameId: currentGameId });
       }
       DEBUG && console.log('[lineup] launching quarter', quarter);
       window.location.href = `/court.html?${params.toString()}`;


### PR DESCRIPTION
## Summary
- avoid creating random game IDs on the lineup screen; clear stored ID for new matchups and read the current ID when launching later quarters
- only reset game context when no existing game ID and pass stored IDs into Phaser scenes
- add debug-controlled logging and persist returned game IDs before navigating between quarters
- add backend debug logs for simulate-quarter endpoint with optional `debug` flag

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b76447c95c8328bf400c4de442262b