### PR TITLE
Make free throws use linear ball path

### DIFF
--- a/FrontEnd/static/js/phaser/animation/animation_config.js
+++ b/FrontEnd/static/js/phaser/animation/animation_config.js
@@ -38,6 +38,7 @@ const defaults = {
     lineupMoveMs: 800,
     shooterPrepMs: 400,
     shotMs: 500,
+    useArc: false,
     arcHeight: 40,
     rimHoldMs: 300,
   },

--- a/FrontEnd/static/js/phaser/animation/ballTween.js
+++ b/FrontEnd/static/js/phaser/animation/ballTween.js
@@ -90,11 +90,21 @@ export function tweenBallTo(scene, ballSprite, target, opts = {}) {
   ballSprite.setVisible(true);
 
   return new Promise((resolve, reject) => {
-    if (arc) {
+    const arcEnabled =
+      !!arc &&
+      !(
+        typeof arc === 'object' &&
+        Object.prototype.hasOwnProperty.call(arc, 'enabled') &&
+        arc.enabled === false
+      );
+
+    if (arcEnabled) {
       const startX = ballSprite.x;
       const startY = ballSprite.y;
       const controlX = (startX + target.x) / 2;
-      const height = typeof arc === 'object' && arc.height ? arc.height : 50;
+      const hasHeightProp =
+        typeof arc === 'object' && Object.prototype.hasOwnProperty.call(arc, 'height');
+      const height = hasHeightProp && arc.height != null && arc.height !== false ? arc.height : 50;
       const controlY = Math.min(startY, target.y) - height;
       const curve = new Phaser.Curves.QuadraticBezier(
         new Phaser.Math.Vector2(startX, startY),

--- a/FrontEnd/static/js/phaser/animation/freeThrow.js
+++ b/FrontEnd/static/js/phaser/animation/freeThrow.js
@@ -143,11 +143,16 @@ export async function runFreeThrowSequence(
         : AWAY_RIM_COORDS);
     const rimPx = gridToPixels(rimGrid.x, rimGrid.y, width, height);
     scene.events?.emit("ft:shotStart");
-    await tween(scene, ballSprite, rimPx, {
+    const shotTweenOptions = {
       duration: animationConfig.freeThrow.shotMs,
       easing: "Sine.easeInOut",
-      arc: { height: 0 },
-    });
+    };
+
+    shotTweenOptions.arc = animationConfig.freeThrow.useArc
+      ? { height: animationConfig.freeThrow.arcHeight }
+      : { height: animationConfig.freeThrow.arcHeight, enabled: false };
+
+    await tween(scene, ballSprite, rimPx, shotTweenOptions);
 
     scene.events?.emit(result === "MAKE" ? "ft:make" : "ft:miss");
     await wait(scene, animationConfig.freeThrow.rimHoldMs);


### PR DESCRIPTION
## Summary
- add a `freeThrow.useArc` toggle to the shared animation configuration so free throws default to linear travel
- update the free throw sequence to respect the toggle while keeping existing attach/detach behavior
- teach the shared ball tween helper to skip arc math when a caller disables it so shots can travel in a straight line

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cff45039cc8328b7d210e7815a30fd