### PR TITLE
Add turnover state and event handler

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animateGameTurns.js
+++ b/FrontEnd/static/js/phaser/animation/animateGameTurns.js
@@ -4,6 +4,7 @@ import { runPass, REBOUND_DEBUG } from "./ballManager.js";
 import animationConfig from "./animation_config.js";
 import runFreeThrowSequence from "./freeThrow.js";
 import runFastBreakSequence from "./fastBreak.js";
+import { handleTurnover } from "./turnoverAdapter.js";
 import { States } from "../state/gameStateMachine.js";
 
 const DEBUG_FLOW =
@@ -99,6 +100,18 @@ export async function animateGameTurns({ //hasBallAtStep
       if (!scene.stateMachine?.is(States.FastBreak)) {
         await runSideInboundSetup({ scene, ballSprite, playerSprites, turnData: turn });
       }
+      if (onUpdate) {
+        try {
+          onUpdate(turn);
+        } catch (err) {
+          console.error('Scoreboard update failed:', err);
+        }
+      }
+      continue;
+    }
+
+    if (turn.result_type === "TURNOVER") {
+      await handleTurnover(scene, { playerSprites, ballSprite, turnData: turn, onUpdate });
       if (onUpdate) {
         try {
           onUpdate(turn);

--- a/FrontEnd/static/js/phaser/animation/turnoverAdapter.js
+++ b/FrontEnd/static/js/phaser/animation/turnoverAdapter.js
@@ -1,0 +1,62 @@
+import runFastBreakSequence from "./fastBreak.js";
+import { runInboundSetup } from "./turnAnimation.js";
+import { States, safeTransition } from "../state/gameStateMachine.js";
+import {
+  clearCurrentOwner,
+  clearPendingOwner,
+  cancelBallTween,
+  getCurrentOwner,
+  getPendingOwner,
+} from "../ball/ballController.js";
+
+/**
+ * Map backend TURNOVER events to appropriate animation sequences.
+ * Live-ball turnovers trigger a fast break; dead-ball turnovers reset to inbound.
+ */
+export async function handleTurnover(scene, { playerSprites, ballSprite, turnData, onUpdate }) {
+  if (!scene || scene.skipToEnd) return;
+
+  safeTransition(
+    scene.stateMachine,
+    States.Turnover,
+    {
+      stepIndex: 0,
+      currentOwnerId: getCurrentOwner(scene),
+      pendingOwnerId: getPendingOwner(scene),
+    },
+    ["stepIndex"]
+  );
+
+  cancelBallTween(scene, ballSprite);
+  clearCurrentOwner(scene);
+  clearPendingOwner(scene);
+  scene.passInFlight = false;
+  scene.tweens?.killAll?.();
+  scene.time?.removeAllEvents?.();
+
+  const liveBall =
+    turnData?.live_ball === true ||
+    turnData?.turnover_type === "STEAL" ||
+    turnData?.result_type === "STEAL";
+
+  const offenseId = turnData?.possession_team_id;
+  if (offenseId != null) {
+    scene.offenseTeamId = offenseId;
+    scene.events?.emit?.("possessionChange", { offenseTeamId: offenseId });
+  }
+
+  if (liveBall) {
+    await runFastBreakSequence(scene, { playerSprites, ballSprite, turnData, onUpdate });
+    return;
+  }
+
+  let newOffenseSide = "home";
+  if (offenseId != null) {
+    const sample = Object.values(playerSprites).find(
+      (s) => String(s.team_id) === String(offenseId)
+    );
+    if (sample) newOffenseSide = sample.team === "away" ? "away" : "home";
+  }
+
+  await runInboundSetup({ scene, ballSprite, playerSprites, newOffenseSide });
+}

--- a/FrontEnd/static/js/phaser/state/gameStateMachine.js
+++ b/FrontEnd/static/js/phaser/state/gameStateMachine.js
@@ -8,16 +8,18 @@ export const States = {
   OutletSetup: 'OutletSetup',
   FastBreak: 'FastBreak',
   FreeThrow: 'FreeThrow',
+  Turnover: 'Turnover',
   EndQuarter: 'EndQuarter'
 };
 
 const transitions = {
   [States.Inbound]: [States.HalfCourt, States.EndQuarter],
-  [States.HalfCourt]: [States.ShotAttempt, States.FreeThrow, States.FastBreak, States.EndQuarter],
+  [States.HalfCourt]: [States.ShotAttempt, States.FreeThrow, States.FastBreak, States.Turnover, States.EndQuarter],
   [States.ShotAttempt]: [States.Rebound, States.FastBreak, States.FreeThrow, States.Inbound, States.EndQuarter],
   [States.Rebound]: [States.OutletSetup, States.HalfCourt, States.ShotAttempt, States.FastBreak, States.FreeThrow, States.EndQuarter],
   [States.OutletSetup]: [States.HalfCourt],
   [States.FastBreak]: [States.ShotAttempt, States.Rebound, States.FreeThrow, States.Inbound, States.EndQuarter],
+  [States.Turnover]: [States.FastBreak, States.Inbound],
   [States.FreeThrow]: [States.Rebound, States.Inbound, States.EndQuarter],
   [States.EndQuarter]: [States.Inbound]
 };

--- a/tests/js/runGameStateMachine.mjs
+++ b/tests/js/runGameStateMachine.mjs
@@ -14,4 +14,9 @@ try {
   illegalError = true;
 }
 
-console.log(JSON.stringify({ allowedFinal, illegalError }));
+const sm3 = createGameStateMachine(States.HalfCourt);
+sm3.transition(States.Turnover);
+sm3.transition(States.Inbound);
+const turnoverFinal = sm3.state;
+
+console.log(JSON.stringify({ allowedFinal, illegalError, turnoverFinal }));


### PR DESCRIPTION
## Summary
- Add `Turnover` state and transitions to the front-end game state machine
- Map backend TURNOVER events to fast breaks or inbounds via new adapter
- Extend game state tests to cover turnover transitions

## Testing
- `pytest -q`
- `node tests/js/runGameStateMachine.mjs`
- `node tests/js/runGenerateBallTween.mjs`
- `node tests/js/runPlayTurnAnimation.mjs` *(fails: ERR_UNSUPPORTED_ESM_URL_SCHEME)*

------
https://chatgpt.com/codex/tasks/task_e_68b89ef11af883289b973ea6a6d7600e