### PR TITLE
Ensure fast break transitions respect FSM flow

### DIFF
--- a/FrontEnd/static/js/phaser/animation/ballManager.js
+++ b/FrontEnd/static/js/phaser/animation/ballManager.js
@@ -498,13 +498,29 @@ export function animatePutbackAttempt(
   });
 }
 
+function coerceFastBreakFlag(value) {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value !== 0;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    return normalized === "true" || normalized === "1" || normalized === "fast_break";
+  }
+  return false;
+}
+
 function isUpcomingFastBreak(scene, explicitFlag) {
-  if (typeof explicitFlag === "boolean") return explicitFlag;
+  if (explicitFlag != null) {
+    return coerceFastBreakFlag(explicitFlag);
+  }
   const currentIndex = typeof scene?.currentTurn === "number" ? scene.currentTurn : null;
   if (currentIndex == null) return false;
   const nextTurn = scene?.simData?.turns?.[currentIndex + 1];
   if (!nextTurn) return false;
-  return nextTurn.fast_break === true || nextTurn.result_type === "FAST_BREAK";
+  if (coerceFastBreakFlag(nextTurn.fast_break)) return true;
+  const resultType = typeof nextTurn.result_type === "string"
+    ? nextTurn.result_type.toUpperCase()
+    : null;
+  return resultType === "FAST_BREAK";
 }
 
 /**
@@ -534,7 +550,7 @@ export function animateRebound({
   clearCurrentOwner(scene);
 
   const debugEnabled = isAnimationDebugEnabled();
-  const holdReboundState = isUpcomingFastBreak(scene, upcomingFastBreak);
+  const shouldHoldForFastBreak = () => isUpcomingFastBreak(scene, upcomingFastBreak);
 
   scene.rebounderId = rebounderId;
   const rebCfg = animationConfig.rebound;
@@ -600,6 +616,7 @@ export function animateRebound({
               offenseTeamId: rebounderSprite.team_id
             });
             if (scene.stateMachine?.is(States.Rebound)) {
+              const holdReboundState = shouldHoldForFastBreak();
               if (holdReboundState) {
                 if (debugEnabled && getDebugTransitions()) {
                   animationDebugLog(

--- a/FrontEnd/static/js/phaser/animation/fastBreak.js
+++ b/FrontEnd/static/js/phaser/animation/fastBreak.js
@@ -4,8 +4,11 @@ import { attachBallToPlayer } from "./ballManager.js";
 import { tweenBallTo, tweenPlayerTo, runPass } from "./ballTween.js";
 import animationConfig, { FAST_BREAK_END_PAUSE_MS } from "./animation_config.js";
 import { HOME_RIM_COORDS, AWAY_RIM_COORDS, HOME_TOP_KEY, AWAY_TOP_KEY } from "./courtConstants.js";
-import { States } from "../state/gameStateMachine.js";
-import { transitionFastBreakState } from "./fastBreakStateHelpers.js";
+import {
+  States,
+  safeTransition,
+  getDebugTransitions,
+} from "../state/gameStateMachine.js";
 import { getCurrentOwner } from "../ball/ballController.js";
 import { createAnimationTimeline } from "./animationTimeline.js";
 import { runInboundSetup } from "./turnAnimation.js";
@@ -25,6 +28,132 @@ function fastBreakEndPause(scene) {
   const delay = DebugFlags?.FB_PAUSE ? FAST_BREAK_END_PAUSE_MS : 0;
   if (scene.skipToEnd || delay <= 0) return Promise.resolve();
   return new Promise((resolve) => scene.time.delayedCall(delay, resolve));
+}
+
+function mergePayload(base, extra) {
+  const normalizedBase = base != null ? base : undefined;
+  if (!extra) return normalizedBase;
+  if (!normalizedBase) return { ...extra };
+  return { ...normalizedBase, ...extra };
+}
+
+function computeFastBreakHopPath(start, target) {
+  if (!target || start === target) return [];
+
+  if (target === States.FastBreakOutlet) {
+    switch (start) {
+      case States.FastBreakOutlet:
+        return [];
+      case States.Rebound:
+        return [States.FastBreakOutlet];
+      case States.FastBreak:
+      case States.ShotAttempt:
+        return [States.Rebound, States.FastBreakOutlet];
+      case States.HalfCourt:
+        return [States.FastBreak, States.Rebound, States.FastBreakOutlet];
+      case States.Inbound:
+        return [
+          States.HalfCourt,
+          States.FastBreak,
+          States.Rebound,
+          States.FastBreakOutlet,
+        ];
+      case States.OutletSetup:
+        return [
+          States.HalfCourt,
+          States.FastBreak,
+          States.Rebound,
+          States.FastBreakOutlet,
+        ];
+      case States.Turnover:
+        return [States.FastBreak, States.Rebound, States.FastBreakOutlet];
+      default:
+        return [States.Rebound, States.FastBreakOutlet];
+    }
+  }
+
+  if (target === States.FastBreak) {
+    switch (start) {
+      case States.FastBreak:
+        return [];
+      case States.FastBreakOutlet:
+        return [States.FastBreak];
+      case States.Rebound:
+        return [States.FastBreak];
+      case States.ShotAttempt:
+        return [States.Rebound, States.FastBreak];
+      case States.HalfCourt:
+        return [States.FastBreak];
+      case States.Inbound:
+        return [States.HalfCourt, States.FastBreak];
+      case States.OutletSetup:
+        return [States.HalfCourt, States.FastBreak];
+      case States.Turnover:
+        return [States.FastBreak];
+      default:
+        return [States.FastBreak];
+    }
+  }
+
+  return [target];
+}
+
+function runFastBreakTransition(scene, target, options = {}) {
+  const machine = scene?.stateMachine;
+  if (!machine || !target) return;
+
+  const startState = machine.state;
+  const path = computeFastBreakHopPath(startState, target);
+  if (!path.length) return;
+
+  const {
+    debugStepIndex = null,
+    context,
+    applyContextToAllSteps = false,
+  } = options;
+
+  const debugTransitionsEnabled = getDebugTransitions();
+  const debugPayload =
+    debugTransitionsEnabled && debugStepIndex != null
+      ? { stepIndex: debugStepIndex }
+      : undefined;
+
+  let blocked = false;
+
+  for (let index = 0; index < path.length; index++) {
+    const step = path[index];
+    if (machine.state === step) continue;
+
+    const prevState = machine.state;
+    const includeContext = applyContextToAllSteps || index === path.length - 1;
+    const payload = includeContext
+      ? mergePayload(context, debugPayload)
+      : debugPayload;
+
+    safeTransition(machine, step, payload);
+
+    if (machine.state === prevState) {
+      blocked = true;
+      animationDebugWarn("fastBreak: blocked transition", {
+        start: startState,
+        target,
+        attempted: step,
+        fromState: prevState,
+        current: machine.state,
+      });
+      break;
+    }
+  }
+
+  const expectedFinal = path[path.length - 1];
+  if (!blocked && machine.state !== expectedFinal) {
+    animationDebugWarn("fastBreak: final state mismatch", {
+      start: startState,
+      target,
+      expected: expectedFinal,
+      current: machine.state,
+    });
+  }
 }
 
 export async function runFastBreakSequence({
@@ -88,7 +217,7 @@ export async function runFastBreakSequence({
       if (debugEnabled)
         animationDebugLog('Fast break: correcting state from Inbound to Rebound before FastBreakOutlet transition');
     }
-    transitionFastBreakState(scene, States.FastBreakOutlet, { debugStepIndex: 0 });
+    runFastBreakTransition(scene, States.FastBreakOutlet, { debugStepIndex: 0 });
     const passerId = turnData.roles.outlet_passer;
     const receiverId = turnData.roles.outlet_receiver;
     const passerSprite   = playerSprites[passerId];
@@ -119,10 +248,10 @@ export async function runFastBreakSequence({
       if (receiverAnim.movement?.length) receiverAnim.movement[0].coords = target;
     }
     if (scene.skipToEnd) return;
-    transitionFastBreakState(scene, States.FastBreak, { debugStepIndex: 1 });
+    runFastBreakTransition(scene, States.FastBreak, { debugStepIndex: 1 });
     scene.events?.emit("fb:start");
   } else {
-    transitionFastBreakState(scene, States.FastBreak, { debugStepIndex: 0 });
+    runFastBreakTransition(scene, States.FastBreak, { debugStepIndex: 0 });
     scene.events?.emit("fb:start");
   }
 


### PR DESCRIPTION
## Summary
- add a local helper that sequences fast-break FSM hops with safeTransition so outlet and sprint phases only advance through legal states
- coerce upcoming fast-break flags and let defensive rebounds keep the FSM in Rebound until the fast-break turn issues the first transition

## Testing
- DEBUG_ANIM=1 node --experimental-loader ./tests/js/phaserLoader.mjs tests/js/fastBreakDrebHandoff.mjs
- DEBUG_ANIM=1 node --experimental-loader ./tests/js/phaserLoader.mjs tests/js/tmp_run_fastbreak.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cf3aa3dca48328badb33433ce39253