### PR TITLE
feat: add fast break end pause

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animation_config.js
+++ b/FrontEnd/static/js/phaser/animation/animation_config.js
@@ -44,6 +44,8 @@ const defaults = {
     arcHeight: 60,
     // Time to hold the ball at the rim after a made fast break shot
     rimHoldMs: 2000,
+    // Extra pause after fast break sequence completes
+    endPauseMs: 3000,
   },
   offensiveRebound: { pauseMs: 1000 },
   putback: { duration: 500, easing: 'Sine.easeInOut' },

--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -12,7 +12,7 @@ import {
 import { tweenBallTo, runPass, PASS_DEBUG, tweenPlayerTo, detachBall } from "./ballTween.js";
 import animationConfig from "./animation_config.js";
 import { HOME_RIM_COORDS, AWAY_RIM_COORDS, HOME_TOP_KEY, AWAY_TOP_KEY } from "./courtConstants.js";
-import { DEBUG } from "../utils/debug.js";
+import { DEBUG, DebugFlags } from "../utils/debug.js";
 
 // Cap the time spent on any single movement step. Large timestamp gaps can
 // otherwise produce multi‑second tweens that appear as animation stalls.
@@ -841,6 +841,12 @@ async function runFastBreakSequence({ scene, turnData, playerSprites, ballSprite
       }
     }
   } finally {
+    if (DebugFlags.FB_PAUSE !== false) {
+      const pauseMs = animationConfig.fastBreak?.endPauseMs;
+      if (pauseMs && scene?.time) {
+        await new Promise((resolve) => scene.time.delayedCall(pauseMs, resolve));
+      }
+    }
     scene.fastBreakInProgress = false;
     scene.events?.emit("fb:end");
   }

--- a/FrontEnd/static/js/phaser/utils/debug.js
+++ b/FrontEnd/static/js/phaser/utils/debug.js
@@ -2,3 +2,10 @@ export const DEBUG =
   (typeof window !== 'undefined' && window.DEBUG) ||
   (typeof process !== 'undefined' && process.env.DEBUG) ||
   false;
+
+const debugFlagsSource =
+  (typeof window !== "undefined" && window.DebugFlags) ||
+  (typeof process !== "undefined" && process.env.DebugFlags) ||
+  {};
+
+export const DebugFlags = { FB_PAUSE: true, ...debugFlagsSource };


### PR DESCRIPTION
## Summary
- allow configuring fast break end pause
- expose DebugFlags with FB_PAUSE control
- pause fast break completion before next transition

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9d0ece3148328b6c3e36e9698ec86