### PR TITLE
fix defensive rebound state transitions

### DIFF
--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -364,8 +364,6 @@ async function runDefensiveReboundSetup({ scene, ballSprite, playerSprites, rebo
     });
   }
 
-  scene.possessionFlipInProgress = false;
-
   if (scene.stateMachine?.is(States.OutletSetup)) {
     if (DebugFlags?.FSM) console.log('FSM: OutletSetup -> HalfCourt');
     safeTransition(
@@ -377,6 +375,8 @@ async function runDefensiveReboundSetup({ scene, ballSprite, playerSprites, rebo
       }
     );
   }
+
+  scene.possessionFlipInProgress = false;
 
   if (typeof scene.startNextHalfCourtOffense === "function") {
     scene.startNextHalfCourtOffense();
@@ -942,7 +942,18 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
                   scene.events?.emit?.("possessionChange", {
                     offenseTeamId: rebounderSprite.team_id
                   });
-                  if (scene.stateMachine?.is(States.Rebound)) scene.stateMachine?.transition(States.HalfCourt, getDebugTransitions() && { stepIndex: shotInfo?.stepIndex, shotResult: turnData.result_type });
+                    if (
+                      turnData.rebound_type !== "DREB" &&
+                      scene.stateMachine?.is(States.Rebound)
+                    ) {
+                      scene.stateMachine?.transition(
+                        States.HalfCourt,
+                        getDebugTransitions() && {
+                          stepIndex: shotInfo?.stepIndex,
+                          shotResult: turnData.result_type,
+                        }
+                      );
+                    }
                   scene.rebounderId = null;
                   if (scene.time?.delayedCall) {
                     scene.time.delayedCall(rebCfg.attachDelayMs, resolve);


### PR DESCRIPTION
## Summary
- keep defensive rebounds in the Rebound state until setup logic runs
- allow defensive rebound setup to advance from OutletSetup to HalfCourt after outlet pass

## Testing
- `pytest` *(fails: KeyError: 'C', assert 0 == 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d359f1248328bf219151b3d715ae