### PR TITLE
Add animation system roadmap documentation

### DIFF
--- a/docs/animations-roadmap.md
+++ b/docs/animations-roadmap.md
@@ -1,0 +1,63 @@
+# Animation System Roadmap
+
+## Context
+The backend simulation already emits authoritative `turns[]` with ordered `steps[]`, rosters, and scoring updates. The Phaser front end can reliably animate half-court sets, inbound plays, free throws, rebounds, and shot attempts, but it is fragile when stitching those pieces together—especially on fast-break possessions and offensive-rebound continuations. The immediate objective is to stabilize transitions while keeping tweening smooth, timings centralized, and game modes (Single, Tournament, Franchise) intact.
+
+## Guiding Principles
+- **Hybrid rebuild:** Keep proven low-level utilities (grid conversion, tween primitives, timing config) while replacing brittle orchestration code with a declarative runner.
+- **Single source of truth for timing:** All durations/easings remain in `animation_config.js`.
+- **Deterministic transitions:** Respect backend order without injecting random offsets or illegal FSM jumps.
+- **Instrumentation first:** High-signal, opt-in logging to expose readiness and teleport bugs before refactors.
+- **Incremental rollout:** Migrate possession types one at a time behind feature flags/debug toggles.
+
+## Near-Term Actions (0–2 sprints)
+1. **Ship DEBUG_ANIM instrumentation**
+   - Gate existing noisy logs behind a shared flag.
+   - Emit structured traces on step receipt, FSM transitions, and post-step outcomes.
+   - Add monotonicity/teleport detectors and document the workflow in `docs/animation-debug.md`.
+
+2. **Patch known blockers**
+   - Provide a Phaser timeline compatibility shim so fast breaks no longer crash on `createTimeline`.
+   - Fix fast-break outlet orientation so rebound teams attack their own rim.
+   - Harden fast-break FSM transitions to avoid illegal `HalfCourt → FastBreakOutlet` hops.
+
+3. **Capture baseline recordings**
+   - Save representative seeds for: defensive rebound → half-court reset, defensive rebound → fast break, offensive rebound → putback, offensive rebound → kick-out.
+   - Use the new instrumentation to mark where transitions diverge from expected flow.
+
+## Migration Plan (High Level)
+1. **Normalize turns into action graphs**
+   - Parse each backend turn into deterministic phases (setup, movement, ball events, resolution) keyed by backend timestamps.
+   - Attach metadata for upcoming possession type (half-court, fast break, free throw, etc.) to guide FSM decisions.
+
+2. **Introduce a `PossessionRunner` timeline**
+   - Consume the normalized graph and schedule tweens via a single Phaser timeline per possession.
+   - Emit canonical events for state changes (setup complete, pass started, shot resolved, possession change).
+
+3. **Centralize FSM control**
+   - Route all state transitions through the runner, allowing it to look ahead and select the correct next state (e.g., stay in Rebound, enter FastBreak, return to HalfCourt).
+   - Remove ad-hoc `safeTransition` calls scattered across helpers.
+
+4. **Port flows incrementally**
+   - Start with half-court possessions (existing stable path) under a feature flag.
+   - Extend to fast breaks and offensive rebounds, ensuring they reuse the same runner primitives instead of bespoke logic.
+
+5. **Retire legacy orchestrators**
+   - After each flow is validated, delete redundant pathways (`animateGameTurns` branches, bespoke fast-break scripts) to reduce maintenance surface.
+
+## Reuse vs. Replace
+- **Reuse:** `ballManager.js`, `ballTween.js`, `animation_config.js`, sprite factories, and grid helpers. These already enforce smooth tweening and centralized timing.
+- **Replace:** High-level orchestrators (`animateGameTurns`, `turnAnimation` rebound/fast-break branches, free-floating FSM transitions) that currently duplicate logic and introduce race conditions.
+
+## Risk & Mitigation
+- **Complexity risk:** The runner introduces new abstractions—mitigate by shipping instrumentation and feature flags first.
+- **Regression risk:** Incremental rollout with baseline recordings lets us compare old vs. new flows turn by turn.
+- **Schedule risk:** Prioritize the minimum features needed for tournament stability (half-court, fast break, offensive rebound) before layering exotic scenarios.
+
+## Open Questions / Follow-Ups
+- Do we need additional backend hints (e.g., explicit `next_possession_type`) to simplify lookahead logic?
+- Should the runner own score/clock updates or delegate to existing HUD utilities?
+- When should we expose developer tooling (e.g., playback scrubber) to accelerate regression testing once the runner is in place?
+
+Document owner: Frontend Animation Team
+Last updated: 2025-09-20


### PR DESCRIPTION
## Summary
- add a docs/animations-roadmap.md file outlining the frontend animation rebuild plan

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cecdbb58188328b03629877fff7ff3