### PR TITLE
Guard shot attempt transition against illegal states

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -153,7 +153,23 @@ export function shootBall({
   if (scene?.stateMachine?.is(States.FreeThrow)) return Promise.resolve();
   cancelBallTween(scene, ballSprite);
   clearCurrentOwner(scene);
-  scene.stateMachine?.transition(States.ShotAttempt);
+  const stateMachine = scene.stateMachine;
+  if (stateMachine) {
+    const prevState = stateMachine.state;
+    const legalState =
+      stateMachine.is(States.HalfCourt) ||
+      stateMachine.is(States.Rebound) ||
+      stateMachine.is(States.FastBreak);
+    if (legalState) {
+      stateMachine.transition(States.ShotAttempt);
+    } else {
+      console.warn("shotBall: illegal state", {
+        prevState,
+        shooterId,
+        stepIndex
+      });
+    }
+  }
   const homeRoster = gameStore.getHomeRoster();
   const storeHomeId =
     homeRoster?.team_id || homeRoster?.teamId || homeRoster?.team_name || homeRoster?.team;


### PR DESCRIPTION
## Summary
- prevent shot attempt transition unless state machine is in HalfCourt, Rebound or FastBreak
- warn when shot is attempted from an unexpected state

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8659e278083289f6750fd41fbb1cb