### PR TITLE
Handle foul during putback attempts

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -414,11 +414,19 @@ export function animatePutbackAttempt(
                 onComplete: () =>
                   resolve({ grid: { x: bounceGridX, y: bounceGridY } })
               });
+            } else if (result === "FOUL") {
+              detachBall(scene, ballSprite);
+              hideBall(ballSprite);
+              scene.rebounderId = null;
+              safeTransition(scene.stateMachine, States.FreeThrow, {
+                shotResult: result,
+              });
+              resolve();
             } else {
               safeTransition(scene.stateMachine, States.FreeThrow, {
                 shotResult: result,
               });
-              // FOUL or unrecognized result: backend will handle next steps
+              // unrecognized result: backend will handle next steps
               resolve();
             }
         };


### PR DESCRIPTION
## Summary
- detach and hide the ball when a putback attempt is fouled
- reset rebounder tracking before transitioning to free throws

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b89c8d69548328a8cbc6a85ddcc24e