### PR TITLE
Reset ball state flags between turns

### DIFF
--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -256,6 +256,8 @@ async function runSideInboundSetup({ scene, ballSprite, playerSprites, turnData 
       );
   }
   scene.isInboundSetup = false;
+  scene.passInFlight = false;
+  scene.ballDetached = false;
 }
 
 // Setup positions after a defensive rebound before new half-court offense
@@ -663,6 +665,8 @@ async function runInboundSetup({
     );
 
   scene.isInboundSetup = false;
+  scene.passInFlight = false;
+  scene.ballDetached = false;
 }
 
 
@@ -671,6 +675,11 @@ async function runInboundSetup({
  * Each stepIndex is animated across all players, then the next step begins.
  */
 export async function playTurnAnimation({ scene, simData, playerSprites, turnData, ballSprite, onAction }) {
+  scene.passInFlight = false;
+  scene.ballDetached = false;
+  scene.rebounderId = null;
+  clearPendingOwner(scene);
+
   const currentBallOwnerRef = { value: null };
   // Store a reference on the scene so other modules (e.g., runPass)
   // can update ball ownership consistently.


### PR DESCRIPTION
## Summary
- Clear pass flags and rebound state at the start of `playTurnAnimation`
- Reset pass-related flags after inbound setup routines to avoid carry-over between turns

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b868343eec83289d8b5b8d6acaa7af