### PR TITLE
refactor ball ownership tracking with controller

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animateStep.js
+++ b/FrontEnd/static/js/phaser/animation/animateStep.js
@@ -11,6 +11,7 @@ import { gridToPixels } from "../utils/gridToPixels.js";
  * @returns {Promise} resolves when tween completes
  */
 import { PASS_DEBUG } from "./ballTween.js";
+import { getPendingOwner } from "../ball/ballController.js";
 
 export const PLAYER_TWEEN_DEBUG = false;
 
@@ -55,7 +56,7 @@ export function animateStep({ scene, sprite, step, duration, ballSprite, current
         if (
           currentBallOwnerRef?.value === sprite &&
           ballSprite?.setPosition &&
-          !scene.pendingBallOwnerId
+          !getPendingOwner(scene)
         ) {
           ballSprite.setPosition(sprite.x, sprite.y);
         }

--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -12,6 +12,7 @@ import {
 } from "./ballTween.js";
 import { States } from "../state/gameStateMachine.js";
 import gameStore from "../../state/gameStore.js";
+import { clearCurrentOwner, cancelBallTween } from "../ball/ballController.js";
 
 function attachBallToPlayer(scene, ballSprite, playerSprite, opts = {}) {
   if (scene.possessionFlipInProgress) return;
@@ -150,6 +151,8 @@ export function shootBall({
 }) {
   if (!scene || !ballSprite) return Promise.resolve();
   if (scene?.stateMachine?.is(States.FreeThrow)) return Promise.resolve();
+  cancelBallTween(scene, ballSprite);
+  clearCurrentOwner(scene);
   const homeRoster = gameStore.getHomeRoster();
   const storeHomeId =
     homeRoster?.team_id || homeRoster?.teamId || homeRoster?.team_name || homeRoster?.team;
@@ -280,7 +283,7 @@ export function animatePutbackAttempt(
   if (!shooterSprite) return Promise.resolve();
 
   if (scene.tweens) scene.tweens.killTweensOf(ballSprite);
-  scene.ballAttachedToPlayerId = null;
+  clearCurrentOwner(scene);
   ballSprite.setPosition(shooterSprite.x, shooterSprite.y);
   ballSprite.setVisible(true);
 
@@ -382,6 +385,8 @@ export function animateRebound({
 }) {
   if (!scene || !ballSprite || !ballSpot) return Promise.resolve();
   if (scene?.stateMachine?.is(States.FreeThrow)) return Promise.resolve();
+  cancelBallTween(scene, ballSprite);
+  clearCurrentOwner(scene);
 
   scene.rebounderId = rebounderId;
   const rebCfg = animationConfig.rebound;

--- a/FrontEnd/static/js/phaser/animation/ballTween.js
+++ b/FrontEnd/static/js/phaser/animation/ballTween.js
@@ -1,5 +1,13 @@
 import * as Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.60.0/dist/phaser.esm.js';
 import animationConfig from "./animation_config.js";
+import {
+  setCurrentOwner,
+  clearCurrentOwner,
+  getCurrentOwner,
+  getLastKnownOwner,
+  setPendingOwner,
+  cancelBallTween
+} from "../ball/ballController.js";
 
 const BALL_DEPTH = 1000;
 export const PASS_DEBUG = false;
@@ -31,7 +39,7 @@ export function attachBallToPlayer(scene, ballSprite, playerSprite, opts = {}) {
     scene.offenseTeamId != null &&
     String(targetTeamId) !== String(scene.offenseTeamId)
   ) {
-    const from = scene.ballAttachedToPlayerId;
+    const from = getCurrentOwner(scene);
     console.warn('overwrite', { from, to: targetId, reason: 'possessionFlipInProgress' });
     return;
   }
@@ -43,8 +51,9 @@ export function attachBallToPlayer(scene, ballSprite, playerSprite, opts = {}) {
   ballSprite.setVisible(true);
   ballSprite.setDepth(depth);
   if (targetId != null) {
-    scene.ballAttachedToPlayerId = targetId;
-    scene.ballLastKnownOwnerId = targetId;
+    setCurrentOwner(scene, targetId);
+  } else {
+    clearCurrentOwner(scene);
   }
 }
 
@@ -55,10 +64,8 @@ export function attachBallToPlayer(scene, ballSprite, playerSprite, opts = {}) {
 export function detachBall(scene, ballSprite) {
   if (!scene || !ballSprite) return;
   scene.ballDetached = true;
-  if (scene.tweens) scene.tweens.killTweensOf(ballSprite);
-  if (typeof scene.ballAttachedToPlayerId !== 'undefined') {
-    scene.ballAttachedToPlayerId = null;
-  }
+  cancelBallTween(scene, ballSprite);
+  clearCurrentOwner(scene);
 }
 
 /**
@@ -138,7 +145,7 @@ export function tweenPlayerTo(scene, sprite, target, opts = {}) {
         const ballSprite = scene.ballSprite;
         if (
           ballSprite &&
-          scene.ballAttachedToPlayerId === sprite.playerId &&
+          getCurrentOwner(scene) === sprite.playerId &&
           ballSprite.setPosition
         ) {
           ballSprite.setPosition(sprite.x, sprite.y);
@@ -177,7 +184,7 @@ export async function runPass(scene, cfg = {}) {
 
   if (scene.__activePass) {
     if (scene.tweens) scene.tweens.killTweensOf(ballSprite);
-    const lastId = scene.ballLastKnownOwnerId;
+    const lastId = getLastKnownOwner(scene);
     const lastSprite = lastId != null ? scene.playerSprites?.[lastId] : null;
     if (lastSprite) {
       attachBallToPlayer(scene, ballSprite, lastSprite);
@@ -186,9 +193,9 @@ export async function runPass(scene, cfg = {}) {
     scene.__activePass = null;
   }
 
-  if (scene.tweens) scene.tweens.killTweensOf(ballSprite);
-  if (scene.ballDetached && scene.ballLastKnownOwnerId != null) {
-    const owner = scene.playerSprites?.[scene.ballLastKnownOwnerId];
+  cancelBallTween(scene, ballSprite);
+  if (scene.ballDetached && getLastKnownOwner(scene) != null) {
+    const owner = scene.playerSprites?.[getLastKnownOwner(scene)];
     if (owner) attachBallToPlayer(scene, ballSprite, owner);
   }
 
@@ -200,7 +207,7 @@ export async function runPass(scene, cfg = {}) {
   scene.__activePass = { key, frame, promise, reject: rejectFn };
 
   scene.passInFlight = true;
-  scene.pendingBallOwnerId = toId;
+  setPendingOwner(scene, toId);
 
   (async () => {
     try {
@@ -263,7 +270,7 @@ export async function runPass(scene, cfg = {}) {
       if (PASS_DEBUG) console.log('passEnd', { toId });
       resolveFn();
     } catch (err) {
-      const lastId = scene.ballLastKnownOwnerId;
+      const lastId = getLastKnownOwner(scene);
       const lastSprite = lastId != null ? scene.playerSprites?.[lastId] : null;
       if (lastSprite) {
         attachBallToPlayer(scene, ballSprite, lastSprite);
@@ -273,7 +280,7 @@ export async function runPass(scene, cfg = {}) {
       if (scene.__activePass && scene.__activePass.key === key && scene.__activePass.frame === frame) {
         scene.__activePass = null;
         scene.passInFlight = false;
-        // Allow pendingBallOwnerId to persist so updateBallOwnership can consume it
+        // Allow pending owner to persist so updateBallOwnership can consume it
       }
     }
   })();

--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -14,6 +14,12 @@ import animationConfig from "./animation_config.js";
 import { HOME_RIM_COORDS, AWAY_RIM_COORDS, HOME_TOP_KEY, AWAY_TOP_KEY } from "./courtConstants.js";
 import { DEBUG } from "../utils/debug.js";
 import { States } from "../state/gameStateMachine.js";
+import {
+  getPendingOwner,
+  clearPendingOwner,
+  setCurrentOwner,
+  getCurrentOwner
+} from "../ball/ballController.js";
 
 // Cap the time spent on any single movement step. Large timestamp gaps can
 // otherwise produce multi‑second tweens that appear as animation stalls.
@@ -34,13 +40,14 @@ function updateBallOwnership({ scene, ballSprite, animations, playerSprites, ste
     return;
   }
 
-  if (scene.pendingBallOwnerId != null) {
-    const pendingId = scene.pendingBallOwnerId;
+  const pendingId = getPendingOwner(scene);
+  if (pendingId != null) {
     const pendingSprite = playerSprites[pendingId];
     if (pendingSprite && ballSprite?.setPosition) {
       ballSprite.setPosition(pendingSprite.x, pendingSprite.y);
       ballSprite.setVisible(true);
       if (currentBallOwnerRef) currentBallOwnerRef.value = pendingSprite;
+      setCurrentOwner(scene, pendingId);
       if (PASS_DEBUG) console.log('ownershipUpdate', { target: pendingId, stepIndex });
     } else {
       console.warn(`Missing sprite for pending ball owner ${pendingId}`);
@@ -51,7 +58,7 @@ function updateBallOwnership({ scene, ballSprite, animations, playerSprites, ste
         ballSprite.setVisible(false);
       }
     }
-    scene.pendingBallOwnerId = null;
+    clearPendingOwner(scene);
     return;
   }
 
@@ -704,7 +711,7 @@ async function runFastBreakSequence({ scene, turnData, playerSprites, ballSprite
     if (scene.skipToEnd) return;
 
     if (turnData.hold_up) {
-      const bhId = scene.ballAttachedToPlayerId;
+      const bhId = getCurrentOwner(scene);
       const bhSprite = bhId != null ? playerSprites[bhId] : null;
       const stopperId = turnData.stopper_id;
       const stopperSprite = stopperId != null ? playerSprites[stopperId] : null;
@@ -795,7 +802,8 @@ async function runFastBreakSequence({ scene, turnData, playerSprites, ballSprite
       return;
     }
 
-    const shooterId = turnData.shooterId || turnData.shooter_id || scene.ballAttachedToPlayerId;
+    const shooterId =
+      turnData.shooterId || turnData.shooter_id || getCurrentOwner(scene);
     const shooterSprite = shooterId != null ? playerSprites[shooterId] : null;
     if (shooterSprite) {
       attachBallToPlayer(scene, ballSprite, shooterSprite);

--- a/FrontEnd/static/js/phaser/ball/ballController.js
+++ b/FrontEnd/static/js/phaser/ball/ballController.js
@@ -1,0 +1,62 @@
+const stateMap = new WeakMap();
+
+function ensure(scene) {
+  let s = stateMap.get(scene);
+  if (!s) {
+    s = { currentOwnerId: null, lastOwnerId: null, pendingOwnerId: null };
+    stateMap.set(scene, s);
+  }
+  return s;
+}
+
+export function getCurrentOwner(scene) {
+  return ensure(scene).currentOwnerId;
+}
+
+export function setCurrentOwner(scene, playerId) {
+  const s = ensure(scene);
+  s.currentOwnerId = playerId;
+  if (playerId != null) {
+    s.lastOwnerId = playerId;
+  }
+}
+
+export function clearCurrentOwner(scene) {
+  ensure(scene).currentOwnerId = null;
+}
+
+export function getLastKnownOwner(scene) {
+  return ensure(scene).lastOwnerId;
+}
+
+export function getPendingOwner(scene) {
+  return ensure(scene).pendingOwnerId;
+}
+
+export function setPendingOwner(scene, playerId) {
+  ensure(scene).pendingOwnerId = playerId;
+}
+
+export function clearPendingOwner(scene) {
+  ensure(scene).pendingOwnerId = null;
+}
+
+export function cancelBallTween(scene, ballSpriteOverride) {
+  const s = ensure(scene);
+  s.pendingOwnerId = null;
+  const ballSprite = ballSpriteOverride || scene.ballSprite;
+  if (scene?.tweens && ballSprite) {
+    scene.tweens.killTweensOf(ballSprite);
+  }
+}
+
+export default {
+  getCurrentOwner,
+  setCurrentOwner,
+  clearCurrentOwner,
+  getLastKnownOwner,
+  getPendingOwner,
+  setPendingOwner,
+  clearPendingOwner,
+  cancelBallTween
+};

--- a/tests/js/ballStateSequence.mjs
+++ b/tests/js/ballStateSequence.mjs
@@ -1,0 +1,68 @@
+import { attachBallToPlayer, animateRebound, shootBall } from '../../FrontEnd/static/js/phaser/animation/ballManager.js';
+import { runPass } from '../../FrontEnd/static/js/phaser/animation/ballTween.js';
+import { getCurrentOwner, getPendingOwner, clearPendingOwner } from '../../FrontEnd/static/js/phaser/ball/ballController.js';
+
+function makeScene() {
+  return {
+    tweens: {
+      add: ({ targets, x, y, duration, ease, onComplete, onStop }) => {
+        if (targets && targets[0]) {
+          targets[0].x = x;
+          targets[0].y = y;
+        }
+        onComplete?.();
+        return { once: () => {}, stop: () => onStop?.() };
+      },
+      killTweensOf: () => {}
+    },
+    time: { delayedCall: (ms, fn) => fn() },
+    events: { emit: () => {}, once: () => {} },
+    game: { config: { width: 100, height: 50 }, loop: { frame: 0 } },
+    playerSprites: {
+      a: { x: 0, y: 0, playerId: 'a', team: 'home', team_id: 'H' },
+      b: { x: 10, y: 0, playerId: 'b', team: 'home', team_id: 'H' },
+      c: { x: 20, y: 0, playerId: 'c', team: 'home', team_id: 'H' }
+    },
+    stateMachine: { is: () => false, transition: () => {} }
+  };
+}
+
+const scene = makeScene();
+const ballSprite = { x:0,y:0,setPosition(x,y){this.x=x;this.y=y;},setVisible(){},setDepth(){} };
+scene.ballSprite = ballSprite;
+
+const states = [];
+
+attachBallToPlayer(scene, ballSprite, scene.playerSprites.a);
+states.push({ step: 'attach', owner: getCurrentOwner(scene), pending: getPendingOwner(scene) });
+
+await runPass(scene, { fromId: 'a', toId: 'b', duration: 0 });
+states.push({ step: 'passComplete', owner: getCurrentOwner(scene), pending: getPendingOwner(scene) });
+clearPendingOwner(scene);
+states.push({ step: 'afterUpdate', owner: getCurrentOwner(scene), pending: getPendingOwner(scene) });
+
+const shot = await shootBall({
+  scene,
+  ballSprite,
+  fromCoords: { x: 0, y: 0 },
+  startTimestamp: 0,
+  result: 'MISS',
+  shooterPos: 'PG',
+  shooterId: 'b',
+  shooterTeamId: 'H',
+  homeTeamId: 'H'
+});
+states.push({ step: 'afterShot', owner: getCurrentOwner(scene), pending: getPendingOwner(scene) });
+
+await animateRebound({
+  scene,
+  ballSprite,
+  playerSprites: scene.playerSprites,
+  animations: [],
+  rebounderId: 'c',
+  ballSpot: shot.grid,
+  shooterId: 'b'
+});
+states.push({ step: 'afterRebound', owner: getCurrentOwner(scene), pending: getPendingOwner(scene) });
+
+console.log(JSON.stringify(states));

--- a/tests/js/offensiveReboundSequence.mjs
+++ b/tests/js/offensiveReboundSequence.mjs
@@ -4,11 +4,12 @@ import {
   animatePutbackAttempt,
   calls
 } from './ballManagerStub.mjs';
+import { setCurrentOwner, clearCurrentOwner, getCurrentOwner } from '../../FrontEnd/static/js/phaser/ball/ballController.js';
 
 const PAUSE_MS = 400;
 
 function makeScene() {
-  return { ballAttachedToPlayerId: null };
+  return {};
 }
 
 function makeBall() { return {}; }
@@ -24,12 +25,12 @@ async function scenarioA() {
   const events = [];
 
   await animateRebound({ scene, ballSprite: ball, playerSprites: players, animations: [], rebounderId: 'c', ballSpot: { x: 0, y: 0 } });
-  scene.ballAttachedToPlayerId = 'c';
+  setCurrentOwner(scene, 'c');
   events.push({ type: 'attach', id: 'c' });
 
   await animateKickoutReset(scene, ball, 'c', 'pg', {}, 0);
   events.push({ type: 'detach', id: 'c' });
-  scene.ballAttachedToPlayerId = 'pg';
+  setCurrentOwner(scene, 'pg');
   events.push({ type: 'attach', id: 'pg' });
 
   return { branch: 'kickout', pause: PAUSE_MS, attachments: { rebound: 'c', afterKickout: 'pg' }, events };
@@ -42,12 +43,12 @@ async function scenarioB(result) {
   const events = [];
 
   await animateRebound({ scene, ballSprite: ball, playerSprites: players, animations: [], rebounderId: 'c', ballSpot: { x: 0, y: 0 } });
-  scene.ballAttachedToPlayerId = 'c';
+  setCurrentOwner(scene, 'c');
   events.push({ type: 'attach', id: 'c' });
 
   const outcome = await animatePutbackAttempt(scene, ball, 'c', { x: 0, y: 0 }, 0, result);
   events.push({ type: 'detach', id: 'c' });
-  scene.ballAttachedToPlayerId = null;
+  clearCurrentOwner(scene);
 
   return { branch: 'putback', result, outcome, pause: 0, events };
 }

--- a/tests/js/runDefensiveReboundFlip.mjs
+++ b/tests/js/runDefensiveReboundFlip.mjs
@@ -1,4 +1,5 @@
 import { playTurnAnimation } from '../../FrontEnd/static/js/phaser/animation/turnAnimation.js';
+import { getCurrentOwner } from '../../FrontEnd/static/js/phaser/ball/ballController.js';
 
 function makeScene() {
   const log = {};
@@ -49,4 +50,4 @@ const turnData = {
 
 await playTurnAnimation({ scene, simData, playerSprites: scene.playerSprites, turnData, ballSprite });
 
-console.log(JSON.stringify({ newOffense: scene.offenseTeamId, eventOffense: scene.possessionLog.event, attached: scene.ballAttachedToPlayerId }));
+console.log(JSON.stringify({ newOffense: scene.offenseTeamId, eventOffense: scene.possessionLog.event, attached: getCurrentOwner(scene) }));

--- a/tests/js/runReboundAnimation.mjs
+++ b/tests/js/runReboundAnimation.mjs
@@ -1,4 +1,5 @@
 import { playTurnAnimation } from '../../FrontEnd/static/js/phaser/animation/turnAnimation.js';
+import { getCurrentOwner } from '../../FrontEnd/static/js/phaser/ball/ballController.js';
 
 function makeScene() {
   return {
@@ -63,7 +64,7 @@ function createBallSprite() {
     events: [{ event_type: 'PUTBACK_ATTEMPT', shooterId: 'c', result: 'MAKE', duration: 0 }]
   };
   await playTurnAnimation({ scene, simData, playerSprites: scene.playerSprites, turnData, ballSprite });
-  var inboundSetup = scene.ballAttachedToPlayerId === 'pgA';
+  var inboundSetup = getCurrentOwner(scene) === 'pgA';
 }
 
 // Putback miss should trigger rebound animation attaching ball to rebounderId
@@ -80,7 +81,7 @@ let reboundAttached;
     events: [{ event_type: 'PUTBACK_ATTEMPT', shooterId: 'c', result: 'MISS', duration: 0, rebound: { rebounderId: 'pg', ballSpot: { x: 0, y: 0 } } }]
   };
   await playTurnAnimation({ scene, simData, playerSprites: scene.playerSprites, turnData, ballSprite });
-  reboundAttached = scene.ballAttachedToPlayerId;
+  reboundAttached = getCurrentOwner(scene);
 }
 
 // Kickout reset should attach ball to PG and start new turn
@@ -98,7 +99,7 @@ let kickoutResult;
     events: [{ event_type: 'KICKOUT_RESET', rebounderId: 'c', pgId: 'pg', pass: { fromCoords: { x: 0, y: 0 }, toCoords: { x: 1, y: 1 }, duration: 0 } }]
   };
   await playTurnAnimation({ scene, simData, playerSprites: scene.playerSprites, turnData, ballSprite });
-  kickoutResult = { attached: scene.ballAttachedToPlayerId, newTurn: scene.newTurn === true };
+  kickoutResult = { attached: getCurrentOwner(scene), newTurn: scene.newTurn === true };
 }
 
 console.log(JSON.stringify({ inboundSetup, reboundAttached, kickoutResult }));

--- a/tests/js/runReboundInProgress.mjs
+++ b/tests/js/runReboundInProgress.mjs
@@ -1,5 +1,6 @@
 import { attachBallToPlayer, animateRebound } from '../../FrontEnd/static/js/phaser/animation/ballManager.js';
 import { createGameStateMachine, States } from '../../FrontEnd/static/js/phaser/state/gameStateMachine.js';
+import { getCurrentOwner } from '../../FrontEnd/static/js/phaser/ball/ballController.js';
 
 function makeScene() {
   return {
@@ -31,7 +32,7 @@ const ballSprite = { setPosition(){}, setVisible(){}, setDepth(){} };
 
 // Attempt to attach to non-rebounder while rebound in progress
 attachBallToPlayer(scene, ballSprite, scene.playerSprites.b);
-const first = scene.ballAttachedToPlayerId ?? null;
+const first = getCurrentOwner(scene) ?? null;
 
 // Animate rebound to attach to rebounder and clear flag
 await animateRebound({
@@ -42,11 +43,11 @@ await animateRebound({
   rebounderId: 'a',
   ballSpot: { x: 0, y: 0 }
 });
-const afterRebound = scene.ballAttachedToPlayerId;
+const afterRebound = getCurrentOwner(scene);
 const flagAfterRebound = scene.stateMachine.is(States.Rebound);
 
 // Now that flag is cleared, attaching to another player works
 attachBallToPlayer(scene, ballSprite, scene.playerSprites.b);
-const final = scene.ballAttachedToPlayerId;
+const final = getCurrentOwner(scene);
 
 console.log(JSON.stringify({ first, afterRebound, flagAfterRebound, final }));


### PR DESCRIPTION
## Summary
- centralize ball state with new `ballController`
- refactor pass, shot, and rebound animations to use controller and cancel tweens
- add regression tests for ball ownership across plays

## Testing
- `node --experimental-loader ./tests/js/httpsLoaderNoStubBall.mjs ./tests/js/ballStateSequence.mjs`
- `node --experimental-loader ./tests/js/httpsLoaderNoStubBall.mjs ./tests/js/runReboundAnimation.mjs`
- `node --experimental-loader ./tests/js/httpsLoaderNoStubBall.mjs ./tests/js/runDefensiveReboundFlip.mjs`
- `node --experimental-loader ./tests/js/httpsLoaderNoStubBall.mjs ./tests/js/runReboundInProgress.mjs`
- `node --experimental-loader ./tests/js/httpsLoader.mjs ./tests/js/offensiveReboundSequence.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68b84aca298c8328a7511ecbb9819275