### PR TITLE
Handle free throw possession changes

### DIFF
--- a/FrontEnd/static/js/phaser/animation/freeThrow.js
+++ b/FrontEnd/static/js/phaser/animation/freeThrow.js
@@ -165,27 +165,47 @@ export async function runFreeThrowSequence(
         }
       }
       if (isFinalFT) {
-        safeTransition(
-          scene.stateMachine,
-          States.Inbound,
-          {
-            shotResult: result,
-            currentOwnerId: getCurrentOwner(scene),
-            pendingOwnerId: getPendingOwner(scene),
-          },
-          ["shotResult"]
-        );
-        const newOffenseSide =
-          turnData.offense_team_id === scene.simData?.home_team_id
-            ? "away"
-            : "home";
-        await inboundSetup({
-          scene,
-          ballSprite,
-          playerSprites,
-          newOffenseSide,
-        });
-        nextStateResolved = States.Inbound;
+        const possessionChanged =
+          typeof turnData.possession_team_id !== "undefined" &&
+          turnData.possession_team_id !== turnData.offense_team_id;
+        if (possessionChanged) {
+          safeTransition(
+            scene.stateMachine,
+            States.Inbound,
+            {
+              shotResult: result,
+              currentOwnerId: getCurrentOwner(scene),
+              pendingOwnerId: getPendingOwner(scene),
+            },
+            ["shotResult"]
+          );
+          const newOffenseSide =
+            turnData.possession_team_id === scene.simData?.home_team_id
+              ? "home"
+              : "away";
+          await inboundSetup({
+            scene,
+            ballSprite,
+            playerSprites,
+            newOffenseSide,
+          });
+          scene.events?.emit?.("possessionChange", {
+            offenseTeamId: turnData.possession_team_id,
+          });
+          nextStateResolved = States.Inbound;
+        } else {
+          safeTransition(
+            scene.stateMachine,
+            States.HalfCourt,
+            {
+              shotResult: result,
+              currentOwnerId: getCurrentOwner(scene),
+              pendingOwnerId: getPendingOwner(scene),
+            },
+            ["shotResult"]
+          );
+          nextStateResolved = States.HalfCourt;
+        }
       } else {
         if (scene.tweens) {
           for (const sprite of Object.values(playerSprites))

--- a/tests/js/runFreeThrowSequence.mjs
+++ b/tests/js/runFreeThrowSequence.mjs
@@ -57,12 +57,17 @@ const ballSpriteHome = makeBall();
 let inboundCalled = false;
 let reboundCalled = false;
 let arcHeight;
+let posChangeHome = false;
+sceneHome.events.emit = (evt) => {
+  if (evt === 'possessionChange') posChangeHome = true;
+};
 await runFreeThrowSequence(sceneHome, {
   playerSprites: playerSpritesHome,
   ballSprite: ballSpriteHome,
   turnData: {
     result_type: 'FREE_THROW',
     offense_team_id: 'HOME',
+    possession_team_id: 'AWAY',
     shooter_id: 'pg',
     shooter_pos: 'PG',
     attempts: ['MAKE'],
@@ -90,6 +95,7 @@ const homeResult = {
   inboundCalled,
   reboundCalled,
   arcHeight,
+  posChange: posChangeHome,
   pg: { x: playerSpritesHome.pg.x, y: playerSpritesHome.pg.y },
   sg: { x: playerSpritesHome.sg.x, y: playerSpritesHome.sg.y },
   pgA: { x: playerSpritesHome.pgA.x, y: playerSpritesHome.pgA.y }
@@ -127,6 +133,43 @@ await runFreeThrowSequence(sceneAway, {
 const awayResult = {
   inboundCalled: inboundCalled2,
   reboundCalled: reboundCalled2,
+};
+const sceneTechnical = makeScene();
+const playerSpritesTechnical = createPlayers();
+sceneTechnical.playerInfo = createInfo();
+const ballSpriteTechnical = makeBall();
+let inboundCalledTech = false;
+let posChangeTech = false;
+sceneTechnical.events.emit = (evt) => {
+  if (evt === 'possessionChange') posChangeTech = true;
+};
+await runFreeThrowSequence(sceneTechnical, {
+  playerSprites: playerSpritesTechnical,
+  ballSprite: ballSpriteTechnical,
+  turnData: {
+    result_type: 'FREE_THROW',
+    offense_team_id: 'HOME',
+    possession_team_id: 'HOME',
+    shooter_id: 'pg',
+    shooter_pos: 'PG',
+    attempts: ['MAKE'],
+    animations: [
+      { playerId: 'pg', movement: [ { timestamp:0, coords:{x:0,y:0} }, { timestamp:800, coords:{x:74,y:25} } ], duration:800 },
+      { playerId: 'ball', movement: [ { timestamp:0, coords:{x:74,y:25} }, { timestamp:500, coords:{x:91,y:25} } ], duration:500 }
+    ]
+  },
+  helpers: {
+    tweenBallTo: (scene, ball, target, opts) => Promise.resolve(),
+    runInboundSetup: () => { inboundCalledTech = true; return Promise.resolve(); },
+    animateRebound: () => Promise.resolve(),
+    attachBallToPlayer: () => {},
+    detachBall: () => {},
+  },
+});
+
+const technicalResult = {
+  inboundCalled: inboundCalledTech,
+  posChange: posChangeTech,
 };
 const sceneFallback = makeScene();
 const playerSpritesFallback = createPlayers();
@@ -167,6 +210,7 @@ console.log(
   JSON.stringify({
     home: homeResult,
     away: awayResult,
+    technical: technicalResult,
     fallback: fallbackResult,
     expected: { pgDest, sgDest, dPgDest },
   })

--- a/tests/test_frontend_free_throw_sequence.py
+++ b/tests/test_frontend_free_throw_sequence.py
@@ -16,3 +16,10 @@ def test_free_throw_sequence_defaults_to_rim():
     assert result["fallback"]["reboundCalled"] is True
     assert result["fallback"]["ballSpot"] == {"x": 91, "y": 25}
     assert result["fallback"]["ballPos"] == {"x": 91, "y": 25}
+
+
+def test_free_throw_possession_change_event():
+    result = run_node("tests/js/httpsLoaderNoStubBall.mjs", "tests/js/runFreeThrowSequence.mjs")
+    assert result["home"]["posChange"] is True
+    assert result["technical"]["posChange"] is False
+    assert result["technical"]["inboundCalled"] is False


### PR DESCRIPTION
## Summary
- Use `turnData.possession_team_id` to determine inbound side after free throws
- Transition directly to HalfCourt when possession doesn't switch and emit `possessionChange` when it does
- Extend tests to cover possession change events and technical free throws

## Testing
- `pytest tests/test_frontend_free_throw_sequence.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9997913e083288940b49e648a53e8