### PR TITLE
Reconcile player stats with score after each possession

### DIFF
--- a/BackEnd/models/turn_manager.py
+++ b/BackEnd/models/turn_manager.py
@@ -268,6 +268,14 @@ class TurnManager:
                     deltas[player.player_id] = {"team": team.name, "stats": diff}
         result["deltas"] = deltas
 
+        # Reconcile player point totals with the authoritative team score.
+        # Clients should treat ``turn.score`` and ``turn.deltas`` as canonical
+        # and never re-apply ``turn.points`` to avoid double counting. To guard
+        # against any desync, compare the team score against the sum of player
+        # PTS at the end of a possession or quarter and push a corrective delta
+        # if they differ.
+        self._reconcile_player_points(result)
+
         # Sync and expose fouls/clock/quarter for live scoreboard updates
         self.game.game_state["team_fouls"] = {
             self.game.home_team.name: self.game.home_team.team_fouls,
@@ -343,6 +351,48 @@ class TurnManager:
         # 🔁 Flip possession if flagged
         if result.get("possession_flips"):
             self.game.switch_possession()
+
+    def _reconcile_player_points(self, result):
+        """Ensure summed player PTS match the official team score.
+
+        This check runs when a possession ends or the quarter expires. If the
+        total points recorded across players for a team does not match the
+        team's score, a corrective delta is added and the discrepancy is
+        logged. This prevents clients from double counting when ``turn.points``
+        is present in the payload.
+        """
+        possession_end = result.get("possession_flips")
+        quarter_end = self.game.game_state.get("time_remaining", 0) == 0
+        if not (possession_end or quarter_end):
+            return
+
+        for team in (self.game.home_team, self.game.away_team):
+            team_score = self.game.score[team.name]
+            total_pts = sum(
+                player.stats["game"].get("PTS", 0) for player in team.get_all_players()
+            )
+            if total_pts == team_score:
+                continue
+
+            diff = team_score - total_pts
+            # Log the discrepancy for debugging/auditing purposes
+            self.logger.log(f"ptsReconcile:{team.name}:{total_pts}->{team_score}")
+
+            # Choose a player to receive the adjustment. Prefer the full roster
+            # but fall back to the current lineup in test environments where the
+            # roster may be empty.
+            players = list(team.get_all_players())
+            if not players:
+                players = list(team.lineup.values())
+            if not players:
+                continue  # nothing we can do
+            player = players[0]
+            player.stats["game"]["PTS"] = player.stats["game"].get("PTS", 0) + diff
+
+            # Reflect the correction in the deltas payload
+            deltas = result.setdefault("deltas", {})
+            entry = deltas.setdefault(player.player_id, {"team": team.name, "stats": {}})
+            entry["stats"]["PTS"] = entry["stats"].get("PTS", 0) + diff
 
     def assign_roles(self, off_call="INSIDE", def_call="MAN"):
         game = self.game

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -365,6 +365,9 @@ export function createGameScene(Phaser) {
         const prevHome = liveScore[homeTeam];
         const prevAway = liveScore[awayTeam];
 
+        // ``turn.score`` is authoritative. ``turn.points`` may appear in the
+        // payload for context but must **not** be re-applied here to avoid
+        // double counting.
         if (turn.score) {
           if (typeof turn.score[homeTeam] === 'number') liveScore[homeTeam] = turn.score[homeTeam];
           if (typeof turn.score[awayTeam] === 'number') liveScore[awayTeam] = turn.score[awayTeam];

--- a/tests/test_scoreboard_turn_updates.py
+++ b/tests/test_scoreboard_turn_updates.py
@@ -82,3 +82,36 @@ def test_turn_payload_includes_clock_quarter_fouls():
     assert result["quarter"] == 1
     assert result["homeFouls"] == 0
     assert result["awayFouls"] == 1
+
+
+def test_pts_reconciliation_adjusts_player_stats():
+    game = build_mock_game()
+    tm = game.turn_manager
+
+    # Create a scoreboard/player stat mismatch for the home team
+    game.score[game.home_team.name] = 3
+    for p in game.home_team.get_all_players():
+        p.stats["game"]["PTS"] = 0
+
+    def fake_turn():
+        return {
+            "result_type": "MISS",
+            "ball_handler": game.offense_team.lineup["PG"],
+            "shooter": game.offense_team.lineup["PG"],
+            "screener": game.offense_team.lineup["SG"],
+            "passer": game.offense_team.lineup["SG"],
+            "defender": game.defense_team.lineup["PG"],
+            "text": "miss",
+            "possession_flips": True,
+            "time_elapsed": 24,
+        }
+
+    tm.resolve_half_court_offense = types.MethodType(lambda self: fake_turn(), tm)
+    result = tm.run_micro_turn()
+
+    # Exactly one player should receive the corrective points
+    players = [p for p in game.home_team.lineup.values() if p.stats["game"].get("PTS")]
+    assert len(players) == 1
+    player = players[0]
+    assert player.stats["game"]["PTS"] == 3
+    assert result["deltas"][player.player_id]["stats"]["PTS"] == 3


### PR DESCRIPTION
## Summary
- prevent clients from double-counting by treating `turn.score` and `turn.deltas` as authoritative
- reconcile team score with summed player points and issue corrective deltas when mismatched
- add regression test for stat reconciliation

## Testing
- `pytest tests/test_scoreboard_turn_updates.py tests/test_turn_manager.py -q`
- `node tests/js/runFreeThrowSequence.mjs` *(fails: Only URLs with a scheme in: file and data are supported by the default ESM loader)*


------
https://chatgpt.com/codex/tasks/task_e_68b9c1f666ec8328a44f3efca82358d2