### PR TITLE
Add possession normalizer and tests

### DIFF
--- a/FrontEnd/static/js/phaser/animation/__tests__/normalizeTurn.test.js
+++ b/FrontEnd/static/js/phaser/animation/__tests__/normalizeTurn.test.js
@@ -1,0 +1,221 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const normalizerPromise = import('../possession/normalizeTurn.js');
+
+function baseSimData() {
+  return {
+    home_team_id: 'HOME',
+    away_team_id: 'AWAY',
+    players: [
+      { playerId: 'pg', team: 'home', team_id: 'HOME', pos: 'PG', name: 'Home PG' },
+      { playerId: 'sg', team: 'home', team_id: 'HOME', pos: 'SG', name: 'Home SG' },
+      { playerId: 'pf', team: 'home', team_id: 'HOME', pos: 'PF', name: 'Home PF' },
+      { playerId: 'sf', team: 'home', team_id: 'HOME', pos: 'SF', name: 'Home SF' },
+      { playerId: 'pgA', team: 'away', team_id: 'AWAY', pos: 'PG', name: 'Away PG' },
+      { playerId: 'wing', team: 'away', team_id: 'AWAY', pos: 'SF', name: 'Away Wing' },
+    ],
+  };
+}
+
+test('normalizeTurn organizes a half-court possession with explicit passes', async () => {
+  const { normalizeTurn } = await normalizerPromise;
+
+  const turn = {
+    id: 'turn-hco',
+    possession_id: 'pos-1',
+    possession_team_id: 'HOME',
+    result_type: 'MAKE',
+    text: 'PG drills the jumper off the kick-out.',
+    shooter_id: 'pg',
+    assist_id: 'sg',
+    points: 2,
+    score: { HOME: 52, AWAY: 48 },
+    clock: '5:12',
+    quarter: 3,
+    passes: [
+      { timestamp: 400, fromId: 'pg', toId: 'sg', duration: 180 },
+      { timestamp: 600, fromId: 'sg', toId: 'pg', duration: 160 },
+    ],
+    animations: [
+      {
+        playerId: 'pg',
+        teamId: 'HOME',
+        position: 'PG',
+        hasBallAtStep: [true, true, false],
+        movement: [
+          { timestamp: 0, coords: { x: 40, y: 24 }, action: 'handle_ball' },
+          { timestamp: 400, coords: { x: 50, y: 24 }, action: 'pass' },
+          { timestamp: 600, coords: { x: 54, y: 24 }, action: 'receive' },
+          { timestamp: 800, coords: { x: 60, y: 23 }, action: 'shoot' },
+        ],
+      },
+      {
+        playerId: 'sg',
+        teamId: 'HOME',
+        position: 'SG',
+        movement: [
+          { timestamp: 0, coords: { x: 32, y: 20 }, action: 'drift' },
+          { timestamp: 400, coords: { x: 45, y: 22 }, action: 'receive' },
+          { timestamp: 600, coords: { x: 52, y: 23 }, action: 'pass' },
+          { timestamp: 800, coords: { x: 58, y: 23 }, action: 'space' },
+        ],
+      },
+      {
+        playerId: 'ball',
+        hasBallAtStep: [true, false, false, false],
+        movement: [
+          { timestamp: 0, coords: { x: 40, y: 24 }, action: 'handle_ball' },
+          { timestamp: 400, coords: { x: 45, y: 22 }, action: 'receive' },
+          { timestamp: 600, coords: { x: 54, y: 24 }, action: 'pass' },
+          { timestamp: 800, coords: { x: 90, y: 25 }, action: 'shoot' },
+        ],
+      },
+    ],
+  };
+
+  const normalized = normalizeTurn(turn, baseSimData());
+
+  assert.equal(normalized.context.offenseTeamId, 'HOME');
+  assert.equal(normalized.context.defenseTeamId, 'AWAY');
+  assert.deepEqual(normalized.setup.order, ['pg', 'sg']);
+  assert.equal(normalized.setup.players.pg.hasBall, true);
+  assert.equal(normalized.setup.players.sg.position, 'SG');
+
+  const frameTimestamps = normalized.timeline.frames.map(frame => frame.timestamp);
+  assert.equal(frameTimestamps[0], 0);
+  assert.equal(frameTimestamps.at(-1), 800);
+  assert.ok(frameTimestamps.includes(400));
+  assert.ok(frameTimestamps.includes(580));
+  assert.ok(frameTimestamps.includes(600));
+  assert.ok(frameTimestamps.includes(760));
+  assert.equal(normalized.timeline.frames[0].players.pg.x, 40);
+  const passAt400 = normalized.timeline.frames.find(frame => frame.timestamp === 400);
+  const passAt600 = normalized.timeline.frames.find(frame => frame.timestamp === 600);
+  assert.equal(passAt400?.passes?.[0]?.fromId, 'pg');
+  assert.equal(passAt600?.passes?.[0]?.toId, 'pg');
+  assert.ok(
+    normalized.timeline.frames.some(frame => (frame.actions || []).some(action => action.action === 'shoot'))
+  );
+
+  assert.equal(normalized.terminal.shot.points, 2);
+  assert.equal(normalized.terminal.shot.shooterId, 'pg');
+  assert.equal(normalized.terminal.shot.timestamp, 800);
+  assert.equal(normalized.terminal.rebound, null);
+});
+
+
+test('normalizeTurn infers passes and fast break metadata', async () => {
+  const { normalizeTurn } = await normalizerPromise;
+
+  const turn = {
+    id: 'turn-fb',
+    possession_id: 'pos-fb',
+    possession_team_id: 'AWAY',
+    fast_break: true,
+    result_type: 'FAST_BREAK',
+    shooter_id: 'wing',
+    points: 2,
+    animations: [
+      {
+        playerId: 'pgA',
+        teamId: 'AWAY',
+        hasBallAtStep: [true, true, false],
+        movement: [
+          { timestamp: 0, coords: { x: 60, y: 25 }, action: 'handle_ball' },
+          { timestamp: 300, coords: { x: 70, y: 25 }, action: 'pass' },
+          { timestamp: 700, coords: { x: 82, y: 25 }, action: 'trail' },
+        ],
+      },
+      {
+        playerId: 'wing',
+        teamId: 'AWAY',
+        movement: [
+          { timestamp: 0, coords: { x: 64, y: 30 }, action: 'sprint' },
+          { timestamp: 300, coords: { x: 72, y: 26 }, action: 'receive' },
+          { timestamp: 700, coords: { x: 90, y: 25 }, action: 'shoot' },
+        ],
+      },
+      {
+        playerId: 'ball',
+        hasBallAtStep: [true, false, false],
+        movement: [
+          { timestamp: 0, coords: { x: 60, y: 25 }, action: 'handle_ball' },
+          { timestamp: 300, coords: { x: 72, y: 26 }, action: 'receive' },
+          { timestamp: 700, coords: { x: 90, y: 25 }, action: 'shoot' },
+        ],
+      },
+    ],
+  };
+
+  const normalized = normalizeTurn(turn, baseSimData());
+
+  assert.equal(normalized.context.offenseTeamId, 'AWAY');
+  assert.equal(normalized.context.fastBreak, true);
+  assert.equal(normalized.timeline.passes.length, 1);
+  assert.equal(normalized.timeline.passes[0].source, 'inferred');
+  assert.equal(normalized.timeline.passes[0].fromId, 'pgA');
+  assert.equal(normalized.timeline.passes[0].toId, 'wing');
+  assert.ok(normalized.timeline.frames.some(frame => (frame.passes || []).length === 1));
+  assert.equal(normalized.terminal.shot.fastBreak, true);
+});
+
+
+test('normalizeTurn captures offensive rebound context', async () => {
+  const { normalizeTurn } = await normalizerPromise;
+
+  const turn = {
+    id: 'turn-or',
+    possession_id: 'pos-or',
+    possession_team_id: 'HOME',
+    result_type: 'MAKE',
+    text: 'SF misses, PF cleans it up.',
+    shooter_id: 'pf',
+    rebounder_id: 'pf',
+    rebound_team_id: 'HOME',
+    rebound_outcome: 'OFFENSIVE_REBOUND',
+    points: 2,
+    animations: [
+      {
+        playerId: 'sf',
+        teamId: 'HOME',
+        hasBallAtStep: [true, true, false],
+        movement: [
+          { timestamp: 0, coords: { x: 48, y: 20 }, action: 'handle_ball' },
+          { timestamp: 600, coords: { x: 68, y: 22 }, action: 'shoot' },
+          { timestamp: 900, coords: { x: 70, y: 23 }, action: 'rebound' },
+        ],
+      },
+      {
+        playerId: 'pf',
+        teamId: 'HOME',
+        movement: [
+          { timestamp: 0, coords: { x: 52, y: 28 }, action: 'box_out' },
+          { timestamp: 600, coords: { x: 66, y: 26 }, action: 'crash' },
+          { timestamp: 900, coords: { x: 68, y: 24 }, action: 'rebound' },
+          { timestamp: 1100, coords: { x: 70, y: 23 }, action: 'shoot' },
+        ],
+      },
+      {
+        playerId: 'ball',
+        hasBallAtStep: [true, false, false, false],
+        movement: [
+          { timestamp: 0, coords: { x: 48, y: 20 }, action: 'handle_ball' },
+          { timestamp: 600, coords: { x: 90, y: 25 }, action: 'shoot' },
+          { timestamp: 900, coords: { x: 68, y: 24 }, action: 'rebound' },
+          { timestamp: 1100, coords: { x: 90, y: 25 }, action: 'shoot' },
+        ],
+      },
+    ],
+  };
+
+  const normalized = normalizeTurn(turn, baseSimData());
+
+  assert.equal(normalized.terminal.rebound.rebounderId, 'pf');
+  assert.equal(normalized.terminal.rebound.offensive, true);
+  assert.equal(normalized.terminal.rebound.timestamp, 900);
+  const finalFrame = normalized.timeline.frames[normalized.timeline.frames.length - 1];
+  assert.equal(finalFrame.timestamp, 1100);
+  assert.equal(finalFrame.duration, 0);
+  assert.ok(finalFrame.actions.some(action => action.action === 'shoot'));
+});

