### PR TITLE
Add outlet setup state and defensive rebound outlet pass

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animation_config.js
+++ b/FrontEnd/static/js/phaser/animation/animation_config.js
@@ -21,6 +21,11 @@ const defaults = {
     easing: 'Sine.easeInOut',
     arc: null,
   },
+  outletSetup: {
+    playerMoveMs: 800,
+    passMs: 300,
+    easing: 'Sine.easeInOut',
+  },
   rebound: {
     // Area (in grid units) around the rim where missed shots can land
     bounceArea: { x: 6, y: 6 },
@@ -75,6 +80,15 @@ export const animationConfig = {
     ...(overrides.offensiveRebound || {}),
   },
   putback: { ...defaults.putback, ...(overrides.putback || {}) },
+};
+
+animationConfig.outletSetup = {
+  playerMoveMs:
+    overrides.outletSetup?.playerMoveMs ?? defaults.outletSetup.playerMoveMs,
+  passMs:
+    overrides.outletSetup?.passMs ?? defaults.outletSetup.passMs,
+  easing:
+    overrides.outletSetup?.easing ?? animationConfig.pass.easing,
 };
 
 export default animationConfig;

--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -13,6 +13,7 @@ import { tweenBallTo, runPass, PASS_DEBUG, tweenPlayerTo } from "./ballTween.js"
 import animationConfig from "./animation_config.js";
 import { HOME_RIM_COORDS, AWAY_RIM_COORDS } from "./courtConstants.js";
 import { DEBUG } from "../utils/debug.js";
