### PR TITLE
Ensure shot context is always passed

### DIFF
--- a/FrontEnd/static/js/phaser/animation/turnAnimation.js
+++ b/FrontEnd/static/js/phaser/animation/turnAnimation.js
@@ -1091,11 +1091,17 @@ export async function playTurnAnimation({ scene, simData, playerSprites, turnDat
         shooterPos,
         shooterId: shotInfo.playerId,
         shooterTeamId,
-        homeTeamId
+        homeTeamId,
+        stepIndex: shotInfo.stepIndex,
+        turnIndex: scene.currentTurn
       };
       if (SHOT_DEBUG) {
-        shootParams.stepIndex = shotInfo.stepIndex;
-        shootParams.turnIndex = scene.currentTurn;
+        animationDebugLog("shootParams", {
+          stepIndex: shootParams.stepIndex,
+          turnIndex: shootParams.turnIndex,
+          shooterId: shootParams.shooterId,
+          result: shootParams.result,
+        });
       }
       const shotResult = await shootBall(shootParams);
       const ballSpot = shotResult?.grid;


### PR DESCRIPTION
## Summary
- always include stepIndex and turnIndex when constructing shootBall parameters so the FSM receives shot context
- keep the SHOT_DEBUG guard by logging the shot context details only when debug logging is enabled

## Testing
- node --loader ./tests/js/httpsLoaderNoStubBall.mjs tests/js/runDefensiveReboundFlip.mjs
- node --loader ./tests/js/httpsLoaderNoStubBall.mjs <<'NODE'
# custom made/miss shot verification script executed in this PR discussion
NODE
- pytest tests/test_frontend_rebound_animation.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cf52d276ec8328acef938683a72e18