### PR TITLE
feat: add fast break outlet state

### DIFF
--- a/FrontEnd/static/js/phaser/state/gameStateMachine.js
+++ b/FrontEnd/static/js/phaser/state/gameStateMachine.js
@@ -6,18 +6,28 @@ export const States = {
   ShotAttempt: 'ShotAttempt',
   Rebound: 'Rebound',
   OutletSetup: 'OutletSetup',
+  FastBreakOutlet: 'FastBreakOutlet',
   FastBreak: 'FastBreak',
   FreeThrow: 'FreeThrow',
   Turnover: 'Turnover',
   EndQuarter: 'EndQuarter'
 };
 
-const transitions = {
+export const transitions = {
   [States.Inbound]: [States.HalfCourt, States.EndQuarter],
   [States.HalfCourt]: [States.ShotAttempt, States.FreeThrow, States.FastBreak, States.Turnover, States.EndQuarter],
   [States.ShotAttempt]: [States.Rebound, States.FastBreak, States.FreeThrow, States.Inbound, States.EndQuarter],
-  [States.Rebound]: [States.OutletSetup, States.HalfCourt, States.ShotAttempt, States.FastBreak, States.FreeThrow, States.EndQuarter],
+  [States.Rebound]: [
+    States.OutletSetup,
+    States.FastBreakOutlet,
+    States.HalfCourt,
+    States.ShotAttempt,
+    States.FastBreak,
+    States.FreeThrow,
+    States.EndQuarter,
+  ],
   [States.OutletSetup]: [States.HalfCourt],
+  [States.FastBreakOutlet]: [States.FastBreak],
   [States.FastBreak]: [States.ShotAttempt, States.Rebound, States.FreeThrow, States.Inbound, States.EndQuarter],
   [States.Turnover]: [States.FastBreak, States.Inbound],
   [States.FreeThrow]: [States.Rebound, States.Inbound, States.EndQuarter],


### PR DESCRIPTION
## Summary
- add FastBreakOutlet to `States` and export transitions for shared use
- allow rebound sequences to transition to FastBreakOutlet then FastBreak

## Testing
- `node tests/js/runGameStateMachine.mjs`
- `node tests/js/runReboundInProgress.mjs` *(fails: ERR_UNSUPPORTED_ESM_URL_SCHEME)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8a9f1e0608328b4c4c3fb96194bb3