### PR TITLE
Implement rim bounce helper for missed shots

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -140,6 +140,41 @@ export function hideBall(ballSprite) {
 }
 
 /**
+ * Bounce a missed shot off the rim to a landing spot.
+ * Resolves with the grid coordinates of the landing spot.
+ */
+export function bounceFromRim(
+  scene,
+  ballSprite,
+  rimCoords,
+  isHomeTeam,
+  duration
+) {
+  return new Promise((resolve) => {
+    const rebCfg = animationConfig.rebound;
+    const bounceGridX = isHomeTeam
+      ? rimCoords.x - rebCfg.bounceArea.x
+      : rimCoords.x + rebCfg.bounceArea.x;
+    const bounceGridY =
+      rimCoords.y + Phaser.Math.Between(-rebCfg.bounceArea.y, rebCfg.bounceArea.y);
+    const bounce = gridToPixels(
+      bounceGridX,
+      bounceGridY,
+      scene.game.config.width,
+      scene.game.config.height
+    );
+    scene.tweens.add({
+      targets: ballSprite,
+      x: bounce.x,
+      y: bounce.y,
+      duration,
+      ease: "Sine.easeOut",
+      onComplete: () => resolve({ grid: { x: bounceGridX, y: bounceGridY } })
+    });
+  });
+}
+
+/**
  * Launches a shot toward the rim along a single tweened path.
  * Resolves after the ball reaches the rim.
 */
@@ -248,28 +283,6 @@ export function shootBall({
             setTimeout(finish, 1000);
           }
         } else if (result === "MISS") {
-          // Bounce the ball off the rim
-          const rebCfg = animationConfig.rebound;
-          const bounceGridX = isHomeTeam
-            ? rimCoords.x - rebCfg.bounceArea.x
-            : rimCoords.x + rebCfg.bounceArea.x;
-          const bounceGridY =
-            rimCoords.y + Phaser.Math.Between(-rebCfg.bounceArea.y, rebCfg.bounceArea.y);
-          const bounce = gridToPixels(
-            bounceGridX,
-            bounceGridY,
-            scene.game.config.width,
-            scene.game.config.height
-          );
-        if (SHOT_DEBUG) {
-          console.log("shot:miss", {
-            type: "miss",
-            shooterId,
-            reboundSpot: { x: bounceGridX, y: bounceGridY },
-            playerId: shooterId,
-            team: shooterTeamId
-          });
-      }
           if (scene.stateMachine?.is(States.ShotAttempt)) {
             safeTransition(
               scene.stateMachine,
@@ -284,14 +297,23 @@ export function shootBall({
             );
           }
           scene.rebounderId = null;
-          scene.tweens.add({
-            targets: ballSprite,
-            x: bounce.x,
-            y: bounce.y,
-            duration: duration / 3,
-            ease: "Sine.easeOut",
-            onComplete: () =>
-              resolve({ grid: { x: bounceGridX, y: bounceGridY } })
+          bounceFromRim(
+            scene,
+            ballSprite,
+            rimCoords,
+            isHomeTeam,
+            duration / 3
+          ).then((miss) => {
+            if (SHOT_DEBUG) {
+              console.log("shot:miss", {
+                type: "miss",
+                shooterId,
+                reboundSpot: miss.grid,
+                playerId: shooterId,
+                team: shooterTeamId,
+              });
+            }
+            resolve(miss);
           });
         } else {
           resolve();

--- a/FrontEnd/static/js/phaser/animation/freeThrow.js
+++ b/FrontEnd/static/js/phaser/animation/freeThrow.js
@@ -3,6 +3,7 @@ import animationConfig, {
   FT_BETWEEN_SHOTS_DELAY_MS,
 } from "./animation_config.js";
 import { HOME_RIM_COORDS, AWAY_RIM_COORDS } from "./courtConstants.js";
+import { bounceFromRim } from "./ballManager.js";
 import { States, safeTransition, createTransitionGuard } from "../state/gameStateMachine.js";
 import { getCurrentOwner, getPendingOwner } from "../ball/ballController.js";
 import { DebugFlags } from "../utils/debugFlags.js";
@@ -244,13 +245,20 @@ export async function runFreeThrowSequence(
           },
           ["shotResult"]
         );
+        const miss = await bounceFromRim(
+          scene,
+          ballSprite,
+          rimGrid,
+          turnData.offense_team_id === scene.simData?.home_team_id,
+          animationConfig.freeThrow.shotMs / 3
+        );
         await rebound({
           scene,
           ballSprite,
           playerSprites,
           animations: [],
           rebounderId: null,
-          ballSpot: rimGrid,
+          ballSpot: miss.grid,
           shooterId: turnData.shooter_id,
         });
         nextStateResolved = States.Rebound;

--- a/tests/test_frontend_free_throw_sequence.py
+++ b/tests/test_frontend_free_throw_sequence.py
@@ -14,8 +14,12 @@ def run_node(loader, script):
 def test_free_throw_sequence_defaults_to_rim():
     result = run_node("tests/js/httpsLoaderNoStubBall.mjs", "tests/js/runFreeThrowSequence.mjs")
     assert result["fallback"]["reboundCalled"] is True
-    assert result["fallback"]["ballSpot"] == {"x": 91, "y": 25}
-    assert result["fallback"]["ballPos"] == {"x": 91, "y": 25}
+    spot = result["fallback"]["ballSpot"]
+    assert spot["x"] == 85
+    assert 19 <= spot["y"] <= 31
+    pos = result["fallback"]["ballPos"]
+    assert pos["x"] == spot["x"]
+    assert pos["y"] == 50 - spot["y"]
 
 
 def test_free_throw_possession_change_event():


### PR DESCRIPTION
## Summary
- add `bounceFromRim` helper to animate missed shot bounces
- use bounce helper in `shootBall` and free throw miss handling
- update frontend free-throw test for new bounce behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9b3f4262c8328ac1b8ecaeee29cd8