### PR TITLE
Implement game state machine for front-end flow

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animateGameTurns.js
+++ b/FrontEnd/static/js/phaser/animation/animateGameTurns.js
@@ -4,6 +4,7 @@ import { runPass, REBOUND_DEBUG } from "./ballManager.js";
 import animationConfig from "./animation_config.js";
 import runFreeThrowSequence from "./freeThrow.js";
 import runFastBreakSequence from "./fastBreak.js";
+import { States } from "../state/gameStateMachine.js";
 
 const DEBUG_FLOW =
   (typeof window !== 'undefined' && window.DEBUG_FLOW) ||
@@ -34,7 +35,7 @@ export async function animateGameTurns({ //hasBallAtStep
   }
 
   const handlePossessionFlip = (payload = {}) => {
-    if (scene.fastBreakInProgress) return;
+    if (scene.stateMachine?.is(States.FastBreak)) return;
     scene.possessionFlipInProgress = true;
     scene.offenseTeamId = payload.offenseTeamId;
     if (REBOUND_DEBUG) {
@@ -64,7 +65,7 @@ export async function animateGameTurns({ //hasBallAtStep
     }
 
     if (turn.result_type === "SIDE_INBOUND") {
-      if (!scene.fastBreakInProgress) {
+      if (!scene.stateMachine?.is(States.FastBreak)) {
         await runSideInboundSetup({ scene, ballSprite, playerSprites, turnData: turn });
       }
       if (onUpdate) {
@@ -116,7 +117,7 @@ export async function animateGameTurns({ //hasBallAtStep
         const movement = anim?.movement || [];
 
         if (action === "pass") {
-          if (scene.fastBreakInProgress) return;
+          if (scene.stateMachine?.is(States.FastBreak)) return;
           const passStep = movement.find(
             m => m.action === "pass" && m.timestamp === timestamp
           );
@@ -174,7 +175,7 @@ export async function animateGameTurns({ //hasBallAtStep
     });
 
     const stealEvent = turn.events?.find(e => e.event_type === "STEAL");
-    if (!scene.fastBreakInProgress && (turn.result_type === "STEAL" || stealEvent)) {
+    if (!scene.stateMachine?.is(States.FastBreak) && (turn.result_type === "STEAL" || stealEvent)) {
       const ballHandlerId = playerMap[turn.ball_handler] ?? turn.ball_handler;
       const stealerRaw =
         turn.stealerId ||
@@ -196,7 +197,7 @@ export async function animateGameTurns({ //hasBallAtStep
         const defenderSprite = playerSprites[stealerId];
         // runPass reattaches the ball after the tween resolves, so only emit
         // possession change once that handoff has finished.
-        if (!scene.fastBreakInProgress && defenderSprite) {
+        if (!scene.stateMachine?.is(States.FastBreak) && defenderSprite) {
           scene.events?.emit?.('possessionChange', { offenseTeamId: defenderSprite.team_id });
         }
       }

--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -10,6 +10,7 @@ import {
   tweenBallTo,
   runPass as baseRunPass
 } from "./ballTween.js";
+import { States } from "../state/gameStateMachine.js";
 
 function attachBallToPlayer(scene, ballSprite, playerSprite, opts = {}) {
   if (scene.possessionFlipInProgress) return;
@@ -24,7 +25,7 @@ function attachBallToPlayer(scene, ballSprite, playerSprite, opts = {}) {
     }
   }
 
-  if (scene.reboundInProgress && targetId !== scene.rebounderId) {
+  if (scene.stateMachine?.is(States.Rebound) && targetId !== scene.rebounderId) {
     return;
   }
 
@@ -60,12 +61,12 @@ function attachBallToPlayer(scene, ballSprite, playerSprite, opts = {}) {
 
 function runInboundSetup(opts) {
   const scene = opts.scene;
-  if (scene.possessionFlipInProgress || scene.fastBreakInProgress) return Promise.resolve();
+  if (scene.possessionFlipInProgress || scene.stateMachine?.is(States.FastBreak)) return Promise.resolve();
   return baseRunInboundSetup(opts);
 }
 
 function runPass(scene, cfg = {}) {
-  if (scene.possessionFlipInProgress || scene.fastBreakInProgress) return Promise.resolve();
+  if (scene.possessionFlipInProgress || scene.stateMachine?.is(States.FastBreak)) return Promise.resolve();
   return baseRunPass(scene, cfg);
 }
 
@@ -89,7 +90,7 @@ export function passBall({
   fromTimestamp,
   toTimestamp
 }) {
-  if (scene?.ftInProgress) return;
+  if (scene?.stateMachine?.is(States.FreeThrow)) return;
   generateBallTween({
     scene,
     ballSprite,
@@ -110,7 +111,7 @@ export function animateInboundPass(
   startTs,
   endTs
 ) {
-  if (scene?.ftInProgress) return;
+  if (scene?.stateMachine?.is(States.FreeThrow)) return;
   generateBallTween({
     scene,
     ballSprite,
@@ -147,7 +148,7 @@ export function shootBall({
   turnIndex
 }) {
   if (!scene || !ballSprite) return Promise.resolve();
-  if (scene?.ftInProgress) return Promise.resolve();
+  if (scene?.stateMachine?.is(States.FreeThrow)) return Promise.resolve();
 
   const isHomeTeam = shooterTeamId === homeTeamId;
 
@@ -229,7 +230,7 @@ export function shootBall({
               team: shooterTeamId
             });
           }
-          scene.reboundInProgress = true;
+          scene.stateMachine?.transition(States.Rebound);
           scene.rebounderId = null;
           scene.tweens.add({
             targets: ballSprite,
@@ -270,7 +271,7 @@ export function animatePutbackAttempt(
   easing = animationConfig.putback.easing
 ) {
   if (!scene || !ballSprite) return Promise.resolve();
-  if (scene?.ftInProgress) return Promise.resolve();
+  if (scene?.stateMachine?.is(States.FreeThrow)) return Promise.resolve();
   const shooterSprite = scene.playerSprites?.[shooterId];
   if (!shooterSprite) return Promise.resolve();
 
@@ -331,7 +332,7 @@ export function animatePutbackAttempt(
                 scene.game.config.width,
                 scene.game.config.height
               );
-              scene.reboundInProgress = true;
+              scene.stateMachine?.transition(States.Rebound);
               scene.rebounderId = null;
               scene.tweens.add({
                 targets: ballSprite,
@@ -375,7 +376,7 @@ export function animateRebound({
   shooterId
 }) {
   if (!scene || !ballSprite || !ballSpot) return Promise.resolve();
-  if (scene?.ftInProgress) return Promise.resolve();
+  if (scene?.stateMachine?.is(States.FreeThrow)) return Promise.resolve();
 
   scene.rebounderId = rebounderId;
   const rebCfg = animationConfig.rebound;
@@ -440,7 +441,7 @@ export function animateRebound({
             scene.events?.emit("possessionChange", {
               offenseTeamId: rebounderSprite.team_id
             });
-            scene.reboundInProgress = false;
+            if (scene.stateMachine?.is(States.Rebound)) scene.stateMachine?.transition(States.HalfCourt);
             scene.rebounderId = null;
             resolve();
           },
@@ -558,7 +559,7 @@ export function animateKickoutReset(
   duration
 ) {
   if (!scene || !ballSprite) return Promise.resolve();
-  if (scene?.ftInProgress) return Promise.resolve();
+  if (scene?.stateMachine?.is(States.FreeThrow)) return Promise.resolve();
 
   const rebounderSprite = scene.playerSprites?.[rebounderId];
   const pgSprite = scene.playerSprites?.[pgId];
@@ -603,7 +604,7 @@ export function animateKickoutReset(
   scene.events?.once('tweenStart', () => console.log('tweenStart'));
   scene.events?.once('tweenEnd', () => console.log('tweenEnd'));
 
-  if (scene.fastBreakInProgress) {
+  if (scene.stateMachine?.is(States.FastBreak)) {
     return Promise.resolve();
   }
 

--- a/FrontEnd/static/js/phaser/animation/freeThrow.js
+++ b/FrontEnd/static/js/phaser/animation/freeThrow.js
@@ -1,6 +1,7 @@
 import { gridToPixels } from "../utils/gridToPixels.js";
 import animationConfig from "./animation_config.js";
 import { HOME_RIM_COORDS, AWAY_RIM_COORDS } from "./courtConstants.js";
+import { States } from "../state/gameStateMachine.js";
 
 function wait(scene, ms) {
   if (!ms) return Promise.resolve();
@@ -33,7 +34,7 @@ export async function runFreeThrowSequence(
 
   if (!scene || !playerSprites || !ballSprite || !turnData) return;
 
-  scene.ftInProgress = true;
+  scene.stateMachine?.transition(States.FreeThrow);
   if (scene.tweens) {
     for (const sprite of Object.values(playerSprites)) {
       scene.tweens.killTweensOf(sprite);
@@ -134,7 +135,7 @@ export async function runFreeThrowSequence(
         }
       }
       if (isLast) {
-        scene.ftInProgress = false;
+        scene.stateMachine?.transition(States.Inbound);
         const newOffenseSide =
           turnData.offense_team_id === scene.simData?.home_team_id
             ? "away"
@@ -163,7 +164,7 @@ export async function runFreeThrowSequence(
       }
     } else {
       if (isLast) {
-        scene.ftInProgress = false;
+        scene.stateMachine?.transition(States.Rebound);
         await rebound({
           scene,
           ballSprite,
@@ -193,7 +194,7 @@ export async function runFreeThrowSequence(
     scene.events?.emit("ft:repeatOrExit");
   }
 
-  scene.ftInProgress = false;
+  if (scene.stateMachine?.is(States.FreeThrow)) scene.stateMachine.transition(States.HalfCourt);
   scene.events?.emit("ft:end");
 }
 

--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -13,6 +13,7 @@ import { tweenBallTo, runPass, PASS_DEBUG, tweenPlayerTo, detachBall } from "./b
 import animationConfig from "./animation_config.js";
 import { HOME_RIM_COORDS, AWAY_RIM_COORDS, HOME_TOP_KEY, AWAY_TOP_KEY } from "./courtConstants.js";
 import { DEBUG } from "../utils/debug.js";
+import { States } from "../state/gameStateMachine.js";
 
 // Cap the time spent on any single movement step. Large timestamp gaps can
 // otherwise produce multi‑second tweens that appear as animation stalls.
@@ -24,7 +25,7 @@ const MAX_STEP_DURATION = 1000; // ms
  * Assigns the ball to the correct player for the current stepIndex
  */
 function updateBallOwnership({ scene, ballSprite, animations, playerSprites, stepIndex, offenseTeamId, currentBallOwnerRef }) {
-  if (scene?.skipToEnd || scene?.fastBreakInProgress) return;
+  if (scene?.skipToEnd || scene?.stateMachine?.is(States.FastBreak)) return;
 
   if (scene.passInFlight) return;
 
@@ -129,7 +130,7 @@ async function runSetupTween({ scene, ballSprite, animations, playerSprites, cur
 
 // Setup sideline inbound play
 async function runSideInboundSetup({ scene, ballSprite, playerSprites, turnData }) {
-  if (!turnData || scene?.skipToEnd || scene?.ftInProgress || scene?.fastBreakInProgress) return;
+  if (!turnData || scene?.skipToEnd || scene?.stateMachine?.is(States.FreeThrow) || scene?.stateMachine?.is(States.FastBreak)) return;
 
   const { ball_spot, oDestinations = {}, dDestinations = {}, possession_team_id } = turnData;
   const offenseTeamId = scene.currentOffenseTeamId ?? possession_team_id;
@@ -214,7 +215,7 @@ async function runSideInboundSetup({ scene, ballSprite, playerSprites, turnData 
     scene.events?.once('passEnd', () => console.log('passEnd'));
 
     console.log(`[sideInbound][passStart] sf:${sfId} pg:${pgId}`);
-    if (pgSprite && !scene.fastBreakInProgress) {
+    if (pgSprite && !scene.stateMachine?.is(States.FastBreak)) {
       await runPass(scene, { fromId: sfId, toId: pgId, duration, easing: ease });
     }
     console.log(`[sideInbound][passEnd] sf:${sfId} pg:${pgId}`);
@@ -303,7 +304,7 @@ async function runInboundSetup({
   homeTeamId,
   awayTeamId
 }) {
-  if (scene?.ftInProgress) return;
+  if (scene?.stateMachine?.is(States.FreeThrow)) return;
   scene.isInboundSetup = true;
   if (!scene.ballSprite) scene.ballSprite = ballSprite;
   const isAwayOffense = newOffenseSide === "away";
@@ -593,7 +594,7 @@ async function runInboundSetup({
   scene.events?.once('passEnd', () => console.log('passEnd'));
 
   console.log(`[inbound][passStart][${newOffenseSide}] sf:${sfId} pg:${pgId}`);
-  if (!scene.fastBreakInProgress) {
+  if (!scene.stateMachine?.is(States.FastBreak)) {
     await runPass(scene, {
       fromId: sfId,
       toId: pgId,
@@ -611,7 +612,7 @@ async function runFastBreakSequence({ scene, turnData, playerSprites, ballSprite
   if (!scene || !turnData || scene.skipToEnd) return;
   if (!scene.ballSprite) scene.ballSprite = ballSprite;
 
-  scene.fastBreakInProgress = true;
+  scene.stateMachine?.transition(States.FastBreak);
   scene.events?.emit("fb:start");
 
   if (scene.tweens) {
@@ -841,7 +842,7 @@ async function runFastBreakSequence({ scene, turnData, playerSprites, ballSprite
       }
     }
   } finally {
-    scene.fastBreakInProgress = false;
+    if (scene.stateMachine?.is(States.FastBreak)) scene.stateMachine?.transition(States.HalfCourt);
     scene.events?.emit("fb:end");
   }
 }
@@ -859,7 +860,7 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
     ...turnData.animations.map(anim => anim.movement.length)
   );
 
-  if (scene.fastBreakInProgress) {
+  if (scene.stateMachine?.is(States.FastBreak)) {
     return;
   }
 
@@ -879,7 +880,7 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
   // Determine which player owns the ball at step 0
   let step0OwnerSprite = null;
   for (const anim of turnData.animations) {
-    if (scene.skipToEnd || scene.fastBreakInProgress) break;
+    if (scene.skipToEnd || scene.stateMachine?.is(States.FastBreak)) break;
     if (anim.hasBallAtStep?.[0]) {
       step0OwnerSprite = playerSprites[anim.playerId];
       break;
@@ -900,7 +901,7 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
     currentBallOwnerRef
   });
 
-  if (scene.skipToEnd || scene.fastBreakInProgress) {
+  if (scene.skipToEnd || scene.stateMachine?.is(States.FastBreak)) {
     return;
   }
 
@@ -926,7 +927,7 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
   let eventsProcessed = false;
 
   for (let stepIndex = 1; stepIndex < maxSteps; stepIndex++) {
-    if (scene.skipToEnd || scene.fastBreakInProgress) break;
+    if (scene.skipToEnd || scene.stateMachine?.is(States.FastBreak)) break;
 
     updateBallOwnership({
       scene,
@@ -1053,7 +1054,7 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
                   scene.events?.emit?.("possessionChange", {
                     offenseTeamId: rebounderSprite.team_id
                   });
-                  scene.reboundInProgress = false;
+                  if (scene.stateMachine?.is(States.Rebound)) scene.stateMachine?.transition(States.HalfCourt);
                   scene.rebounderId = null;
                   if (scene.time?.delayedCall) {
                     scene.time.delayedCall(rebCfg.attachDelayMs, resolve);

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -5,6 +5,7 @@ import { finalizeGame } from './finalizeGame.js';
 import { emit } from './utils/eventBus.js';
 import { appendToTextScroll } from './utils/textScroll.js';
 import { DEBUG } from './utils/debug.js';
+import { createGameStateMachine, States } from './state/gameStateMachine.js';
 
 const DEBUG_SIM_PAYLOAD =
   (typeof window !== 'undefined' && window.DEBUG_SIM_PAYLOAD) ||
@@ -32,8 +33,8 @@ export function createGameScene(Phaser) {
     constructor() {
       super("GameScene");
       this.lastTurnShown = -1;
-      this.reboundInProgress = false;
       this.rebounderId = null;
+      this.stateMachine = createGameStateMachine(States.Inbound);
     }
 
     init(data) {

--- a/FrontEnd/static/js/phaser/state/gameStateMachine.js
+++ b/FrontEnd/static/js/phaser/state/gameStateMachine.js
@@ -1,0 +1,40 @@
+export const States = {
+  Inbound: 'Inbound',
+  HalfCourt: 'HalfCourt',
+  ShotAttempt: 'ShotAttempt',
+  Rebound: 'Rebound',
+  FastBreak: 'FastBreak',
+  FreeThrow: 'FreeThrow',
+  EndQuarter: 'EndQuarter'
+};
+
+const transitions = {
+  [States.Inbound]: [States.HalfCourt, States.EndQuarter],
+  [States.HalfCourt]: [States.ShotAttempt, States.FreeThrow, States.FastBreak, States.EndQuarter],
+  [States.ShotAttempt]: [States.Rebound, States.FastBreak, States.FreeThrow, States.Inbound, States.EndQuarter],
+  [States.Rebound]: [States.HalfCourt, States.ShotAttempt, States.FastBreak, States.FreeThrow, States.EndQuarter],
+  [States.FastBreak]: [States.ShotAttempt, States.Rebound, States.FreeThrow, States.Inbound, States.EndQuarter],
+  [States.FreeThrow]: [States.Rebound, States.Inbound, States.EndQuarter],
+  [States.EndQuarter]: [States.Inbound]
+};
+
+export function createGameStateMachine(initialState = States.Inbound) {
+  let state = initialState;
+  return {
+    transition(next) {
+      const allowed = transitions[state] || [];
+      if (!allowed.includes(next)) {
+        throw new Error(`Invalid transition: ${state} -> ${next}`);
+      }
+      state = next;
+    },
+    is(s) {
+      return state === s;
+    },
+    get state() {
+      return state;
+    }
+  };
+}
+
+export default createGameStateMachine;

--- a/tests/js/runGameStateMachine.mjs
+++ b/tests/js/runGameStateMachine.mjs
@@ -1,0 +1,17 @@
+import { createGameStateMachine, States } from '../../FrontEnd/static/js/phaser/state/gameStateMachine.js';
+
+const sm = createGameStateMachine(States.Inbound);
+sm.transition(States.HalfCourt);
+sm.transition(States.ShotAttempt);
+sm.transition(States.Rebound);
+const allowedFinal = sm.state;
+
+const sm2 = createGameStateMachine(States.Inbound);
+let illegalError = false;
+try {
+  sm2.transition(States.Rebound);
+} catch (e) {
+  illegalError = true;
+}
+
+console.log(JSON.stringify({ allowedFinal, illegalError }));

--- a/tests/js/runReboundInProgress.mjs
+++ b/tests/js/runReboundInProgress.mjs
@@ -1,4 +1,5 @@
 import { attachBallToPlayer, animateRebound } from '../../FrontEnd/static/js/phaser/animation/ballManager.js';
+import { createGameStateMachine, States } from '../../FrontEnd/static/js/phaser/state/gameStateMachine.js';
 
 function makeScene() {
   return {
@@ -20,8 +21,8 @@ function makeScene() {
       b: { x: 0, y: 0, playerId: 'b', team: 'home', team_id: 'HOME' }
     },
     events: { emit: () => {} },
-    reboundInProgress: true,
-    rebounderId: 'a'
+    rebounderId: 'a',
+    stateMachine: createGameStateMachine(States.Rebound)
   };
 }
 
@@ -42,7 +43,7 @@ await animateRebound({
   ballSpot: { x: 0, y: 0 }
 });
 const afterRebound = scene.ballAttachedToPlayerId;
-const flagAfterRebound = scene.reboundInProgress;
+const flagAfterRebound = scene.stateMachine.is(States.Rebound);
 
 // Now that flag is cleared, attaching to another player works
 attachBallToPlayer(scene, ballSprite, scene.playerSprites.b);

--- a/tests/test_game_state_machine.py
+++ b/tests/test_game_state_machine.py
@@ -1,0 +1,13 @@
+import json
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_game_state_machine_transitions():
+    cmd = ["node", str(ROOT / "tests/js/runGameStateMachine.mjs")]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    data = json.loads(completed.stdout.strip().splitlines()[-1])
+    assert data["allowedFinal"] == "Rebound"
+    assert data["illegalError"] is True


### PR DESCRIPTION
## Summary
- add reusable game state machine with legal transition checks
- refactor animations and scene code to use stateMachine for FastBreak, Rebound, and FreeThrow flow
- add tests covering state machine transitions and rebound handling

## Testing
- `pytest tests/test_game_state_machine.py tests/test_rebound_in_progress_flag.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8460b28b08328a8df83d0598b13eb