### PR TITLE
Handle Phaser timeline fallback

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animationTimeline.js
+++ b/FrontEnd/static/js/phaser/animation/animationTimeline.js
@@ -7,7 +7,21 @@ export function createAnimationTimeline(scene) {
     scene.__activeTimeline.stop();
     scene.__activeTimeline = null;
   }
-  const timeline = scene.tweens.createTimeline();
+  const { tweens } = scene;
+  let timelineFactory = null;
+
+  if (typeof tweens.createTimeline === "function") {
+    timelineFactory = () => tweens.createTimeline();
+  } else if (typeof tweens.timeline === "function") {
+    timelineFactory = () => tweens.timeline();
+  } else if (typeof tweens.addTimeline === "function") {
+    timelineFactory = () => tweens.addTimeline();
+  }
+
+  if (!timelineFactory) return null;
+
+  const timeline = timelineFactory();
+  if (!timeline) return null;
   timeline.once("complete", () => {
     if (scene.__activeTimeline === timeline) {
       scene.__activeTimeline = null;


### PR DESCRIPTION
## Summary
- prefer `scene.tweens.createTimeline` but fall back to `timeline`/`addTimeline` helpers when the factory is missing
- ensure timeline creation still clears any prior active timeline reference on completion

## Testing
- node --experimental-loader ./tests/js/phaserLoader.mjs /tmp/fast_break_smoke.mjs
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ceebdb883c8328bd03b7851deb5102