### PR TITLE
Refactor scoring with helper

### DIFF
--- a/BackEnd/engine/phase_resolution.py
+++ b/BackEnd/engine/phase_resolution.py
@@ -21,7 +21,7 @@ from BackEnd.utils.shared import (
     choose_rebounder,
     default_rebounder_dict,
     resolve_offensive_rebound,
-    record_team_points,
+    apply_scoring,
     unpack_game_context
 )
 
@@ -323,8 +323,7 @@ def resolve_free_throw_logic(game):
     shooter_pos = get_player_position(off_lineup, shooter)
 
     if makes_shot:
-        shooter.record_stat("FTM")
-        record_team_points(game, off_team, 1)
+        apply_scoring(game, off_team, shooter, 1, ["FTM"])
         text += "and hits the free throw!"
     else:
         text += "but misses the free throw."

--- a/BackEnd/models/shot_manager.py
+++ b/BackEnd/models/shot_manager.py
@@ -7,11 +7,11 @@ from BackEnd.constants import (
 )
 from BackEnd.utils.shared import (
     apply_help_defense_if_triggered,
+    apply_scoring,
     get_fast_break_chance,
     get_time_elapsed,
     resolve_offensive_rebound,
     get_player_position,
-    record_team_points,
     calculate_screen_score,
     choose_rebounder,
     calculate_rebound_score,
@@ -67,14 +67,10 @@ class ShotManager:
         # 🎯 Shot is Made
         # ------------------------
         if made:
-            shooter.record_stat("FGM")
             if passer:
                 passer.record_stat("AST")
-            if is_three:
-                shooter.record_stat("3PTM")
-
-            points = 3 if is_three else 2
-            record_team_points(self.game, off_team, points)
+            stats = ["FGM", "3PTM"] if is_three else ["FGM"]
+            apply_scoring(self.game, off_team, shooter, 3 if is_three else 2, stats)
 
             possession_flips = True
             if screener:
@@ -364,15 +360,13 @@ class ShotManager:
         # print(f"{get_name_safe(shooter)} attempts a fast breakshot")
 
         if made:
-            shooter.record_stat("FGM")
             if passer:
                 passer.record_stat("AST")
+            points = 2
+            apply_scoring(self.game, off_team, shooter, points, ["FGM"])
             text = f"{shooter} converts the fast break shot!"
             possession_flips = True
             self.game_state["offensive_state"] = "HCO"
-            is_three = False
-            points = 3 if is_three else 2
-            record_team_points(self.game, off_team, points)
         else:
             if defender:
                 defender.record_stat("DEF_S")

--- a/BackEnd/utils/shared.py
+++ b/BackEnd/utils/shared.py
@@ -160,10 +160,8 @@ def resolve_offensive_rebound(game, rebounder):
         }
 
         if made:
-            rebounder.record_stat("FGM")
-            points = 2
-            record_team_points(game, off_team, points)
-            event["points"] = points
+            apply_scoring(game, off_team, rebounder, 2, ["FGM"])
+            event["points"] = 2
             event["possession_flips"] = True
         else:
             new_rebounder, new_team, new_stat = determine_rebounder(game)
@@ -330,6 +328,20 @@ def get_quarter_index_from_game(game):
 def calculate_rebound_score(player):
     attr = player.attributes
     return attr["RB"] * 0.5 + attr["ST"] * 0.3 + attr["AG"] * 0.2
+
+def apply_scoring(game, team, player, points, stats):
+    """Record player scoring stats and update team points.
+
+    Parameters:
+        game: GameManager object
+        team: TeamManager object receiving the points
+        player: Player object recording the stats
+        points: int number of points scored
+        stats: iterable of stat strings to record on the player
+    """
+    for stat in stats:
+        player.record_stat(stat)
+    record_team_points(game, team, points)
 
 def record_team_points(game, team, points):
     """


### PR DESCRIPTION
## Summary
- centralize stat & score updates in new `apply_scoring`
- use `apply_scoring` in shot, fast break, putback, and free throw resolutions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9b9a81a70832881d5a0f9df4e705d