### PR TITLE
Stop extra fast-break runners and freeze off-ball players

### DIFF
--- a/BackEnd/engine/phase_resolution.py
+++ b/BackEnd/engine/phase_resolution.py
@@ -167,10 +167,14 @@ def resolve_fast_break_logic(game: "GameManager"):
         fb_roles["outlet_passer"] = None
         fb_roles["outlet_receiver"] = None
 
-        for pos in ["PG", "SG", "SF"]:
-            if off_lineup[pos] != ball_handler:
-                if random.random() < {"PG": 0.5, "SG": 0.4, "SF": 0.05}.get(pos, 0):
-                    fb_roles["offense"].append(off_lineup[pos])
+        # Previous logic added additional offensive players to the fast break,
+        # potentially scheduling runners beyond the ball handler. The current
+        # approach freezes all non-ball-handlers so no extra offense is added
+        # to the break.
+        # for pos in ["PG", "SG", "SF"]:
+        #     if off_lineup[pos] != ball_handler:
+        #         if random.random() < {"PG": 0.5, "SG": 0.4, "SF": 0.05}.get(pos, 0):
+        #             fb_roles["offense"].append(off_lineup[pos])
 
     target_is_away = off_team.team_id == game.away_team.team_id
     fb_roles["defense"] = get_in_play_defenders(ball_handler, def_lineup, target_is_away)

--- a/BackEnd/models/animator.py
+++ b/BackEnd/models/animator.py
@@ -114,19 +114,21 @@ class Animator:
                     continue
                 build_movement(d, between_key_and_rim(), action=ACTIONS["GUARD_OFFBALL"])
 
-            # Non-in-play defenders
+            # Non-in-play defenders should remain frozen in their current spots
+            # rather than drifting to legacy half-court positions.
             non_play_defenders = [
                 p for p in defense_team.lineup.values() if p not in defenders
             ]
             for d in non_play_defenders:
-                build_movement(d, half_court_spot())
+                build_movement(d, getattr(d, "coords", {"x": 25, "y": 50}))
 
-            # Non-ball-handling offensive players
+            # Non-ball-handling offensive players also freeze at their existing
+            # coordinates to avoid half-court repositioning.
             non_bh_offense = [
                 p for p in offense_team.lineup.values() if p is not ball_handler
             ]
             for o in non_bh_offense:
-                build_movement(o, half_court_spot())
+                build_movement(o, getattr(o, "coords", {"x": 25, "y": 50}))
         else:
             # Keep all other players stationary
             for d in defense_team.lineup.values():


### PR DESCRIPTION
## Summary
- remove loop that schedules extra offensive fast-break runners after steals
- keep non-play defenders/offense frozen during held-up breaks

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8abea3b6c8328a1f7733c347295a8