### PR TITLE
Prevent premature Rebound transitions on made shots

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -10,7 +10,7 @@ import {
   tweenBallTo,
   runPass as baseRunPass
 } from "./ballTween.js";
-import { States, getDebugTransitions, safeTransition } from "../state/gameStateMachine.js";
+import { States, getDebugTransitions, safeTransition, createTransitionGuard } from "../state/gameStateMachine.js";
 import gameStore from "../../state/gameStore.js";
 import {
   clearCurrentOwner,
@@ -375,6 +375,7 @@ export function animatePutbackAttempt(
             const awayTeamId =
               gameStore.getAwayRoster()?.team_id || gameStore.getAwayRoster()?.teamId;
 
+            const releaseGuard = createTransitionGuard(scene.stateMachine, [States.Rebound]);
             await runInboundSetup({
               scene,
               ballSprite,
@@ -383,6 +384,7 @@ export function animatePutbackAttempt(
               homeTeamId,
               awayTeamId
             });
+            releaseGuard?.();
             resolve();
             } else if (result === "MISS") {
               if (scene.stateMachine?.is(States.ShotAttempt)) {

--- a/FrontEnd/static/js/phaser/animation/freeThrow.js
+++ b/FrontEnd/static/js/phaser/animation/freeThrow.js
@@ -3,7 +3,7 @@ import animationConfig, {
   FT_BETWEEN_SHOTS_DELAY_MS,
 } from "./animation_config.js";
 import { HOME_RIM_COORDS, AWAY_RIM_COORDS } from "./courtConstants.js";
-import { States, safeTransition } from "../state/gameStateMachine.js";
+import { States, safeTransition, createTransitionGuard } from "../state/gameStateMachine.js";
 import { getCurrentOwner, getPendingOwner } from "../ball/ballController.js";
 import { DebugFlags } from "../utils/debugFlags.js";
 
@@ -12,22 +12,6 @@ function wait(scene, ms) {
   return scene.time?.delayedCall
     ? new Promise((res) => scene.time.delayedCall(ms, res))
     : new Promise((res) => setTimeout(res, ms));
-}
-
-function createTransitionGuard(machine, disallowed = []) {
-  if (!machine) return () => {};
-  const original = machine.transition.bind(machine);
-  machine.transition = (next, ...args) => {
-    if (disallowed.includes(next)) {
-      if (DebugFlags?.FSM)
-        console.log("FSM: FreeThrow guard rejected", next); // remove when stable
-      return;
-    }
-    return original(next, ...args);
-  };
-  return () => {
-    machine.transition = original;
-  };
 }
 
 export async function runFreeThrowSequence(

--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -14,7 +14,7 @@ import animationConfig from "./animation_config.js";
 import { HOME_RIM_COORDS, AWAY_RIM_COORDS } from "./courtConstants.js";
 import { DEBUG } from "../utils/debug.js";
 import { DebugFlags } from "../utils/debugFlags.js";
-import { States, getDebugTransitions, safeTransition } from "../state/gameStateMachine.js";
+import { States, getDebugTransitions, safeTransition, createTransitionGuard } from "../state/gameStateMachine.js";
 import {
   getPendingOwner,
   clearPendingOwner,
@@ -899,6 +899,7 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
           const shooterTeamIsHome =
             String(shooterTeamId) === String(homeTeamId);
           const newOffenseSide = shooterTeamIsHome ? "away" : "home";
+          const releaseGuard = createTransitionGuard(scene.stateMachine, [States.Rebound]);
           await runInboundSetup({
             scene,
             ballSprite,
@@ -907,6 +908,7 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
             homeTeamId,
             awayTeamId,
           });
+          releaseGuard?.();
         }
       } else if (ballSpot) {
         const rebounderId =

--- a/FrontEnd/static/js/phaser/state/gameStateMachine.js
+++ b/FrontEnd/static/js/phaser/state/gameStateMachine.js
@@ -1,3 +1,5 @@
+import { DebugFlags } from "../utils/debugFlags.js";
+
 export const States = {
   Inbound: 'Inbound',
   HalfCourt: 'HalfCourt',
@@ -28,6 +30,22 @@ export function setDebugTransitions(value) {
 
 export function getDebugTransitions() {
   return debugTransitions;
+}
+
+export function createTransitionGuard(machine, disallowed = []) {
+  if (!machine) return () => {};
+  const original = machine.transition.bind(machine);
+  machine.transition = (next, ...args) => {
+    if (disallowed.includes(next)) {
+      if (DebugFlags?.FSM)
+        console.log("FSM: guard rejected", next);
+      return;
+    }
+    return original(next, ...args);
+  };
+  return () => {
+    machine.transition = original;
+  };
 }
 
 export function safeTransition(machine, next, ctx = {}, required = []) {


### PR DESCRIPTION
## Summary
- Export `createTransitionGuard` from the FSM to block disallowed transitions
- Use transition guards in free throws, turn animations, and putbacks to delay `Rebound` until inbound setup completes

## Testing
- `pytest -q`
- `node --input-type=module -e "import { createGameStateMachine, States, createTransitionGuard } from './FrontEnd/static/js/phaser/state/gameStateMachine.js'; const m=createGameStateMachine(States.ShotAttempt); const r=createTransitionGuard(m, [States.Rebound]); m.transition(States.Rebound); console.log('state after attempt', m.state); r(); m.transition(States.Rebound); console.log('state after release', m.state);"`


------
https://chatgpt.com/codex/tasks/task_e_68b89db523cc8328abf1e777a0e640da