### PR TITLE
Delay ball ownership change until pass tween completes

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballTween.js
+++ b/FrontEnd/static/js/phaser/animation/ballTween.js
@@ -169,6 +169,7 @@ export async function runPass(scene, cfg = {}) {
   const { fromId, toId, startCoords, endCoords, duration, easing } = cfg;
   const usedDuration = duration ?? 300;
   const usedEasing = easing ?? 'Linear';
+  const deferOwnership = typeof cfg.onComplete === 'function';
   const ballSprite = scene.ballSprite;
   if (!ballSprite) return;
   const fromSprite = fromId != null ? scene.playerSprites?.[fromId] : null;
@@ -207,7 +208,7 @@ export async function runPass(scene, cfg = {}) {
   scene.__activePass = { key, frame, promise, reject: rejectFn };
 
   scene.passInFlight = true;
-  setPendingOwner(scene, toId);
+  if (!deferOwnership) setPendingOwner(scene, toId);
 
   (async () => {
     try {
@@ -268,6 +269,7 @@ export async function runPass(scene, cfg = {}) {
 
       scene.events?.emit('passEnd', { toId });
       if (PASS_DEBUG) console.log('passEnd', { toId });
+      cfg.onComplete?.();
       resolveFn();
     } catch (err) {
       const lastId = getLastKnownOwner(scene);

--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -18,6 +18,7 @@ import { States, getDebugTransitions, safeTransition, createTransitionGuard } fr
 import {
   getPendingOwner,
   clearPendingOwner,
+  setPendingOwner,
   setCurrentOwner,
   getCurrentOwner
 } from "../ball/ballController.js";
@@ -363,6 +364,10 @@ async function runDefensiveReboundSetup({ scene, ballSprite, playerSprites, rebo
       toId: pgId,
       duration: animationConfig.outletSetup.passMs,
       easing: animationConfig.outletSetup.easing,
+      onComplete: () => {
+        setPendingOwner(scene, pgId);
+        setCurrentOwner(scene, pgId);
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- Add optional deferred-ownership callback to `runPass`
- Use `runPass` onComplete in defensive rebound setup to update ball controller after pass animation

## Testing
- `node tests/js/runPassTweenFlag.mjs` *(fails: ERR_UNSUPPORTED_ESM_URL_SCHEME)*
- `node tests/js/ballStateSequence.mjs` *(fails: ERR_UNSUPPORTED_ESM_URL_SCHEME)*
- `pytest` *(fails: tests/test_overtime.py::test_run_simulation_handles_overtime, tests/test_scoreboard_turn_updates.py::test_pts_reconciliation_adjusts_player_stats)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d74949508328ab3d9b20171fe33a