### PR TITLE
Ensure side inbound transitions to half-court state

### DIFF
--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -139,6 +139,9 @@ async function runSetupTween({ scene, ballSprite, animations, playerSprites, cur
 async function runSideInboundSetup({ scene, ballSprite, playerSprites, turnData }) {
   if (!turnData || scene?.skipToEnd || scene?.stateMachine?.is(States.FreeThrow) || scene?.stateMachine?.is(States.FastBreak)) return;
 
+  scene.isInboundSetup = true;
+  if (!scene.stateMachine?.is(States.Inbound)) scene.stateMachine?.transition?.(States.Inbound, getDebugTransitions() && { stepIndex: 0 });
+
   const { ball_spot, oDestinations = {}, dDestinations = {}, possession_team_id } = turnData;
   const offenseTeamId = scene.currentOffenseTeamId ?? possession_team_id;
 
@@ -229,7 +232,9 @@ async function runSideInboundSetup({ scene, ballSprite, playerSprites, turnData 
     if (pgSprite) {
       console.log(`[sideInbound][pgAttach] sf:${sfId} pg:${pgId}`);
     }
+    if (scene.stateMachine?.is(States.Inbound)) scene.stateMachine?.transition?.(States.HalfCourt, getDebugTransitions() && { stepIndex: 0 });
   }
+  scene.isInboundSetup = false;
 }
 
 // Setup positions after a defensive rebound before new half-court offense


### PR DESCRIPTION
## Summary
- Ensure side inbound setup runs in Inbound state
- Transition to HalfCourt after SF to PG pass and clear inbound flag

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8640884608328b4d8aa845de93169