### PR TITLE
Fix fast-break outlet targeting after defensive rebounds

### DIFF
--- a/FrontEnd/static/js/phaser/animation/outletUtils.js
+++ b/FrontEnd/static/js/phaser/animation/outletUtils.js
@@ -28,13 +28,24 @@ export function computeFastBreakOutletTarget({
   const distance = randomDistance();
   const direction = newOffenseBasket.x > rebounderGridX ? 1 : -1;
 
+  const rimX = newOffenseBasket.x;
   let minX = COURT_BOUNDS.minX;
   let maxX = COURT_BOUNDS.maxX;
 
   if (newOffenseTeam === "home") {
-    minX = Math.max(minX, newOffenseBasket.x - separationBuffer);
+    minX = Math.max(
+      minX,
+      rimX - separationBuffer,
+      Math.min(rimX, rebounderGridX)
+    );
+    maxX = Math.min(maxX, rimX + separationBuffer);
   } else {
-    maxX = Math.min(maxX, newOffenseBasket.x + separationBuffer);
+    minX = Math.max(minX, rimX - separationBuffer);
+    maxX = Math.min(
+      maxX,
+      rimX + separationBuffer,
+      Math.max(rimX, rebounderGridX)
+    );
   }
 
   const targetX = clamp(

--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -297,7 +297,8 @@ async function runDefensiveReboundSetup({ scene, ballSprite, playerSprites, rebo
     );
   }
 
-  const { newOffenseTeam, newOffenseBasket } = deriveOffenseContext(rebounderSprite.team);
+  const rebounderTeamKey = rebounderSprite.team;
+  const { newOffenseTeam, newOffenseBasket } = deriveOffenseContext(rebounderTeamKey);
   const width = scene.game.config.width;
   const height = scene.game.config.height;
 


### PR DESCRIPTION
## Summary
- ensure defensive-rebound fast breaks derive the new offense context from the rebounder's team
- clamp fast-break outlet targets toward the correct rim while retaining existing lane-spacing buffers

## Testing
- DEBUG_ANIM=true node --experimental-loader ./tests/js/httpsLoader.mjs /tmp/run_fastbreak.mjs
- node --experimental-loader ./tests/js/httpsLoader.mjs tests/js/fastBreakOutletSnapshot.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cf36fa9a1883289134eaabb8a44a1f