--- a/FrontEnd/static/js/phaser/animation/possession/normalizeTurn.js
+++ b/FrontEnd/static/js/phaser/animation/possession/normalizeTurn.js
@@ -1,0 +1,582 @@
+const BALL_PLAYER_ID = "ball";
+const PASS_ACTION = "pass";
+const RECEIVE_ACTION = "receive";
+const SHOT_ACTIONS = new Set(["shoot", "shot"]);
+const REBOUND_ACTIONS = new Set(["rebound"]);
+const TURNOVER_ACTIONS = new Set(["turnover", "steal"]);
+
+function toNumber(value) {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (value == null) return null;
+  const coerced = Number(value);
+  return Number.isFinite(coerced) ? coerced : null;
+}
+
+function compactObject(value) {
+  if (!value || typeof value !== "object") return null;
+  const output = {};
+  for (const [key, val] of Object.entries(value)) {
+    if (val == null) continue;
+    output[key] = val;
+  }
+  return Object.keys(output).length ? output : null;
+}
+
+function buildPlayerMetaLookup(simData = {}) {
+  const players = Array.isArray(simData.players) ? simData.players : [];
+  const lookup = new Map();
+  for (const player of players) {
+    const id = player?.playerId ?? player?.player_id;
+    if (!id) continue;
+    lookup.set(id, {
+      id,
+      teamId: player?.team_id ?? player?.teamId ?? null,
+      team: player?.team ?? null,
+      position: player?.pos ?? player?.position ?? null,
+      name: player?.name ?? null,
+    });
+  }
+  return lookup;
+}
+
+function deriveDefenseTeamId(offenseTeamId, simData = {}, turn = {}) {
+  const explicit = turn?.defense_team_id ?? turn?.defenseTeamId ?? null;
+  if (explicit) return explicit;
+  const home = simData?.home_team_id ?? simData?.homeTeamId ?? null;
+  const away = simData?.away_team_id ?? simData?.awayTeamId ?? null;
+  if (!offenseTeamId) return null;
+  if (offenseTeamId === home) return away;
+  if (offenseTeamId === away) return home;
+  return null;
+}
+
+function normalizeCoords(step = {}) {
+  const coords =
+    step?.coords ??
+    step?.grid ??
+    step?.position ??
+    (Array.isArray(step?.spot) ? { x: step.spot[0], y: step.spot[1] } : step?.spot) ??
+    null;
+  const x = typeof coords?.x === "number" ? coords.x : toNumber(coords?.[0]);
+  const y = typeof coords?.y === "number" ? coords.y : toNumber(coords?.[1]);
+  return {
+    x: typeof x === "number" ? x : null,
+    y: typeof y === "number" ? y : null,
+  };
+}
+
+function normalizeAction(value) {
+  if (typeof value !== "string") return null;
+  return value.trim().toLowerCase();
+}
+
+function createTrack(anim = {}) {
+  const playerId = anim?.playerId ?? anim?.player_id ?? null;
+  if (!playerId) return null;
+
+  const rawMovement = Array.isArray(anim?.movement) ? anim.movement : [];
+  const hasBallArr = Array.isArray(anim?.hasBallAtStep) ? anim.hasBallAtStep : [];
+
+  const steps = [];
+  let lastTimestamp = null;
+  let syntheticTime = 0;
+
+  rawMovement.forEach((step, index) => {
+    let timestamp = toNumber(step?.timestamp);
+    if (timestamp == null) {
+      const duration = toNumber(step?.duration);
+      if (lastTimestamp != null && duration != null) {
+        timestamp = lastTimestamp + duration;
+      } else if (lastTimestamp != null) {
+        syntheticTime = lastTimestamp + 1;
+        timestamp = syntheticTime;
+      } else {
+        timestamp = syntheticTime;
+      }
+    }
+    if (lastTimestamp != null && timestamp < lastTimestamp) {
+      timestamp = lastTimestamp;
+    }
+    lastTimestamp = timestamp;
+    syntheticTime = timestamp;
+
+    const coords = normalizeCoords(step);
+    const action = normalizeAction(step?.action ?? step?.type ?? step?.event);
+    const hasBall = Boolean(hasBallArr[index] ?? step?.hasBall);
+
+    steps.push({
+      timestamp,
+      coords,
+      action,
+      hasBall,
+      raw: step,
+      index,
+    });
+  });
+
+  steps.sort((a, b) => {
+    if (a.timestamp == null && b.timestamp == null) return a.index - b.index;
+    if (a.timestamp == null) return 1;
+    if (b.timestamp == null) return -1;
+    if (a.timestamp === b.timestamp) return a.index - b.index;
+    return a.timestamp - b.timestamp;
+  });
+
+  return {
+    playerId,
+    steps,
+    raw: anim,
+    hasBallAtStep: hasBallArr,
+    teamId: anim?.teamId ?? anim?.team_id ?? null,
+    position: anim?.position ?? null,
+  };
+}
+
+function buildPassKey(timestamp, fromId, toId) {
+  if (timestamp == null || !fromId) return null;
+  return `${timestamp}:${fromId}:${toId ?? "*"}`;
+}
+
+function normalizeExplicitPasses(passes = [], defaultDuration = 250) {
+  if (!Array.isArray(passes)) return [];
+  const results = [];
+  for (const entry of passes) {
+    const timestamp = toNumber(entry?.timestamp ?? entry?.start ?? entry?.startTimestamp);
+    const fromId = entry?.fromId ?? entry?.from_id ?? entry?.source ?? null;
+    const toId = entry?.toId ?? entry?.to_id ?? entry?.target ?? null;
+    const duration = toNumber(entry?.duration);
+    const completionTimestamp =
+      toNumber(entry?.completionTimestamp ?? entry?.endTimestamp ?? entry?.completeTimestamp) ??
+      (timestamp != null && duration != null ? timestamp + duration : null);
+    const resolvedDuration =
+      duration ??
+      (timestamp != null && completionTimestamp != null ? Math.max(0, completionTimestamp - timestamp) : defaultDuration);
+    results.push({
+      timestamp,
+      completionTimestamp,
+      duration: resolvedDuration ?? defaultDuration,
+      fromId,
+      toId,
+      source: "explicit",
+      raw: entry,
+    });
+  }
+  return results;
+}
+
+function inferPassesFromTracks(tracks = [], knownKeys = new Set(), defaultDuration = 250) {
+  const passes = [];
+  const receiveLookup = new Map();
+
+  for (const track of tracks) {
+    if (track.playerId === BALL_PLAYER_ID) continue;
+    for (const step of track.steps) {
+      if (step.timestamp == null) continue;
+      if (normalizeAction(step.action) === RECEIVE_ACTION) {
+        if (!receiveLookup.has(step.timestamp)) receiveLookup.set(step.timestamp, []);
+        receiveLookup.get(step.timestamp).push({ playerId: track.playerId, step });
+      }
+    }
+  }
+
+  for (const track of tracks) {
+    if (track.playerId === BALL_PLAYER_ID) continue;
+    for (const step of track.steps) {
+      if (step.timestamp == null) continue;
+      if (normalizeAction(step.action) !== PASS_ACTION) continue;
+
+      const receivers = receiveLookup.get(step.timestamp) ?? [];
+      let receiver = null;
+      for (const candidate of receivers) {
+        if (candidate.used) continue;
+        receiver = candidate;
+        candidate.used = true;
+        break;
+      }
+
+      const key = buildPassKey(step.timestamp, track.playerId, receiver?.playerId ?? null);
+      if (key && knownKeys.has(key)) continue;
+
+      let completionTimestamp = null;
+      let duration = defaultDuration;
+      if (receiver?.step?.timestamp != null && receiver.step.timestamp > step.timestamp) {
+        completionTimestamp = receiver.step.timestamp;
+        duration = receiver.step.timestamp - step.timestamp;
+      } else if (receiver?.step?.raw) {
+        const raw = receiver.step.raw;
+        const inferredEnd = toNumber(raw?.completionTimestamp ?? raw?.endTimestamp ?? raw?.timestampComplete);
+        if (inferredEnd != null && inferredEnd >= step.timestamp) {
+          completionTimestamp = inferredEnd;
+          duration = inferredEnd - step.timestamp;
+        }
+      }
+
+      if (completionTimestamp == null && duration != null && step.timestamp != null) {
+        completionTimestamp = step.timestamp + duration;
+      }
+
+      passes.push({
+        timestamp: step.timestamp,
+        completionTimestamp,
+        duration: duration ?? defaultDuration,
+        fromId: track.playerId,
+        toId: receiver?.playerId ?? null,
+        source: "inferred",
+      });
+    }
+  }
+
+  return passes;
+}
+
+function getStepForTimestamp(track, targetTimestamp) {
+  if (!track?.steps?.length) return null;
+  let candidate = null;
+  for (const step of track.steps) {
+    if (step.timestamp == null) continue;
+    if (step.timestamp === targetTimestamp) return step;
+    if (step.timestamp < targetTimestamp) {
+      if (!candidate || step.timestamp > candidate.timestamp) {
+        candidate = step;
+      }
+    } else if (!candidate) {
+      candidate = step;
+      break;
+    } else {
+      break;
+    }
+  }
+  if (!candidate) {
+    candidate = track.steps[0];
+  }
+  return candidate;
+}
+
+function gatherTimestamps(tracks = [], passes = []) {
+  const timestamps = new Set();
+  for (const track of tracks) {
+    for (const step of track.steps) {
+      if (step.timestamp == null) continue;
+      timestamps.add(step.timestamp);
+    }
+  }
+  for (const pass of passes) {
+    if (pass.timestamp != null) timestamps.add(pass.timestamp);
+    if (pass.completionTimestamp != null) timestamps.add(pass.completionTimestamp);
+  }
+  return Array.from(timestamps).sort((a, b) => a - b);
+}
+
+function buildFrames({ tracks, timestamps, passes, defaultFrameDuration = 0 }) {
+  const frames = [];
+  const passByTimestamp = new Map();
+  for (const pass of passes) {
+    if (pass.timestamp == null) continue;
+    if (!passByTimestamp.has(pass.timestamp)) passByTimestamp.set(pass.timestamp, []);
+    passByTimestamp.get(pass.timestamp).push(pass);
+  }
+
+  for (let i = 0; i < timestamps.length; i++) {
+    const timestamp = timestamps[i];
+    const nextTimestamp = timestamps[i + 1];
+    const framePlayers = {};
+    const actions = [];
+
+    for (const track of tracks) {
+      const step = getStepForTimestamp(track, timestamp);
+      if (!step) continue;
+      const { coords, action, hasBall } = step;
+      if (coords?.x == null && coords?.y == null && !action) continue;
+
+      const payload = {
+        x: coords?.x ?? null,
+        y: coords?.y ?? null,
+        action: action ?? null,
+        hasBall: hasBall || false,
+        teamId: track.teamId ?? null,
+        position: track.position ?? null,
+        index: step.index,
+      };
+
+      if (action) actions.push({ playerId: track.playerId, action });
+      framePlayers[track.playerId] = payload;
+    }
+
+    const frame = {
+      timestamp,
+      duration:
+        nextTimestamp != null && Number.isFinite(nextTimestamp)
+          ? Math.max(0, nextTimestamp - timestamp)
+          : defaultFrameDuration,
+      players: framePlayers,
+    };
+
+    const passEvents = passByTimestamp.get(timestamp) || [];
+    if (passEvents.length) {
+      frame.passes = passEvents.map(evt => ({ ...evt }));
+    }
+
+    if (actions.length) {
+      frame.actions = actions;
+    }
+
+    frames.push(frame);
+  }
+
+  return frames;
+}
+
+function findFirstActionTimestamp(tracks = [], actionSet = new Set()) {
+  let earliest = null;
+  for (const track of tracks) {
+    for (const step of track.steps) {
+      if (!step.action || step.timestamp == null) continue;
+      if (!actionSet.has(step.action)) continue;
+      if (earliest == null || step.timestamp < earliest) {
+        earliest = step.timestamp;
+      }
+    }
+  }
+  return earliest;
+}
+
+function extractShotMetadata({ turn, tracks, offenseTeamId, fastBreak }) {
+  const shooterId = turn?.shooter_id ?? turn?.shooterId ?? turn?.shot?.shooterId ?? null;
+  const assistId = turn?.assist_id ?? turn?.assistId ?? turn?.shot?.assistId ?? null;
+  const points = toNumber(turn?.points ?? turn?.points_scored ?? turn?.pointsScored);
+  const outcome = turn?.shot_result ?? turn?.result ?? turn?.shotOutcome ?? null;
+  const resultType = turn?.result_type ?? turn?.resultType ?? null;
+  const playType = turn?.play_type ?? turn?.playType ?? null;
+  const location = turn?.shot_location ?? turn?.shotLocation ?? null;
+  const shotClock = toNumber(turn?.shot_clock ?? turn?.shotClock);
+  const gameClock = turn?.clock ?? null;
+  const timestamp = findFirstActionTimestamp(tracks, SHOT_ACTIONS) ??
+    toNumber(turn?.shot_timestamp ?? turn?.shotTimestamp);
+
+  return compactObject({
+    timestamp,
+    shooterId,
+    assistId,
+    points,
+    outcome,
+    resultType,
+    playType,
+    location,
+    shotClock,
+    gameClock,
+    teamId: offenseTeamId ?? null,
+    fastBreak: fastBreak ? true : undefined,
+    text: turn?.text ?? null,
+  });
+}
+
+function extractReboundMetadata({ turn, tracks, offenseTeamId, playerLookup }) {
+  const rebounderId =
+    turn?.rebounder_id ??
+    turn?.rebounderId ??
+    turn?.rebound?.rebounderId ??
+    null;
+  const timestamp = findFirstActionTimestamp(tracks, REBOUND_ACTIONS) ??
+    toNumber(turn?.rebound_timestamp ?? turn?.reboundTimestamp);
+  const teamId =
+    turn?.rebound_team_id ??
+    turn?.reboundTeamId ??
+    (rebounderId && playerLookup?.get(rebounderId)?.teamId) ??
+    null;
+  const outcome = turn?.rebound_outcome ?? turn?.reboundOutcome ?? null;
+  const offensive = teamId != null && offenseTeamId != null ? teamId === offenseTeamId : undefined;
+
+  return compactObject({
+    timestamp,
+    rebounderId,
+    teamId,
+    outcome,
+    offensive,
+  });
+}
+
+function extractTurnoverMetadata({ turn, tracks }) {
+  const isTurnover =
+    (turn?.result_type ?? turn?.resultType ?? "").toUpperCase() === "TURNOVER" ||
+    (turn?.turnover === true);
+  if (!isTurnover) return null;
+  const timestamp = findFirstActionTimestamp(tracks, TURNOVER_ACTIONS) ??
+    toNumber(turn?.turnover_timestamp ?? turn?.turnoverTimestamp);
+  const playerId = turn?.turnover_player_id ?? turn?.turnoverPlayerId ?? turn?.victim_id ?? turn?.victimId ?? null;
+  const cause = turn?.turnover_type ?? turn?.turnoverType ?? turn?.turnoverCause ?? null;
+  const forcedBy = turn?.stealer_id ?? turn?.stealerId ?? null;
+  return compactObject({ timestamp, playerId, cause, forcedBy });
+}
+
+function dedupePasses(passes = []) {
+  const seen = new Set();
+  const output = [];
+  for (const pass of passes) {
+    const key = buildPassKey(pass.timestamp, pass.fromId, pass.toId);
+    if (key && seen.has(key)) continue;
+    if (key) seen.add(key);
+    output.push(pass);
+  }
+  return output;
+}
+
+export function normalizeTurn(turn = {}, simData = {}, options = {}) {
+  const playerLookup = buildPlayerMetaLookup(simData);
+  const offenseTeamId =
+    options?.offenseTeamId ??
+    turn?.possession_team_id ??
+    turn?.possessionTeamId ??
+    turn?.starting_possession_team_id ??
+    turn?.startingPossessionTeamId ??
+    null;
+  const defenseTeamId =
+    options?.defenseTeamId ??
+    deriveDefenseTeamId(offenseTeamId, simData, turn);
+  const fastBreak = Boolean(
+    options?.fastBreak ??
+    turn?.fast_break ??
+    turn?.fastBreak ??
+    ((turn?.result_type ?? turn?.resultType) === "FAST_BREAK")
+  );
+  const secondaryBreak = Boolean(options?.secondaryBreak ?? turn?.secondary_break ?? turn?.secondaryBreak);
+
+  const animations = Array.isArray(turn?.animations) ? turn.animations : [];
+  const tracks = [];
+  const setupPlayers = {};
+  const playerOrder = [];
+  let ballOwnerId = null;
+  let ballStartCoords = null;
+
+  for (const anim of animations) {
+    const track = createTrack(anim);
+    if (!track) continue;
+
+    const meta = playerLookup.get(track.playerId) ?? {};
+    if (!track.teamId && meta.teamId) {
+      track.teamId = meta.teamId;
+    }
+    if (!track.position && meta.position) {
+      track.position = meta.position;
+    }
+
+    if (track.playerId === BALL_PLAYER_ID) {
+      const firstStep = track.steps.find(step => step.coords?.x != null && step.coords?.y != null);
+      if (firstStep) {
+        ballStartCoords = { x: firstStep.coords.x, y: firstStep.coords.y };
+      }
+      tracks.push(track);
+      continue;
+    }
+
+    const firstStep = track.steps.find(step => step.coords?.x != null && step.coords?.y != null) ?? track.steps[0];
+    if (firstStep) {
+      setupPlayers[track.playerId] = {
+        x: firstStep.coords?.x ?? null,
+        y: firstStep.coords?.y ?? null,
+        hasBall: Boolean(track.hasBallAtStep?.[firstStep.index] ?? firstStep.hasBall ?? false),
+        teamId: track.teamId ?? meta.teamId ?? null,
+        team: meta.team ?? null,
+        position: track.position ?? meta.position ?? null,
+        name: meta.name ?? null,
+        action: firstStep.action ?? null,
+      };
+      if (!playerOrder.includes(track.playerId)) playerOrder.push(track.playerId);
+    }
+
+    if (ballOwnerId == null && Array.isArray(track.hasBallAtStep) && track.hasBallAtStep[0]) {
+      ballOwnerId = track.playerId;
+      if (!ballStartCoords && firstStep?.coords) {
+        ballStartCoords = { x: firstStep.coords.x, y: firstStep.coords.y };
+      }
+    }
+
+    tracks.push(track);
+  }
+
+  if (ballOwnerId == null) {
+    const firstWithBall = animations.find(anim => Array.isArray(anim?.hasBallAtStep) && anim.hasBallAtStep[0]);
+    if (firstWithBall) {
+      ballOwnerId = firstWithBall.playerId ?? firstWithBall.player_id ?? null;
+    }
+  }
+
+  const explicitPasses = normalizeExplicitPasses(turn?.passes, options?.defaultPassDuration ?? 250);
+  const passKeys = new Set(explicitPasses.map(pass => buildPassKey(pass.timestamp, pass.fromId, pass.toId)).filter(Boolean));
+  const inferredPasses = inferPassesFromTracks(tracks, passKeys, options?.defaultPassDuration ?? 250);
+  const passes = dedupePasses([...explicitPasses, ...inferredPasses]).sort((a, b) => {
+    if (a.timestamp == null && b.timestamp == null) return 0;
+    if (a.timestamp == null) return 1;
+    if (b.timestamp == null) return -1;
+    if (a.timestamp !== b.timestamp) return a.timestamp - b.timestamp;
+    const fromA = a.fromId ?? "";
+    const fromB = b.fromId ?? "";
+    if (fromA < fromB) return -1;
+    if (fromA > fromB) return 1;
+    return 0;
+  });
+
+  const timestamps = gatherTimestamps(tracks, passes);
+  const frames = buildFrames({
+    tracks,
+    timestamps,
+    passes,
+    defaultFrameDuration: options?.defaultFrameDuration ?? 0,
+  });
+
+  const startTimestamp = timestamps.length ? timestamps[0] : null;
+  const endTimestamp = timestamps.length ? timestamps[timestamps.length - 1] : null;
+
+  const shotMeta = extractShotMetadata({ turn, tracks, offenseTeamId, fastBreak });
+  const reboundMeta = extractReboundMetadata({ turn, tracks, offenseTeamId, playerLookup });
+  const turnoverMeta = extractTurnoverMetadata({ turn, tracks });
+
+  const terminal = {
+    shot: shotMeta ?? null,
+    rebound: reboundMeta ?? null,
+    turnover: turnoverMeta ?? null,
+  };
+
+  const setup = {
+    offenseTeamId,
+    defenseTeamId,
+    ball: compactObject({ ownerId: ballOwnerId, coords: ballStartCoords }),
+    players: setupPlayers,
+    order: playerOrder,
+  };
+
+  const context = compactObject({
+    turnId: turn?.id ?? turn?.turn_id ?? null,
+    possessionId: turn?.possession_id ?? turn?.possessionId ?? null,
+    possessionIndex: turn?.possession_index ?? turn?.possessionIndex ?? null,
+    offenseTeamId,
+    defenseTeamId,
+    startingOffenseTeamId:
+      turn?.starting_possession_team_id ?? turn?.startingPossessionTeamId ?? null,
+    fastBreak: fastBreak ? true : undefined,
+    secondaryBreak: secondaryBreak ? true : undefined,
+    resultType: turn?.result_type ?? turn?.resultType ?? null,
+    text: turn?.text ?? null,
+    score: turn?.score ?? null,
+    clock: turn?.clock ?? null,
+    quarter: turn?.quarter ?? turn?.period ?? null,
+    periodLabel: turn?.period_label ?? turn?.periodLabel ?? null,
+    shotClock: toNumber(turn?.shot_clock ?? turn?.shotClock),
+    timeElapsed: toNumber(turn?.time_elapsed ?? turn?.timeElapsed),
+    startTimestamp,
+    endTimestamp,
+  }) || {};
+
+  return {
+    context,
+    setup,
+    timeline: {
+      startTimestamp,
+      endTimestamp,
+      frames,
+      passes,
+    },
+    terminal,
+  };
+}
+
+export default normalizeTurn;


### PR DESCRIPTION
## Summary
- create a normalizeTurn utility that builds possession context, timelines, passes, and terminal metadata for animation playback
- add safeguards around pass inference and metadata extraction for reliable payloads
- cover half-court, fast-break, and offensive-rebound scenarios with node-based unit tests

## Testing
- node --test FrontEnd/static/js/phaser/animation/__tests__/normalizeTurn.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cff309d2ec83289bc544b7a59edce6