### PR TITLE
Fix Phaser timeline fallback

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animationTimeline.js
+++ b/FrontEnd/static/js/phaser/animation/animationTimeline.js
@@ -8,20 +8,19 @@ export function createAnimationTimeline(scene) {
     scene.__activeTimeline = null;
   }
   const { tweens } = scene;
-  let timelineFactory = null;
+  let timeline = null;
 
   if (typeof tweens.createTimeline === "function") {
-    timelineFactory = () => tweens.createTimeline();
+    timeline = tweens.createTimeline();
   } else if (typeof tweens.timeline === "function") {
-    timelineFactory = () => tweens.timeline();
+    timeline = tweens.timeline();
   } else if (typeof tweens.addTimeline === "function") {
-    timelineFactory = () => tweens.addTimeline();
+    timeline = tweens.addTimeline();
   }
 
-  if (!timelineFactory) return null;
-
-  const timeline = timelineFactory();
   if (!timeline) return null;
+  scene.__activeTimeline = timeline;
+
   timeline.once("complete", () => {
     if (scene.__activeTimeline === timeline) {
       scene.__activeTimeline = null;


### PR DESCRIPTION
## Summary
- ensure the Phaser animation timeline helper prefers `createTimeline` but falls back to older factories when unavailable
- store the new timeline as the active instance so it is cleared on completion

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf3671a7f48328813d1ed86c4825f6