### PR TITLE
Skip inbound after makes with pending free throw

### DIFF
--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -892,17 +892,22 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
       const shotResult = await shootBall(shootParams);
       const ballSpot = shotResult?.grid;
       if (turnData.result_type === "MAKE") {
-        const shooterTeamIsHome =
-          String(shooterTeamId) === String(homeTeamId);
-        const newOffenseSide = shooterTeamIsHome ? "away" : "home";
-        await runInboundSetup({
-          scene,
-          ballSprite,
-          playerSprites,
-          newOffenseSide,
-          homeTeamId,
-          awayTeamId
-        });
+        const nextTurn = simData?.turns?.[scene.currentTurn + 1];
+        const hasPendingFreeThrow =
+          nextTurn?.result_type === "FREE_THROW";
+        if (!hasPendingFreeThrow) {
+          const shooterTeamIsHome =
+            String(shooterTeamId) === String(homeTeamId);
+          const newOffenseSide = shooterTeamIsHome ? "away" : "home";
+          await runInboundSetup({
+            scene,
+            ballSprite,
+            playerSprites,
+            newOffenseSide,
+            homeTeamId,
+            awayTeamId,
+          });
+        }
       } else if (ballSpot) {
         const rebounderId =
           turnData.rebounder_player_id ||


### PR DESCRIPTION
## Summary
- avoid inbound setup when a made basket is followed by a free throw turn

## Testing
- `npm test tests/js/runFreeThrowSequence.mjs` *(fails: Could not read package.json)*
- `node tests/js/runFreeThrowSequence.mjs`
- `node <inline script>` (simulate shot make + FT make/miss)

------
https://chatgpt.com/codex/tasks/task_e_68b88d2220788328914edf196290997c