### PR TITLE
Add fast break hold config and rebound pass defaults

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animation_config.js
+++ b/FrontEnd/static/js/phaser/animation/animation_config.js
@@ -35,11 +35,12 @@ const defaults = {
     shotMs: 500,
     arcHeight: 60,
     rimHoldMs: 800,
+    goodHoldMs: 2000,
   },
   reboundPass: {
-    moveDuration: 400,
+    moveDuration: 300,
     moveEase: 'Sine.easeInOut',
-    passDuration: 150,
+    passDuration: 250,
     passEase: 'Sine.easeInOut',
   },
 };

--- a/tests/js/ballManagerStub.mjs
+++ b/tests/js/ballManagerStub.mjs
@@ -12,6 +12,11 @@ export function animateRebound(opts) {
   calls.push({ type: 'rebound', opts });
 }
 
+export async function animateReboundPass(scene, ballSprite, rebounderId, pgId, rebounderCoords) {
+  calls.push({ type: 'reboundPass', scene, ballSprite, rebounderId, pgId, rebounderCoords });
+  return Promise.resolve();
+}
+
 export function animatePutbackAttempt(scene, ballSprite, shooterId, rimCoords, duration, result) {
   calls.push({ type: 'putback', scene, ballSprite, shooterId, rimCoords, duration, result });
   if (result === 'MISS') {


### PR DESCRIPTION
## Summary
- expand fast break animation defaults with goodHoldMs timing
- define rebound pass animation defaults and expose overrides
- update test stub to support rebound pass animation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8d054d7c08328b17b7f076e3df603