### PR TITLE
Refine free throw possession handling

### DIFF
--- a/BackEnd/engine/phase_resolution.py
+++ b/BackEnd/engine/phase_resolution.py
@@ -418,7 +418,9 @@ def resolve_free_throw_logic(game):
                         "possession_flips": False,
                     }
         else:
-            possession_flips = True
+            if not game_state.get("no_lane", False):
+                possession_flips = True
+    # When additional free throws remain, possession stays with the shooter’s team
 
     result = {
         "result_type": "FREE_THROW",


### PR DESCRIPTION
## Summary
- Flip possession only after the final made free throw unless `no_lane` is active
- Preserve rebound logic and keep team points updated on each make

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b87ba1b4d0832880c16fdae2181c96