### PR TITLE
feat: introduce global game store

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -11,6 +11,7 @@ import {
   runPass as baseRunPass
 } from "./ballTween.js";
 import { States } from "../state/gameStateMachine.js";
+import gameStore from "../../state/gameStore.js";
 
 function attachBallToPlayer(scene, ballSprite, playerSprite, opts = {}) {
   if (scene.possessionFlipInProgress) return;
@@ -149,8 +150,11 @@ export function shootBall({
 }) {
   if (!scene || !ballSprite) return Promise.resolve();
   if (scene?.stateMachine?.is(States.FreeThrow)) return Promise.resolve();
-
-  const isHomeTeam = shooterTeamId === homeTeamId;
+  const homeRoster = gameStore.getHomeRoster();
+  const storeHomeId =
+    homeRoster?.team_id || homeRoster?.teamId || homeRoster?.team_name || homeRoster?.team;
+  const effectiveHomeId = homeTeamId ?? storeHomeId;
+  const isHomeTeam = String(shooterTeamId) === String(effectiveHomeId);
 
   const start = gridToPixels(
     fromCoords.x,
@@ -305,9 +309,10 @@ export function animatePutbackAttempt(
 
             const shooterTeamKey = shooterSprite.team;
             const newOffenseSide = shooterTeamKey === "home" ? "away" : "home";
-            const sprites = Object.values(scene.playerSprites || {});
-            const homeTeamId = sprites.find(s => s.team === "home")?.team_id;
-            const awayTeamId = sprites.find(s => s.team === "away")?.team_id;
+            const homeTeamId =
+              gameStore.getHomeRoster()?.team_id || gameStore.getHomeRoster()?.teamId;
+            const awayTeamId =
+              gameStore.getAwayRoster()?.team_id || gameStore.getAwayRoster()?.teamId;
 
             await runInboundSetup({
               scene,

--- a/FrontEnd/static/js/phaser/bootGame.js
+++ b/FrontEnd/static/js/phaser/bootGame.js
@@ -4,6 +4,7 @@ import { setCourtOffsets } from './utils/gridToPixels.js';
 import { on, emit } from './utils/eventBus.js';
 import { finalizeGame } from './finalizeGame.js';
 import { DEBUG } from './utils/debug.js';
+import gameStore from '../state/gameStore.js';
 
 const DEBUG_GAME_ID =
   (typeof window !== 'undefined' && window.DEBUG_GAME_ID) ||
@@ -138,6 +139,7 @@ function resetGameContext() {
   if (typeof localStorage !== 'undefined' && typeof localStorage.removeItem === 'function') {
     localStorage.removeItem('game_id');
   }
+  gameStore.reset();
   updateScoreboardScores({ home: 0, away: 0 });
 }
 
@@ -156,6 +158,20 @@ async function fetchTeamRoster(teamName) {
 
 async function startGame({ homeRoster, awayRoster, animate = true }) {
   DEBUG && console.log('[bootGame] startGame', { quarter, animate });
+  gameStore.reset();
+  gameStore.setTeams({ home: homeTeam, away: awayTeam });
+  gameStore.setRosters({ home: homeRoster, away: awayRoster });
+  gameStore.setColors({
+    home: {
+      primary_color: homeRoster.primary_color,
+      secondary_color: homeRoster.secondary_color,
+    },
+    away: {
+      primary_color: awayRoster.primary_color,
+      secondary_color: awayRoster.secondary_color,
+    },
+  });
+  gameStore.setGameId(gameId);
   if (!game) {
     game = new Phaser.Game({
       type: Phaser.AUTO,
@@ -170,16 +186,12 @@ async function startGame({ homeRoster, awayRoster, animate = true }) {
   }
 
   const sceneData = {
-    rosters: { homeRoster, awayRoster },
     tournamentId,
     franchiseId,
-    homeTeam,
-    awayTeam,
     animate,
     homeLineup,
     awayLineup,
     periodLabel,
-    gameId,
     quarter,
   };
 

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -6,6 +6,7 @@ import { emit } from './utils/eventBus.js';
 import { appendToTextScroll } from './utils/textScroll.js';
 import { DEBUG } from './utils/debug.js';
 import { createGameStateMachine, States } from './state/gameStateMachine.js';
+import gameStore from '../state/gameStore.js';
 
 const DEBUG_SIM_PAYLOAD =
   (typeof window !== 'undefined' && window.DEBUG_SIM_PAYLOAD) ||
@@ -38,29 +39,27 @@ export function createGameScene(Phaser) {
     }
 
     init(data) {
-        this.rosters = data.rosters;
         this.tournamentId = data.tournamentId;
         this.franchiseId = data.franchiseId;
-        this.homeTeam = data.homeTeam;
-        this.awayTeam = data.awayTeam;
         this.animate = data.animate;
         this.mode = data.mode;
         this.homeLineup = data.homeLineup || {};
         this.awayLineup = data.awayLineup || {};
         this.periodLabel = data.periodLabel;
-        this.gameId = data.gameId || null;
+        this.gameId = gameStore.getGameId();
         if (!this.gameId && typeof localStorage !== 'undefined') {
           localStorage.removeItem('game_id');
         }
         this.quarter = data.quarter || 1;
 
         if (DEBUG_FLOW) {
+          const teams = gameStore.getTeams();
           console.log("🧠 Game initialized with:", {
-            rosters: this.rosters,
+            rosters: gameStore.getRosters(),
             tournamentId: this.tournamentId,
             franchiseId: this.franchiseId,
-            homeTeam: this.homeTeam,
-            awayTeam: this.awayTeam,
+            homeTeam: teams.home,
+            awayTeam: teams.away,
             mode: this.mode,
             periodLabel: this.periodLabel,
           });
@@ -72,8 +71,9 @@ export function createGameScene(Phaser) {
       if (DEBUG_FLOW) console.log("✅ GameScene preloaded");
       if (this.animate) {
         this.load.image("ball", "/static/images/ball.png");
+        const { home } = gameStore.getTeams();
         const normalizeTeamName = (name) => name.toLowerCase().replace(/[\s\-]/g, '_');
-        const teamId = normalizeTeamName(this.homeTeam);
+        const teamId = normalizeTeamName(home);
         this.load.image("court-bg", `/static/images/courts/${teamId}.jpg`);
       }
 
@@ -92,11 +92,7 @@ export function createGameScene(Phaser) {
       this.playerInfo = {};
       this.playerStats = {};
 
-    //   const homeTeam = this.homeTeam || this.rosters.homeRoster.team || this.rosters.homeRoster.team_name;
-    //   const awayTeam = this.awayTeam || this.rosters.awayRoster.team || this.rosters.awayRoster.team_name;
-
-      const homeTeam = this.rosters.homeRoster.team_name;
-      const awayTeam = this.rosters.awayRoster.team_name;
+      const { home: homeTeam, away: awayTeam } = gameStore.getTeams();
 
       if (DEBUG_TEAMS) {
         console.log("📨 Sending /api/simulate-quarter request for:", homeTeam, "vs", awayTeam);
@@ -181,6 +177,11 @@ export function createGameScene(Phaser) {
       if (this.gameId && typeof localStorage !== 'undefined') {
         localStorage.setItem('game_id', this.gameId);
       }
+      gameStore.setGameId(this.gameId);
+      gameStore.setColors({
+        home: simData.home_team_colors,
+        away: simData.away_team_colors,
+      });
       this.isFinal = simData.is_final;
       if (DEBUG_FLOW) {
         console.log(
@@ -299,18 +300,7 @@ export function createGameScene(Phaser) {
       hydrateBoxScore();
 
       if (this.animate) {
-        this.playerSprites = loadPhaserPlayers(this, simData.players, {
-          home: {
-            player_ids: simData.players.filter(p => p.team === 'home').map(p => p.playerId ?? p.player_id),
-            primary_color: simData.home_team_colors.primary_color,
-            secondary_color: simData.home_team_colors.secondary_color,
-          },
-          away: {
-            player_ids: simData.players.filter(p => p.team === 'away').map(p => p.playerId ?? p.player_id),
-            primary_color: simData.away_team_colors.primary_color,
-            secondary_color: simData.away_team_colors.secondary_color,
-          },
-        }, Phaser);
+        this.playerSprites = loadPhaserPlayers(this, simData.players, Phaser);
       }
 
       const applyPlayerStats = (turn = {}) => {

--- a/FrontEnd/static/js/phaser/setup/loadPhaserPlayers.js
+++ b/FrontEnd/static/js/phaser/setup/loadPhaserPlayers.js
@@ -1,21 +1,52 @@
 import { createPhaserPlayer } from "./createPhaserPlayer.js";
+import gameStore from "../../state/gameStore.js";
 
 /**
  * Creates Phaser player containers for all players and stores them by ID.
  * 
  * @param {Phaser.Scene} scene - The active Phaser scene
  * @param {Array} allPlayers - Array of player objects from simData
- * @param {Object} teamInfo - { home: { colors }, away: { colors } }
+ * @param {Object} [teamInfo] - Optional colors; defaults to gameStore values
  * @returns {Object} Map of playerId -> Phaser container
  */
-export function loadPhaserPlayers(scene, allPlayers, teamInfo, Phaser) {
+export function loadPhaserPlayers(
+  scene,
+  allPlayers,
+  teamInfoOrPhaser,
+  maybePhaser
+) {
+  let teamInfo = teamInfoOrPhaser;
+  let PhaserLib = maybePhaser;
+  if (typeof maybePhaser === "undefined") {
+    PhaserLib = teamInfoOrPhaser;
+    teamInfo = null;
+  }
+
+  if (!teamInfo) {
+    const colors = gameStore.getColors();
+    teamInfo = {
+      home: {
+        player_ids: allPlayers
+          .filter(p => p.team === "home")
+          .map(p => p.playerId ?? p.player_id),
+        ...colors.home,
+      },
+      away: {
+        player_ids: allPlayers
+          .filter(p => p.team === "away")
+          .map(p => p.playerId ?? p.player_id),
+        ...colors.away,
+      },
+    };
+  }
+
   const playerSprites = {};
 
   for (const player of allPlayers) {
     const id = player.playerId ?? player.player_id;
-    const isHome = teamInfo.home.player_ids.includes(id);
+    const isHome = teamInfo.home.player_ids.includes(id) || player.team === "home";
     const teamColors = isHome ? teamInfo.home : teamInfo.away;
-    
+
     const sprite = createPhaserPlayer({
       scene,
       player,
@@ -24,7 +55,7 @@ export function loadPhaserPlayers(scene, allPlayers, teamInfo, Phaser) {
         isHome
       },
       position: player.pos,
-      Phaser
+      Phaser: PhaserLib
     });
     // ✅ Attach team metadata for later logic
     sprite.team_id = player.team_id; // e.g., "MORRISTOWN"

--- a/FrontEnd/static/js/state/gameStore.js
+++ b/FrontEnd/static/js/state/gameStore.js
@@ -1,0 +1,68 @@
+const state = {
+  teams: { home: null, away: null },
+  colors: { home: {}, away: {} },
+  rosters: { home: null, away: null },
+  gameId: null,
+};
+
+export default {
+  // Teams
+  setTeams({ home, away }) {
+    state.teams.home = home || null;
+    state.teams.away = away || null;
+  },
+  getTeams() {
+    return { ...state.teams };
+  },
+  getHomeTeam() {
+    return state.teams.home;
+  },
+  getAwayTeam() {
+    return state.teams.away;
+  },
+
+  // Colors
+  setColors({ home, away }) {
+    state.colors.home = home ? { ...home } : {};
+    state.colors.away = away ? { ...away } : {};
+  },
+  getColors() {
+    return { ...state.colors };
+  },
+  getHomeColors() {
+    return { ...state.colors.home };
+  },
+  getAwayColors() {
+    return { ...state.colors.away };
+  },
+
+  // Rosters
+  setRosters({ home, away }) {
+    state.rosters.home = home || null;
+    state.rosters.away = away || null;
+  },
+  getRosters() {
+    return { ...state.rosters };
+  },
+  getHomeRoster() {
+    return state.rosters.home;
+  },
+  getAwayRoster() {
+    return state.rosters.away;
+  },
+
+  // Game ID
+  setGameId(id) {
+    state.gameId = id || null;
+  },
+  getGameId() {
+    return state.gameId;
+  },
+
+  reset() {
+    state.teams = { home: null, away: null };
+    state.colors = { home: {}, away: {} };
+    state.rosters = { home: null, away: null };
+    state.gameId = null;
+  },
+};


### PR DESCRIPTION
## Summary
- add a simple gameStore for rosters, teams, colors and game id
- hydrate gameStore in bootGame and consume it across scenes and animations
- reset gameStore between games or quarters

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8483f9508832889b50440d2b0e47d