### PR TITLE
Add outlet advance step to fast break animation

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animation_config.js
+++ b/FrontEnd/static/js/phaser/animation/animation_config.js
@@ -45,6 +45,7 @@ const defaults = {
     sprintSpeed: 1.5, // multiplier
     laneSpacing: 6,
     passMs: 250,
+    outletMoveMs: 300, // duration for outlet receiver’s advance
     shotMs: 500,
     arcHeight: 60,
     // Time to hold the ball at the rim after a made fast break shot

--- a/FrontEnd/static/js/phaser/animation/fastBreak.js
+++ b/FrontEnd/static/js/phaser/animation/fastBreak.js
@@ -30,6 +30,39 @@ export async function runFastBreakSequence({ scene, turnData, playerSprites, bal
   const animations = turnData.animations || [];
   const width = scene.game.config.width;
   const height = scene.game.config.height;
+  if (turnData.roles?.outlet_passer) {
+    const passerId = turnData.roles.outlet_passer;
+    const receiverId = turnData.roles.outlet_receiver;
+    const passerSprite = playerSprites[passerId];
+    const receiverSprite = playerSprites[receiverId];
+    const receiverAnim = animations.find(a => a.playerId === receiverId);
+    const startGrid = receiverAnim?.start || receiverAnim?.movement?.[0]?.coords;
+    if (passerSprite && receiverSprite && startGrid) {
+      attachBallToPlayer(scene, ballSprite, passerSprite);
+      const rim = passerSprite.team === "home" ? HOME_RIM_COORDS : AWAY_RIM_COORDS;
+      const sign = rim.x > startGrid.x ? -1 : 1;
+      const target = {
+        x: Phaser.Math.Clamp(startGrid.x + sign * Phaser.Math.Between(15, 20), 4, 97),
+        y: Phaser.Math.Clamp(startGrid.y + Phaser.Math.Between(-6, 6), 1, 50)
+      };
+      const targetPx = gridToPixels(target.x, target.y, width, height);
+      await tweenPlayerTo(scene, receiverSprite, targetPx, {
+        duration: animationConfig.fastBreak.outletMoveMs,
+        easing: animationConfig.pass.easing
+      });
+      if (scene.skipToEnd) return;
+      await runPass(scene, {
+        fromId: passerId,
+        toId: receiverId,
+        duration: animationConfig.fastBreak.passMs,
+        easing: animationConfig.pass.easing
+      });
+      receiverAnim.start = target;
+      if (receiverAnim.movement && receiverAnim.movement.length > 0) {
+        receiverAnim.movement[0].coords = target;
+      }
+    }
+  }
   const sprintDuration = animationConfig.fastBreak?.sprintDuration ?? 800;
   const timeline = createAnimationTimeline(scene);
 


### PR DESCRIPTION
## Summary
- Expose `outletMoveMs` for fast break configuration
- Add pre-sprint outlet movement and pass handling when an outlet passer exists

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8802489ec83289743bc082d6ac2f1