### PR TITLE
Track shot attempts and guard rebound transition

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -153,6 +153,7 @@ export function shootBall({
   if (scene?.stateMachine?.is(States.FreeThrow)) return Promise.resolve();
   cancelBallTween(scene, ballSprite);
   clearCurrentOwner(scene);
+  scene.stateMachine?.transition(States.ShotAttempt);
   const homeRoster = gameStore.getHomeRoster();
   const storeHomeId =
     homeRoster?.team_id || homeRoster?.teamId || homeRoster?.team_name || homeRoster?.team;
@@ -236,8 +237,10 @@ export function shootBall({
               playerId: shooterId,
               team: shooterTeamId
             });
+        }
+          if (scene.stateMachine?.is(States.ShotAttempt)) {
+            scene.stateMachine.transition(States.Rebound);
           }
-          scene.stateMachine?.transition(States.Rebound);
           scene.rebounderId = null;
           scene.tweens.add({
             targets: ballSprite,


### PR DESCRIPTION
## Summary
- Transition to `ShotAttempt` state when starting a shot
- Only move to `Rebound` state on miss if currently in `ShotAttempt`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8579b124c8328acfa5bc957ab7437