### PR TITLE
Set hold_up flag after fast break scores

### DIFF
--- a/BackEnd/models/shot_manager.py
+++ b/BackEnd/models/shot_manager.py
@@ -401,6 +401,7 @@ class ShotManager:
         if made:
             result["points"] = points
             result["scoring_team"] = off_team.name
+            result["hold_up"] = True
 
         return result
 


### PR DESCRIPTION
## Summary
- Add hold_up flag to fast break shot results so frontend can pause for inbound

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8cc4195ec8328aa4e392bdc00649c