### PR TITLE
Handle consecutive free throws with context and transition guard

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animateGameTurns.js
+++ b/FrontEnd/static/js/phaser/animation/animateGameTurns.js
@@ -11,6 +11,36 @@ const DEBUG_FLOW =
   (typeof process !== 'undefined' && process.env.DEBUG_FLOW) ||
   false;
 
+function annotateFreeThrowTurns(turns = []) {
+  let group = null;
+  const flush = () => {
+    if (!group) return;
+    const total = group.turns.length;
+    group.turns.forEach((t, idx) => {
+      t.ftContext = {
+        ftIndex: idx + 1,
+        ftTotal: total,
+        bonusType: group.bonusType,
+      };
+    });
+    group = null;
+  };
+  for (const turn of turns) {
+    if (turn.result_type === "FREE_THROW") {
+      if (!group) {
+        group = {
+          turns: [],
+          bonusType: turn.bonus_type || turn.bonusType,
+        };
+      }
+      group.turns.push(turn);
+    } else {
+      flush();
+    }
+  }
+  flush();
+}
+
 /**
  * Animate all turns from simData.turns using real backend structure.
  */
@@ -22,6 +52,7 @@ export async function animateGameTurns({ //hasBallAtStep
   onUpdate
 }) {
   const turns = simData.turns || [];
+  annotateFreeThrowTurns(turns);
   const allPlayers = simData.players || [];
   if (DEBUG_FLOW) {
     const stepCount = turns.reduce((acc, t) => {
@@ -53,7 +84,7 @@ export async function animateGameTurns({ //hasBallAtStep
     if (DEBUG_FLOW) console.log(`🔁 Turn ${i + 1}`, turn);
 
     if (turn.result_type === "FREE_THROW") {
-      await runFreeThrowSequence(scene, { playerSprites, ballSprite, turnData: turn, onUpdate });
+      await runFreeThrowSequence(scene, { playerSprites, ballSprite, turnData: turn, onUpdate, ftContext: turn.ftContext });
       if (onUpdate) {
         try {
           onUpdate(turn);

--- a/FrontEnd/static/js/phaser/animation/freeThrow.js
+++ b/FrontEnd/static/js/phaser/animation/freeThrow.js
@@ -11,6 +11,18 @@ function wait(scene, ms) {
     : new Promise((res) => setTimeout(res, ms));
 }
 
+function createTransitionGuard(machine, disallowed = []) {
+  if (!machine) return () => {};
+  const original = machine.transition.bind(machine);
+  machine.transition = (next, ...args) => {
+    if (disallowed.includes(next)) return;
+    return original(next, ...args);
+  };
+  return () => {
+    machine.transition = original;
+  };
+}
+
 export async function runFreeThrowSequence(
   scene,
   {
@@ -19,6 +31,7 @@ export async function runFreeThrowSequence(
     turnData,
     onUpdate,
     helpers = {},
+    ftContext = {},
   }
 ) {
   const attach =
@@ -33,18 +46,31 @@ export async function runFreeThrowSequence(
   const rebound =
     helpers.animateRebound || (await import("./ballManager.js")).animateRebound;
 
-  if (!scene || !playerSprites || !ballSprite || !turnData) return;
+  const { ftIndex = 1, ftTotal = 1, bonusType } = ftContext || {};
+  const isFinalTurn = ftIndex >= ftTotal;
 
-  safeTransition(
-    scene.stateMachine,
-    States.FreeThrow,
-    {
-      stepIndex: 0,
-      currentOwnerId: getCurrentOwner(scene),
-      pendingOwnerId: getPendingOwner(scene),
-    },
-    ["stepIndex"]
-  );
+  const releaseGuard =
+    !isFinalTurn && scene.stateMachine
+      ? createTransitionGuard(scene.stateMachine, [States.Inbound, 'DeadBall'])
+      : null;
+
+  if (!scene || !playerSprites || !ballSprite || !turnData) {
+    releaseGuard?.();
+    return;
+  }
+
+  if (!scene.stateMachine?.is(States.FreeThrow)) {
+    safeTransition(
+      scene.stateMachine,
+      States.FreeThrow,
+      {
+        stepIndex: 0,
+        currentOwnerId: getCurrentOwner(scene),
+        pendingOwnerId: getPendingOwner(scene),
+      },
+      ["stepIndex"]
+    );
+  }
   if (scene.tweens) {
     for (const sprite of Object.values(playerSprites)) {
       scene.tweens.killTweensOf(sprite);
@@ -135,7 +161,10 @@ export async function runFreeThrowSequence(
     await wait(scene, animationConfig.freeThrow.rimHoldMs);
     scene.events?.emit("ft:rimHoldEnd");
 
-    const isLast = i === attempts.length - 1;
+    const isLastAttempt = i === attempts.length - 1;
+    const isFinalFT = isLastAttempt && isFinalTurn;
+    const earlyExit = bonusType === 'ONE_AND_ONE' && result === 'MISS';
+    const exitNow = isFinalFT || earlyExit;
     if (result === "MAKE") {
       if (onUpdate) {
         try {
@@ -144,7 +173,7 @@ export async function runFreeThrowSequence(
           console.error("Scoreboard update failed:", err);
         }
       }
-      if (isLast) {
+      if (exitNow) {
         safeTransition(
           scene.stateMachine,
           States.Inbound,
@@ -182,7 +211,7 @@ export async function runFreeThrowSequence(
         if (shooterSprite) attach(scene, ballSprite, shooterSprite);
       }
     } else {
-      if (isLast) {
+      if (exitNow) {
         safeTransition(
           scene.stateMachine,
           States.Rebound,
@@ -222,7 +251,9 @@ export async function runFreeThrowSequence(
     scene.events?.emit("ft:repeatOrExit");
   }
 
-  if (scene.stateMachine?.is(States.FreeThrow))
+  releaseGuard?.();
+
+  if (isFinalTurn && scene.stateMachine?.is(States.FreeThrow))
     safeTransition(scene.stateMachine, States.HalfCourt, {
       currentOwnerId: getCurrentOwner(scene),
       pendingOwnerId: getPendingOwner(scene),


### PR DESCRIPTION
## Summary
- group consecutive free throws and tag each with ft index/total/bonus
- pass FT context to runFreeThrowSequence and drive final-shot logic from it
- guard unwanted state transitions during intermediate free throws

## Testing
- `node tests/js/runFreeThrowSequence.mjs`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8831040008328ac8de21460ba2823