### PR TITLE
feat: add safe state transitions with context checks

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -10,9 +10,14 @@ import {
   tweenBallTo,
   runPass as baseRunPass
 } from "./ballTween.js";
-import { States, getDebugTransitions } from "../state/gameStateMachine.js";
+import { States, getDebugTransitions, safeTransition } from "../state/gameStateMachine.js";
 import gameStore from "../../state/gameStore.js";
-import { clearCurrentOwner, cancelBallTween } from "../ball/ballController.js";
+import {
+  clearCurrentOwner,
+  cancelBallTween,
+  getCurrentOwner,
+  getPendingOwner,
+} from "../ball/ballController.js";
 
 function attachBallToPlayer(scene, ballSprite, playerSprite, opts = {}) {
   if (scene.possessionFlipInProgress) return;
@@ -161,7 +166,16 @@ export function shootBall({
       stateMachine.is(States.Rebound) ||
       stateMachine.is(States.FastBreak);
     if (legalState) {
-      stateMachine.transition(States.ShotAttempt);
+      safeTransition(
+        stateMachine,
+        States.ShotAttempt,
+        {
+          stepIndex,
+          currentOwnerId: getCurrentOwner(scene),
+          pendingOwnerId: getPendingOwner(scene),
+        },
+        ["stepIndex"]
+      );
     } else {
       console.warn("shotBall: illegal state", {
         prevState,
@@ -245,17 +259,27 @@ export function shootBall({
             scene.game.config.width,
             scene.game.config.height
           );
-          if (SHOT_DEBUG) {
-            console.log("shot:miss", {
-              type: "miss",
-              shooterId,
-              reboundSpot: { x: bounceGridX, y: bounceGridY },
-              playerId: shooterId,
-              team: shooterTeamId
-            });
-        }
+        if (SHOT_DEBUG) {
+          console.log("shot:miss", {
+            type: "miss",
+            shooterId,
+            reboundSpot: { x: bounceGridX, y: bounceGridY },
+            playerId: shooterId,
+            team: shooterTeamId
+          });
+      }
           if (scene.stateMachine?.is(States.ShotAttempt)) {
-            scene.stateMachine.transition(States.Rebound);
+            safeTransition(
+              scene.stateMachine,
+              States.Rebound,
+              {
+                shotResult: result,
+                stepIndex,
+                currentOwnerId: getCurrentOwner(scene),
+                pendingOwnerId: getPendingOwner(scene),
+              },
+              ["shotResult"]
+            );
           }
           scene.rebounderId = null;
           scene.tweens.add({
@@ -470,7 +494,11 @@ export function animateRebound({
             scene.events?.emit("possessionChange", {
               offenseTeamId: rebounderSprite.team_id
             });
-            if (scene.stateMachine?.is(States.Rebound)) scene.stateMachine?.transition(States.HalfCourt, getDebugTransitions() && {});
+            if (scene.stateMachine?.is(States.Rebound))
+              safeTransition(scene.stateMachine, States.HalfCourt, {
+                currentOwnerId: getCurrentOwner(scene),
+                pendingOwnerId: getPendingOwner(scene),
+              });
             scene.rebounderId = null;
             resolve();
           },

--- a/FrontEnd/static/js/phaser/animation/freeThrow.js
+++ b/FrontEnd/static/js/phaser/animation/freeThrow.js
@@ -1,7 +1,8 @@
 import { gridToPixels } from "../utils/gridToPixels.js";
 import animationConfig from "./animation_config.js";
 import { HOME_RIM_COORDS, AWAY_RIM_COORDS } from "./courtConstants.js";
-import { States, getDebugTransitions } from "../state/gameStateMachine.js";
+import { States, safeTransition } from "../state/gameStateMachine.js";
+import { getCurrentOwner, getPendingOwner } from "../ball/ballController.js";
 
 function wait(scene, ms) {
   if (!ms) return Promise.resolve();
@@ -34,7 +35,16 @@ export async function runFreeThrowSequence(
 
   if (!scene || !playerSprites || !ballSprite || !turnData) return;
 
-  scene.stateMachine?.transition(States.FreeThrow, getDebugTransitions() && { stepIndex: 0 });
+  safeTransition(
+    scene.stateMachine,
+    States.FreeThrow,
+    {
+      stepIndex: 0,
+      currentOwnerId: getCurrentOwner(scene),
+      pendingOwnerId: getPendingOwner(scene),
+    },
+    ["stepIndex"]
+  );
   if (scene.tweens) {
     for (const sprite of Object.values(playerSprites)) {
       scene.tweens.killTweensOf(sprite);
@@ -135,7 +145,16 @@ export async function runFreeThrowSequence(
         }
       }
       if (isLast) {
-        scene.stateMachine?.transition(States.Inbound, getDebugTransitions() && { shotResult: result });
+        safeTransition(
+          scene.stateMachine,
+          States.Inbound,
+          {
+            shotResult: result,
+            currentOwnerId: getCurrentOwner(scene),
+            pendingOwnerId: getPendingOwner(scene),
+          },
+          ["shotResult"]
+        );
         const newOffenseSide =
           turnData.offense_team_id === scene.simData?.home_team_id
             ? "away"
@@ -164,7 +183,16 @@ export async function runFreeThrowSequence(
       }
     } else {
       if (isLast) {
-        scene.stateMachine?.transition(States.Rebound, getDebugTransitions() && { shotResult: result });
+        safeTransition(
+          scene.stateMachine,
+          States.Rebound,
+          {
+            shotResult: result,
+            currentOwnerId: getCurrentOwner(scene),
+            pendingOwnerId: getPendingOwner(scene),
+          },
+          ["shotResult"]
+        );
         await rebound({
           scene,
           ballSprite,
@@ -194,7 +222,11 @@ export async function runFreeThrowSequence(
     scene.events?.emit("ft:repeatOrExit");
   }
 
-  if (scene.stateMachine?.is(States.FreeThrow)) scene.stateMachine.transition(States.HalfCourt, getDebugTransitions() && {});
+  if (scene.stateMachine?.is(States.FreeThrow))
+    safeTransition(scene.stateMachine, States.HalfCourt, {
+      currentOwnerId: getCurrentOwner(scene),
+      pendingOwnerId: getPendingOwner(scene),
+    });
   scene.events?.emit("ft:end");
 }
 

--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -13,7 +13,7 @@ import { tweenBallTo, runPass, PASS_DEBUG, tweenPlayerTo } from "./ballTween.js"
 import animationConfig from "./animation_config.js";
 import { HOME_RIM_COORDS, AWAY_RIM_COORDS } from "./courtConstants.js";
 import { DEBUG } from "../utils/debug.js";
-import { States, getDebugTransitions } from "../state/gameStateMachine.js";
+import { States, getDebugTransitions, safeTransition } from "../state/gameStateMachine.js";
 import {
   getPendingOwner,
   clearPendingOwner,
@@ -140,7 +140,18 @@ async function runSideInboundSetup({ scene, ballSprite, playerSprites, turnData 
   if (!turnData || scene?.skipToEnd || scene?.stateMachine?.is(States.FreeThrow) || scene?.stateMachine?.is(States.FastBreak)) return;
 
   scene.isInboundSetup = true;
-  if (!scene.stateMachine?.is(States.Inbound)) scene.stateMachine?.transition?.(States.Inbound, getDebugTransitions() && { stepIndex: 0 });
+  if (!scene.stateMachine?.is(States.Inbound)) {
+    safeTransition(
+      scene.stateMachine,
+      States.Inbound,
+      {
+        stepIndex: 0,
+        currentOwnerId: getCurrentOwner(scene),
+        pendingOwnerId: getPendingOwner(scene),
+      },
+      ["stepIndex"]
+    );
+  }
 
   const { ball_spot, oDestinations = {}, dDestinations = {}, possession_team_id } = turnData;
   const offenseTeamId = scene.currentOffenseTeamId ?? possession_team_id;
@@ -232,7 +243,17 @@ async function runSideInboundSetup({ scene, ballSprite, playerSprites, turnData 
     if (pgSprite) {
       console.log(`[sideInbound][pgAttach] sf:${sfId} pg:${pgId}`);
     }
-    if (scene.stateMachine?.is(States.Inbound)) scene.stateMachine?.transition?.(States.HalfCourt, getDebugTransitions() && { stepIndex: 0 });
+    if (scene.stateMachine?.is(States.Inbound))
+      safeTransition(
+        scene.stateMachine,
+        States.HalfCourt,
+        {
+          stepIndex: 0,
+          currentOwnerId: getCurrentOwner(scene),
+          pendingOwnerId: getPendingOwner(scene),
+        },
+        ["stepIndex"]
+      );
   }
   scene.isInboundSetup = false;
 }
@@ -318,7 +339,18 @@ async function runInboundSetup({
 }) {
   if (scene?.stateMachine?.is(States.FreeThrow)) return;
   scene.isInboundSetup = true;
-  if (!scene.stateMachine?.is(States.Inbound)) scene.stateMachine?.transition?.(States.Inbound, getDebugTransitions() && { stepIndex: 0 });
+  if (!scene.stateMachine?.is(States.Inbound)) {
+    safeTransition(
+      scene.stateMachine,
+      States.Inbound,
+      {
+        stepIndex: 0,
+        currentOwnerId: getCurrentOwner(scene),
+        pendingOwnerId: getPendingOwner(scene),
+      },
+      ["stepIndex"]
+    );
+  }
   if (!scene.ballSprite) scene.ballSprite = ballSprite;
   const isAwayOffense = newOffenseSide === "away";
 
@@ -618,7 +650,17 @@ async function runInboundSetup({
   console.log(`[inbound][passEnd][${newOffenseSide}] sf:${sfId} pg:${pgId}`);
   console.log(`[inbound][pgAttach][${newOffenseSide}] sf:${sfId} pg:${pgId}`);
 
-  if (scene.stateMachine?.is(States.Inbound)) scene.stateMachine?.transition?.(States.HalfCourt, getDebugTransitions() && { stepIndex: 0 });
+  if (scene.stateMachine?.is(States.Inbound))
+    safeTransition(
+      scene.stateMachine,
+      States.HalfCourt,
+      {
+        stepIndex: 0,
+        currentOwnerId: getCurrentOwner(scene),
+        pendingOwnerId: getPendingOwner(scene),
+      },
+      ["stepIndex"]
+    );
 
   scene.isInboundSetup = false;
 }

--- a/FrontEnd/static/js/phaser/state/gameStateMachine.js
+++ b/FrontEnd/static/js/phaser/state/gameStateMachine.js
@@ -28,27 +28,58 @@ export function getDebugTransitions() {
   return debugTransitions;
 }
 
+export function safeTransition(machine, next, ctx = {}, required = []) {
+  if (!machine) return;
+  const missing = required.filter(
+    (key) => ctx[key] === undefined || ctx[key] === null
+  );
+  if (missing.length) {
+    const stack = new Error().stack?.split("\n")[2]?.trim();
+    console.warn("safeTransition missing context", { missing, caller: stack });
+    return;
+  }
+
+  const allowed = transitions[machine.state] || [];
+  if (!allowed.includes(next)) {
+    const stack = new Error().stack?.split("\n")[2]?.trim();
+    console.warn(`Invalid transition: ${machine.state} -> ${next}`, {
+      caller: stack,
+    });
+    return;
+  }
+
+  const prevState = machine.state;
+  machine.transition(next);
+  if (debugTransitions) {
+    const { stepIndex, shotResult, currentOwnerId, pendingOwnerId } = ctx;
+    console.log({
+      prevState,
+      event: next,
+      nextState: machine.state,
+      stepIndex,
+      shotResult,
+      currentOwnerId,
+      pendingOwnerId,
+    });
+  }
+}
+
 export function createGameStateMachine(initialState = States.Inbound) {
   let state = initialState;
   return {
-    transition(next, context) {
+    transition(next) {
       const allowed = transitions[state] || [];
       if (!allowed.includes(next)) {
         throw new Error(`Invalid transition: ${state} -> ${next}`);
       }
-      const prevState = state;
       state = next;
-      if (debugTransitions) {
-        const { stepIndex, shotResult } = context || {};
-        console.log({ prevState, nextState: state, event: next, stepIndex, shotResult });
-      }
     },
     is(s) {
       return state === s;
     },
     get state() {
       return state;
-    }
+    },
   };
 }
 


### PR DESCRIPTION
## Summary
- add `safeTransition` wrapper around state changes with required context validation and debug logging
- replace direct `transition` calls in ball and inbound handlers with `safeTransition`
- ensure free throw and rebound flows use validated transitions

## Testing
- `pytest`
- `node tests/js/runGameStateMachine.mjs`
- `node tests/js/runFreeThrowSequence.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68b8664770b8832887054c85eccf41c0