### PR TITLE
chore: halt non-PG outlet movement

### DIFF
--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -330,6 +330,7 @@ async function runDefensiveReboundSetup({ scene, ballSprite, playerSprites, rebo
     }
   }
 
+  /*
   for (const [id, sprite] of Object.entries(playerSprites)) {
     const info = scene.playerInfo?.[id];
     if (!info || id === rebounderId || id === pgId) continue;
@@ -350,6 +351,7 @@ async function runDefensiveReboundSetup({ scene, ballSprite, playerSprites, rebo
       })
     );
   }
+  */
 
   await Promise.all(promises);
 


### PR DESCRIPTION
## Summary
- stop tweening non-PG players toward half court during outlet

## Testing
- `pytest` *(fails: KeyError 'C'; assert 0 == 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d4b53c9483288964692d74f55816