### PR TITLE
Handle defensive rebound outlet pass

### DIFF
--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -357,8 +357,14 @@ async function runDefensiveReboundSetup({ scene, ballSprite, playerSprites, rebo
   await Promise.all(promises);
 
   if (pgId && pgId !== rebounderId) {
-    if (DebugFlags?.BALL)
-      console.log('outletPass', { fromId: rebounderId, toId: pgId });
+    const outletLog = {
+      event: 'OUTLET_PASS',
+      from: rebounderId,
+      to: pgId,
+      pgTarget,
+      startedAt: Date.now(),
+    };
+    if (DebugFlags?.OUTLET) console.log(outletLog);
     await runPass(scene, {
       fromId: rebounderId,
       toId: pgId,
@@ -367,6 +373,8 @@ async function runDefensiveReboundSetup({ scene, ballSprite, playerSprites, rebo
       onComplete: () => {
         setPendingOwner(scene, pgId);
         setCurrentOwner(scene, pgId);
+        outletLog.completedAt = Date.now();
+        if (DebugFlags?.OUTLET) console.log(outletLog);
       }
     });
   }
@@ -950,6 +958,7 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
                     offenseTeamId: rebounderSprite.team_id
                   });
                     if (
+                      turnData.rebound_type &&
                       turnData.rebound_type !== "DREB" &&
                       scene.stateMachine?.is(States.Rebound)
                     ) {
@@ -971,7 +980,10 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
                 onStop: resolve
               });
             });
-            if (turnData.rebound_type === "DREB" && !turnData.fast_break) {
+            const isDreb = turnData.rebound_type
+              ? turnData.rebound_type === "DREB"
+              : rebounderSprite?.team_id !== turnData.possession_team_id;
+            if (isDreb && !turnData.fast_break) {
               await runDefensiveReboundSetup({
                 scene,
                 ballSprite,

--- a/FrontEnd/static/js/phaser/utils/debugFlags.js
+++ b/FrontEnd/static/js/phaser/utils/debugFlags.js
@@ -2,6 +2,7 @@ export const DebugFlags = {
   BALL: false,
   FSM: false,
   FB_PAUSE: true,
+  OUTLET: false,
 };
 
 export default DebugFlags;


### PR DESCRIPTION
## Summary
- Avoid early Rebound→HalfCourt transition when rebound type is undefined or defensive
- Ensure defensive rebound setup runs when rebound type missing
- Add OUTLET debug logging around outlet passes

## Testing
- ❌ `pytest` *(failing: KeyError: 'C'; assert 0 == 1)*
- ⚠️ `npm test` *(missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9df90565c83289e09610e3a31e83c