### PR TITLE
feat: add optional game state transition debug logging

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -10,7 +10,7 @@ import {
   tweenBallTo,
   runPass as baseRunPass
 } from "./ballTween.js";
-import { States } from "../state/gameStateMachine.js";
+import { States, getDebugTransitions } from "../state/gameStateMachine.js";
 import gameStore from "../../state/gameStore.js";
 import { clearCurrentOwner, cancelBallTween } from "../ball/ballController.js";
 
@@ -237,7 +237,7 @@ export function shootBall({
               team: shooterTeamId
             });
           }
-          scene.stateMachine?.transition(States.Rebound);
+          scene.stateMachine?.transition(States.Rebound, getDebugTransitions() && { stepIndex, shotResult: result });
           scene.rebounderId = null;
           scene.tweens.add({
             targets: ballSprite,
@@ -340,7 +340,7 @@ export function animatePutbackAttempt(
                 scene.game.config.width,
                 scene.game.config.height
               );
-              scene.stateMachine?.transition(States.Rebound);
+              scene.stateMachine?.transition(States.Rebound, getDebugTransitions() && { shotResult: result });
               scene.rebounderId = null;
               scene.tweens.add({
                 targets: ballSprite,
@@ -451,7 +451,7 @@ export function animateRebound({
             scene.events?.emit("possessionChange", {
               offenseTeamId: rebounderSprite.team_id
             });
-            if (scene.stateMachine?.is(States.Rebound)) scene.stateMachine?.transition(States.HalfCourt);
+            if (scene.stateMachine?.is(States.Rebound)) scene.stateMachine?.transition(States.HalfCourt, getDebugTransitions() && {});
             scene.rebounderId = null;
             resolve();
           },

--- a/FrontEnd/static/js/phaser/animation/fastBreak.js
+++ b/FrontEnd/static/js/phaser/animation/fastBreak.js
@@ -4,7 +4,7 @@ import { attachBallToPlayer } from "./ballManager.js";
 import { tweenBallTo, tweenPlayerTo, runPass } from "./ballTween.js";
 import animationConfig from "./animation_config.js";
 import { HOME_RIM_COORDS, AWAY_RIM_COORDS, HOME_TOP_KEY, AWAY_TOP_KEY } from "./courtConstants.js";
-import { States } from "../state/gameStateMachine.js";
+import { States, getDebugTransitions } from "../state/gameStateMachine.js";
 import { getCurrentOwner } from "../ball/ballController.js";
 import { createAnimationTimeline } from "./animationTimeline.js";
 import { runInboundSetup } from "./turnAnimation.js";
@@ -17,7 +17,7 @@ export async function runFastBreakSequence({ scene, turnData, playerSprites, bal
   if (!scene || !turnData || scene.skipToEnd) return;
   if (!scene.ballSprite) scene.ballSprite = ballSprite;
 
-  scene.stateMachine?.transition(States.FastBreak);
+  scene.stateMachine?.transition(States.FastBreak, getDebugTransitions() && { stepIndex: 0 });
   scene.events?.emit("fb:start");
 
   // stop any existing timeline/tweens

--- a/FrontEnd/static/js/phaser/animation/freeThrow.js
+++ b/FrontEnd/static/js/phaser/animation/freeThrow.js
@@ -1,7 +1,7 @@
 import { gridToPixels } from "../utils/gridToPixels.js";
 import animationConfig from "./animation_config.js";
 import { HOME_RIM_COORDS, AWAY_RIM_COORDS } from "./courtConstants.js";
-import { States } from "../state/gameStateMachine.js";
+import { States, getDebugTransitions } from "../state/gameStateMachine.js";
 
 function wait(scene, ms) {
   if (!ms) return Promise.resolve();
@@ -34,7 +34,7 @@ export async function runFreeThrowSequence(
 
   if (!scene || !playerSprites || !ballSprite || !turnData) return;
 
-  scene.stateMachine?.transition(States.FreeThrow);
+  scene.stateMachine?.transition(States.FreeThrow, getDebugTransitions() && { stepIndex: 0 });
   if (scene.tweens) {
     for (const sprite of Object.values(playerSprites)) {
       scene.tweens.killTweensOf(sprite);
@@ -135,7 +135,7 @@ export async function runFreeThrowSequence(
         }
       }
       if (isLast) {
-        scene.stateMachine?.transition(States.Inbound);
+        scene.stateMachine?.transition(States.Inbound, getDebugTransitions() && { shotResult: result });
         const newOffenseSide =
           turnData.offense_team_id === scene.simData?.home_team_id
             ? "away"
@@ -164,7 +164,7 @@ export async function runFreeThrowSequence(
       }
     } else {
       if (isLast) {
-        scene.stateMachine?.transition(States.Rebound);
+        scene.stateMachine?.transition(States.Rebound, getDebugTransitions() && { shotResult: result });
         await rebound({
           scene,
           ballSprite,
@@ -194,7 +194,7 @@ export async function runFreeThrowSequence(
     scene.events?.emit("ft:repeatOrExit");
   }
 
-  if (scene.stateMachine?.is(States.FreeThrow)) scene.stateMachine.transition(States.HalfCourt);
+  if (scene.stateMachine?.is(States.FreeThrow)) scene.stateMachine.transition(States.HalfCourt, getDebugTransitions() && {});
   scene.events?.emit("ft:end");
 }
 

--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -13,7 +13,7 @@ import { tweenBallTo, runPass, PASS_DEBUG, tweenPlayerTo } from "./ballTween.js"
 import animationConfig from "./animation_config.js";
 import { HOME_RIM_COORDS, AWAY_RIM_COORDS } from "./courtConstants.js";
 import { DEBUG } from "../utils/debug.js";
-import { States } from "../state/gameStateMachine.js";
+import { States, getDebugTransitions } from "../state/gameStateMachine.js";
 import {
   getPendingOwner,
   clearPendingOwner,
@@ -313,7 +313,7 @@ async function runInboundSetup({
 }) {
   if (scene?.stateMachine?.is(States.FreeThrow)) return;
   scene.isInboundSetup = true;
-  if (!scene.stateMachine?.is(States.Inbound)) scene.stateMachine?.transition?.(States.Inbound);
+  if (!scene.stateMachine?.is(States.Inbound)) scene.stateMachine?.transition?.(States.Inbound, getDebugTransitions() && { stepIndex: 0 });
   if (!scene.ballSprite) scene.ballSprite = ballSprite;
   const isAwayOffense = newOffenseSide === "away";
 
@@ -613,7 +613,7 @@ async function runInboundSetup({
   console.log(`[inbound][passEnd][${newOffenseSide}] sf:${sfId} pg:${pgId}`);
   console.log(`[inbound][pgAttach][${newOffenseSide}] sf:${sfId} pg:${pgId}`);
 
-  if (scene.stateMachine?.is(States.Inbound)) scene.stateMachine?.transition?.(States.HalfCourt);
+  if (scene.stateMachine?.is(States.Inbound)) scene.stateMachine?.transition?.(States.HalfCourt, getDebugTransitions() && { stepIndex: 0 });
 
   scene.isInboundSetup = false;
 }
@@ -826,7 +826,7 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
                   scene.events?.emit?.("possessionChange", {
                     offenseTeamId: rebounderSprite.team_id
                   });
-                  if (scene.stateMachine?.is(States.Rebound)) scene.stateMachine?.transition(States.HalfCourt);
+                  if (scene.stateMachine?.is(States.Rebound)) scene.stateMachine?.transition(States.HalfCourt, getDebugTransitions() && { stepIndex: shotInfo?.stepIndex, shotResult: turnData.result_type });
                   scene.rebounderId = null;
                   if (scene.time?.delayedCall) {
                     scene.time.delayedCall(rebCfg.attachDelayMs, resolve);

--- a/FrontEnd/static/js/phaser/state/gameStateMachine.js
+++ b/FrontEnd/static/js/phaser/state/gameStateMachine.js
@@ -18,15 +18,30 @@ const transitions = {
   [States.EndQuarter]: [States.Inbound]
 };
 
+let debugTransitions = false;
+
+export function setDebugTransitions(value) {
+  debugTransitions = !!value;
+}
+
+export function getDebugTransitions() {
+  return debugTransitions;
+}
+
 export function createGameStateMachine(initialState = States.Inbound) {
   let state = initialState;
   return {
-    transition(next) {
+    transition(next, context) {
       const allowed = transitions[state] || [];
       if (!allowed.includes(next)) {
         throw new Error(`Invalid transition: ${state} -> ${next}`);
       }
+      const prevState = state;
       state = next;
+      if (debugTransitions) {
+        const { stepIndex, shotResult } = context || {};
+        console.log({ prevState, nextState: state, event: next, stepIndex, shotResult });
+      }
     },
     is(s) {
       return state === s;


### PR DESCRIPTION
## Summary
- add debugTransitions flag with setter/getter for game state logging
- log state transitions with step and shot context when enabled
- supply stepIndex and shotResult context from animation helpers

## Testing
- `pytest tests/test_game_state_machine.py tests/test_frontend_free_throw_sequence.py tests/test_frontend_rebound_animation.py tests/test_frontend_rim_animation.py`

------
https://chatgpt.com/codex/tasks/task_e_68b857a5c1f483288d89de1edd5d1c55