+import { DebugFlags } from "../utils/debugFlags.js";
 import { States, getDebugTransitions, safeTransition } from "../state/gameStateMachine.js";
 import {
   getPendingOwner,
@@ -270,6 +271,18 @@ async function runDefensiveReboundSetup({ scene, ballSprite, playerSprites, rebo
   scene.possessionFlipInProgress = true;
   if (ballSprite) attachBallToPlayer(scene, ballSprite, rebounderSprite);
 
+  if (scene.stateMachine?.is(States.Rebound)) {
+    if (DebugFlags?.FSM) console.log('FSM: Rebound -> OutletSetup');
+    safeTransition(
+      scene.stateMachine,
+      States.OutletSetup,
+      {
+        currentOwnerId: getCurrentOwner(scene),
+        pendingOwnerId: getPendingOwner(scene),
+      }
+    );
+  }
+
   const basketGrid =
     rebounderSprite.team === "home" ? HOME_RIM_COORDS : AWAY_RIM_COORDS;
   const width = scene.game.config.width;
@@ -289,19 +302,31 @@ async function runDefensiveReboundSetup({ scene, ballSprite, playerSprites, rebo
     }
   }
 
+  const promises = [];
+  let pgTarget = null;
   if (pgId && pgId !== rebounderId) {
     const pgSprite = playerSprites[pgId];
     if (pgSprite) {
       const sign = basketGrid.x > rebGridX ? 1 : -1;
-      const targetGrid = {
-        x: rebGridX + sign * Phaser.Math.Between(3, 9),
-        y: rebGridY + Phaser.Math.Between(-6, 6)
+      pgTarget = {
+        x: Phaser.Math.Clamp(
+          rebGridX + sign * Phaser.Math.Between(3, 6),
+          4,
+          97
+        ),
+        y: Phaser.Math.Clamp(
+          rebGridY + Phaser.Math.Between(-6, 6),
+          1,
+          50
+        ),
       };
-      if (sign > 0) targetGrid.x = Math.min(targetGrid.x, basketGrid.x - 1);
-      else targetGrid.x = Math.max(targetGrid.x, basketGrid.x + 1);
-      targetGrid.y = Math.max(0, Math.min(50, targetGrid.y));
-      const pgPx = gridToPixels(targetGrid.x, targetGrid.y, width, height);
-      tweenPlayerTo(scene, pgSprite, pgPx, { duration: 2000 });
+      const pgPx = gridToPixels(pgTarget.x, pgTarget.y, width, height);
+      promises.push(
+        tweenPlayerTo(scene, pgSprite, pgPx, {
+          duration: animationConfig.outletSetup.playerMoveMs,
+        })
+      );
+      if (DebugFlags?.BALL) console.log('pgOutletTarget', { pgId, pgTarget });
     }
   }
 
@@ -316,15 +341,43 @@ async function runDefensiveReboundSetup({ scene, ballSprite, playerSprites, rebo
     const sign = basketGrid.x > 50 ? -1 : 1;
     const targetGrid = {
       x: basketGrid.x + sign * offset,
-      y: Phaser.Math.Between(10, 40)
+      y: Phaser.Math.Between(10, 40),
     };
     const targetPx = gridToPixels(targetGrid.x, targetGrid.y, width, height);
-    tweenPlayerTo(scene, sprite, targetPx, { duration: 2000 });
+    promises.push(
+      tweenPlayerTo(scene, sprite, targetPx, {
+        duration: animationConfig.outletSetup.playerMoveMs,
+      })
+    );
   }
 
-  await new Promise((resolve) => scene.time.delayedCall(2000, resolve));
+  await Promise.all(promises);
+
+  if (pgId && pgId !== rebounderId) {
+    if (DebugFlags?.BALL)
+      console.log('outletPass', { fromId: rebounderId, toId: pgId });
+    await runPass(scene, {
+      fromId: rebounderId,
+      toId: pgId,
+      duration: animationConfig.outletSetup.passMs,
+      easing: animationConfig.outletSetup.easing,
+    });
+  }
 
   scene.possessionFlipInProgress = false;
+
+  if (scene.stateMachine?.is(States.OutletSetup)) {
+    if (DebugFlags?.FSM) console.log('FSM: OutletSetup -> HalfCourt');
+    safeTransition(
+      scene.stateMachine,
+      States.HalfCourt,
+      {
+        currentOwnerId: getCurrentOwner(scene),
+        pendingOwnerId: getPendingOwner(scene),
+      }
+    );
+  }
+
   if (typeof scene.startNextHalfCourtOffense === "function") {
     scene.startNextHalfCourtOffense();
   }

--- a/FrontEnd/static/js/phaser/state/gameStateMachine.js
+++ b/FrontEnd/static/js/phaser/state/gameStateMachine.js
@@ -3,6 +3,7 @@ export const States = {
   HalfCourt: 'HalfCourt',
   ShotAttempt: 'ShotAttempt',
   Rebound: 'Rebound',
+  OutletSetup: 'OutletSetup',
   FastBreak: 'FastBreak',
   FreeThrow: 'FreeThrow',
   EndQuarter: 'EndQuarter'
@@ -12,7 +13,8 @@ const transitions = {
   [States.Inbound]: [States.HalfCourt, States.EndQuarter],
   [States.HalfCourt]: [States.ShotAttempt, States.FreeThrow, States.FastBreak, States.EndQuarter],
   [States.ShotAttempt]: [States.Rebound, States.FastBreak, States.FreeThrow, States.Inbound, States.EndQuarter],
-  [States.Rebound]: [States.HalfCourt, States.ShotAttempt, States.FastBreak, States.FreeThrow, States.EndQuarter],
+  [States.Rebound]: [States.OutletSetup, States.HalfCourt, States.ShotAttempt, States.FastBreak, States.FreeThrow, States.EndQuarter],
+  [States.OutletSetup]: [States.HalfCourt],
   [States.FastBreak]: [States.ShotAttempt, States.Rebound, States.FreeThrow, States.Inbound, States.EndQuarter],
   [States.FreeThrow]: [States.Rebound, States.Inbound, States.EndQuarter],
   [States.EndQuarter]: [States.Inbound]


### PR DESCRIPTION
## Summary
- add `outletSetup` animation configuration for outlet passing
- introduce `OutletSetup` state and transitions in game state machine
- drive defensive rebound outlet sequence with tweened player motion and pass

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b87636815c8328ae0e4022b0b8d52a