### PR TITLE
Handle missing Phaser timeline helpers

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animationTimeline.js
+++ b/FrontEnd/static/js/phaser/animation/animationTimeline.js
@@ -1,3 +1,5 @@
+import * as Phaser from "https://cdn.jsdelivr.net/npm/phaser@3.60.0/dist/phaser.esm.js";
+
 // Simple wrapper around Phaser's timeline creation. Ensures any previously
 // active timeline on the scene is stopped before creating a new one so that
 // overlapping sequences do not conflict.
@@ -16,6 +18,13 @@ export function createAnimationTimeline(scene) {
     timeline = tweens.timeline();
   } else if (typeof tweens.addTimeline === "function") {
     timeline = tweens.addTimeline();
+  } else if (Phaser?.Tweens?.Timeline) {
+    try {
+      timeline = new Phaser.Tweens.Timeline(tweens);
+    } catch (error) {
+      console.warn("Failed to construct Phaser timeline", error);
+      timeline = null;
+    }
   }
 
   if (!timeline) return null;

--- a/FrontEnd/static/js/phaser/animation/fastBreak.js
+++ b/FrontEnd/static/js/phaser/animation/fastBreak.js
@@ -283,6 +283,14 @@ export async function runFastBreakSequence({
 
   // Use backend timeline data instead of fixed duration
   const timeline = createAnimationTimeline(scene);
+  if (!timeline && debugEnabled) {
+    animationDebugWarn("fastBreak: timeline unavailable - skipping sprint animation", {
+      hasTweenManager: !!scene?.tweens,
+      hasCreateTimeline: typeof scene?.tweens?.createTimeline === "function",
+      hasTimelineFactory: typeof scene?.tweens?.timeline === "function",
+      hasAddTimeline: typeof scene?.tweens?.addTimeline === "function",
+    });
+  }
 
   const fallbackSprintDuration =
     animationConfig.fastBreak?.shotMs ?? animationConfig.fastBreak.shotMs ?? 0;
@@ -340,14 +348,19 @@ export async function runFastBreakSequence({
     
     const endPx = gridToPixels(endX, endY, width, height);
 
-    // Add to timeline with backend timing
-    timeline.add({
-      targets: sprite,
-      x: endPx.x,
-      y: endPx.y,
-      duration: duration,
-      ease: "Sine.easeInOut"
-    }, startStep.timestamp);
+    if (timeline) {
+      // Add to timeline with backend timing
+      timeline.add({
+        targets: sprite,
+        x: endPx.x,
+        y: endPx.y,
+        duration: duration,
+        ease: "Sine.easeInOut"
+      }, startStep.timestamp);
+    } else {
+      // Without a timeline, snap directly to the destination to avoid leaving players behind
+      sprite.setPosition(endPx.x, endPx.y);
+    }
   }
 
   if (
@@ -358,15 +371,19 @@ export async function runFastBreakSequence({
     sprintDuration = latestSprintTimestamp - earliestSprintTimestamp;
   }
 
-  scene.__activeTimeline = timeline;
+  if (timeline) {
+    scene.__activeTimeline = timeline;
 
-  await new Promise(resolve => {
-    timeline.once("complete", resolve);
-    timeline.play();
-  });
+    await new Promise(resolve => {
+      timeline.once("complete", resolve);
+      timeline.play();
+    });
 
-  scene.__activeTimeline = null;
-  if (scene.skipToEnd) return;
+    scene.__activeTimeline = null;
+    if (scene.skipToEnd) return;
+  } else if (scene.skipToEnd) {
+    return;
+  }
 
   // Handle passes after sprint
   const passes = turnData.passes || [];


### PR DESCRIPTION
## Summary
- add a Phaser 3.60 timeline fallback in the animation timeline factory so a timeline is still created when helper methods are missing
- guard the fast break sequence to warn when no timeline is available and skip the timeline-driven sprint animation gracefully

## Testing
- not run (frontend change)


------
https://chatgpt.com/codex/tasks/task_e_68cf54b08aac8328853f45cc2ca12816