### PR TITLE
feat: centralize Phaser debug flag

### DIFF
--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -12,14 +12,11 @@ import {
 import { tweenBallTo, runPass, PASS_DEBUG, tweenPlayerTo, detachBall } from "./ballTween.js";
 import animationConfig from "./animation_config.js";
 import { HOME_RIM_COORDS, AWAY_RIM_COORDS, HOME_TOP_KEY, AWAY_TOP_KEY } from "./courtConstants.js";
+import { DEBUG } from "../utils/debug.js";
 
 // Cap the time spent on any single movement step. Large timestamp gaps can
 // otherwise produce multi‑second tweens that appear as animation stalls.
 const MAX_STEP_DURATION = 1000; // ms
-const DEBUG =
-  (typeof window !== 'undefined' && window.DEBUG) ||
-  (typeof process !== 'undefined' && process.env.DEBUG) ||
-  false;
 
 
 /**

--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -3,6 +3,7 @@ import { createGameScene } from './gameScene.js';
 import { setCourtOffsets } from './utils/gridToPixels.js';
 import { on, emit } from './utils/eventBus.js';
 import { finalizeGame } from './finalizeGame.js';
+import { DEBUG } from './utils/debug.js';
 
 const DEBUG_GAME_ID =
   (typeof window !== 'undefined' && window.DEBUG_GAME_ID) ||
@@ -15,10 +16,6 @@ const DEBUG_TEAMS =
 const DEBUG_SERIALIZATION =
   (typeof window !== 'undefined' && window.DEBUG_SERIALIZATION) ||
   (typeof process !== 'undefined' && process.env.DEBUG_SERIALIZATION) ||
-  false;
-const DEBUG =
-  (typeof window !== 'undefined' && window.DEBUG) ||
-  (typeof process !== 'undefined' && process.env.DEBUG) ||
   false;
 
 if (typeof window !== 'undefined') {

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -4,6 +4,7 @@ import { gridToPixels } from './utils/gridToPixels.js';
 import { finalizeGame } from './finalizeGame.js';
 import { emit } from './utils/eventBus.js';
 import { appendToTextScroll } from './utils/textScroll.js';
+import { DEBUG } from './utils/debug.js';
 
 const DEBUG_SIM_PAYLOAD =
   (typeof window !== 'undefined' && window.DEBUG_SIM_PAYLOAD) ||

--- a/FrontEnd/static/js/phaser/utils/debug.js
+++ b/FrontEnd/static/js/phaser/utils/debug.js
@@ -1,0 +1,4 @@
+export const DEBUG =
+  (typeof window !== 'undefined' && window.DEBUG) ||
+  (typeof process !== 'undefined' && process.env.DEBUG) ||
+  false;


### PR DESCRIPTION
## Summary
- add reusable DEBUG flag helper for Phaser front-end
- replace local DEBUG constants with helper import in bootGame and turnAnimation
- use shared DEBUG flag in gameScene

## Testing
- `node -e "import('file://' + process.cwd() + '/FrontEnd/static/js/phaser/utils/debug.js').then(m => console.log('DEBUG', m.DEBUG))"`
- `node -e "import('file://' + process.cwd() + '/FrontEnd/static/js/phaser/gameScene.js').then(m => console.log('gameScene loaded', typeof m.createGameScene))"` *(fails: Only URLs with a scheme in: file and data are supported by the default ESM loader. Received protocol 'https:')*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b84145b9d88328b6abda46c387eff8