### PR TITLE
Add rebound pass animation event

### DIFF
--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -7,7 +7,8 @@ import {
   SHOT_DEBUG,
   animateRebound,
   animatePutbackAttempt,
-  animateKickoutReset
+  animateKickoutReset,
+  animateReboundPass
 } from "./ballManager.js";
 import { tweenBallTo, runPass, PASS_DEBUG } from "./ballTween.js";
 import animationConfig from "./animation_config.js";
@@ -887,6 +888,17 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
             rebounderId: evt.rebound.rebounderId,
             ballSpot: putbackResult?.grid || evt.rebound.ballSpot
           });
+        }
+      } else if (evt.event_type === "REBOUND_PASS") {
+        await animateReboundPass(
+          scene,
+          ballSprite,
+          evt.rebounderId,
+          evt.pgId,
+          evt.rebounderCoords
+        );
+        if (typeof scene.startNextHalfCourtOffense === "function") {
+          scene.startNextHalfCourtOffense();
         }
       } else if (evt.event_type === "KICKOUT_RESET") {
         await animateKickoutReset(


### PR DESCRIPTION
## Summary
- handle rebound pass events by calling animateReboundPass and resuming offense
- import animateReboundPass from ballManager

## Testing
- `pytest -q` *(fails: CalledProcessError from Node experimental loader)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cfa2d9808328971e28e7fabc1663