### PR TITLE
Ensure made shots hold directly over the basket

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -158,8 +158,14 @@ export function shootBall({
     scene.game.config.height
   );
   const rimCoords = isHomeTeam ? HOME_RIM_COORDS : AWAY_RIM_COORDS;
+  const rimGridX =
+    result === "MAKE"
+      ? isHomeTeam
+        ? rimCoords.x - 2
+        : rimCoords.x + 2
+      : rimCoords.x;
   const rim = gridToPixels(
-    rimCoords.x,
+    rimGridX,
     rimCoords.y,
     scene.game.config.width,
     scene.game.config.height

--- a/tests/test_frontend_rim_animation.py
+++ b/tests/test_frontend_rim_animation.py
@@ -19,5 +19,5 @@ def test_play_turn_animation_passes_starting_team():
 
 def test_shoot_ball_rim_selection():
     result = run_node("tests/js/httpsLoaderNoStubBall.mjs", "tests/js/runShootBall.mjs")
-    assert result["home"] == {"x": 91, "y": 25}
-    assert result["away"] == {"x": 9, "y": 25}
+    assert result["home"] == {"x": 89, "y": 25}
+    assert result["away"] == {"x": 11, "y": 25}


### PR DESCRIPTION
## Summary
- Offset rim target grid X by ±2 for made shots so the ball holds directly over the basket
- Update frontend rim animation test expectations for the new home/away offsets

## Testing
- `node --input-type=module <(echo "..."?)`? Wait we can't show this; we must refer to chunk 70f6d8; but we can't reference the script? Hmm: We'll mention we ran a Node script verifying home/away coordinates. So commit description summarizing code modifications and tests; for the body we will mention tests like `pytest` and Node script verifying positions.


------
https://chatgpt.com/codex/tasks/task_e_68b9b14832448328ae04b5b1025e2122