### PR TITLE
Ensure safeTransition warnings respect animation debug channel

### DIFF
--- a/FrontEnd/static/js/phaser/state/gameStateMachine.js
+++ b/FrontEnd/static/js/phaser/state/gameStateMachine.js
@@ -52,11 +52,15 @@ function toObject(payload) {
 }
 
 function emitTransitionWarning(message, payload = {}, debugPayload = {}) {
-  const merged = { ...toObject(debugPayload), ...toObject(payload) };
+  const structured = {
+    message,
+    ...toObject(debugPayload),
+    ...toObject(payload),
+  };
   if (isAnimationDebugEnabled()) {
-    animationDebugWarn(message, merged);
+    animationDebugWarn(message, structured);
   } else {
-    console.warn(message, merged);
+    console.warn(message, structured);
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure safeTransition warnings include their message inside the structured payload
- keep warning emission on the animation debug channel whenever DEBUG_ANIM is enabled

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf338eee6083289531c90f34b8fffd