### PR TITLE
Document possession runner debug workflow

### DIFF
--- a/docs/animation-debug.md
+++ b/docs/animation-debug.md
@@ -5,11 +5,25 @@ controls verbose logging across the Phaser animation helpers. By default the
 flag is disabled. Toggle it at runtime from the browser console:
 
 ```js
-// Enable detailed animation tracing
+// Enable detailed animation tracing and the new runner in one go
 window.DEBUG_ANIM = true;
+window.FEATURE_POSSESSION_RUNNER = true;
 
-// Disable the logs when you are done
+// Disable everything when you are done
 window.DEBUG_ANIM = false;
+window.FEATURE_POSSESSION_RUNNER = false;
+```
+
+Both flags are also exposed via `debugFlags.js` for module consumers:
+
+```js
+import {
+  setAnimationDebugEnabled,
+  setPossessionRunnerEnabled,
+} from 'FrontEnd/static/js/phaser/utils/debugFlags';
+
+setAnimationDebugEnabled(true);
+setPossessionRunnerEnabled(true);
 ```
 
 Enabling the flag unlocks a series of structured diagnostics that are emitted
@@ -25,15 +39,40 @@ backend payload they consume. Each entry includes:
 - `stepIndex` and the first timestamp observed for that step
 - A list of `{ playerId, action }` pairs participating in the step
 
-The step logger enforces a per-possession monotonicity check. If a subsequent
-step reports a lower `stepIndex` than the last processed value for that
-possession you will see a warning similar to:
+The step logger (shared by the legacy orchestrators and the runner) enforces a
+per-possession monotonicity check. If a subsequent step reports a lower
+`stepIndex` than the last processed value for that possession you will see a
+warning similar to:
 
 ```
 ANIM: stepIndex regression { fromState: ..., lastStepIndex: 12, stepIndex: 10, ... }
 ```
 
 Use this to quickly spot gaps or out-of-order movement data from the simulator.
+When `FEATURE_POSSESSION_RUNNER` is enabled the same warning will also include
+the offending node id and graph edge so you can track the regression back to
+the possession graph.
+
+## Runner-specific tracing
+
+`PossessionRunner` adds a layer of instrumentation that surfaces under the
+`ANIM` prefix when both `DEBUG_ANIM` and `FEATURE_POSSESSION_RUNNER` are true.
+Key entries include:
+
+- `ANIM runner:graph-loaded` – prints the possession id, node/edge counts, and
+  whether the graph passed validation.
+- `ANIM runner:phase-enter` / `ANIM runner:phase-exit` – documents which phase
+  is active and how long the previous phase took.
+- `ANIM runner:step-start` / `ANIM runner:step-complete` – log the node id,
+  backend step index, and resolved tween duration. Use these to correlate
+  runner scheduling with sprite motion.
+- `ANIM runner:ball-transfer` – highlights ball ownership changes, including
+  assists, rebounds, and turnovers detected mid-sequence.
+
+Each runner hook mirrors the event emitter outlined in
+`docs/animations-roadmap.md`. If you only see the events without their paired
+`ANIM` log entries, double-check that `DEBUG_ANIM` and
+`FEATURE_POSSESSION_RUNNER` are both enabled.
 
 ## Tween and pass summaries
 
@@ -56,7 +95,10 @@ ANIM teleport suspicion { plannedDistance: 180, actualDistance: 360, ... }
 ```
 
 The warning highlights the IDs involved along with the start/target
-coordinates so you can trace unexpected teleports.
+coordinates so you can trace unexpected teleports. When the runner is active it
+also annotates the graph node that triggered the discrepancy. Treat repeated
+teleport warnings as blockers before promoting the runner flag to wider
+audiences.
 
 ## FSM transition tracing
 
@@ -79,5 +121,7 @@ movement with scoring plays.
   feature flags such as `PASS_DEBUG` and `DebugFlags.OUTLET` still gate their
   respective sections but now require `DEBUG_ANIM` to be enabled before they
   print.
-- You can reset any accumulated step state by toggling the flag off and back
+- Use `DebugFlags.ANIM` / `DebugFlags.FEATURE_POSSESSION_RUNNER` from the
+  console to confirm flag state if you suspect conflicting overrides.
+- You can reset any accumulated step state by toggling either flag off and back
   on; new possessions start with a fresh monotonicity tracker.

--- a/docs/animations-roadmap.md
+++ b/docs/animations-roadmap.md
@@ -33,6 +33,7 @@ The backend simulation already emits authoritative `turns[]` with ordered `steps
 2. **Introduce a `PossessionRunner` timeline**
    - Consume the normalized graph and schedule tweens via a single Phaser timeline per possession.
    - Emit canonical events for state changes (setup complete, pass started, shot resolved, possession change).
+   - Ship behind `FEATURE_POSSESSION_RUNNER` so the legacy orchestrators remain available while we validate parity.
 
 3. **Centralize FSM control**
    - Route all state transitions through the runner, allowing it to look ahead and select the correct next state (e.g., stay in Rebound, enter FastBreak, return to HalfCourt).
@@ -49,6 +50,28 @@ The backend simulation already emits authoritative `turns[]` with ordered `steps
 - **Reuse:** `ballManager.js`, `ballTween.js`, `animation_config.js`, sprite factories, and grid helpers. These already enforce smooth tweening and centralized timing.
 - **Replace:** High-level orchestrators (`animateGameTurns`, `turnAnimation` rebound/fast-break branches, free-floating FSM transitions) that currently duplicate logic and introduce race conditions.
 
+## Possession graph format
+
+The runner consumes a normalized possession graph produced by the backend transformer. Each graph is a deterministic DAG:
+
+- **`nodes[]`** – ordered structures with `{ id, phase, stepIndex, payload }`. `phase` enumerates `setup`, `movement`, `ball-event`, `resolution`, and future fast-break specializations.
+- **`edges[]`** – directional transitions describing legal successors. Edges capture `{ from, to, condition }` where `condition` can include shot or rebound outcomes.
+- **`meta`** – possession-level hints including `possessionType`, `expectedNextType`, and shot/clock timestamps.
+
+Nodes preserve backend timestamps so the runner can compute tween durations deterministically. The format is forward-compatible with additional metadata (e.g., foul sequences) so long as new phases map to the same schema.
+
+## Runner event hooks
+
+`PossessionRunner` exposes a thin event emitter to make instrumentation and HUD updates predictable. When `FEATURE_POSSESSION_RUNNER` is active the following hooks fire:
+
+- **`runner:graph-loaded`** – emitted once a possession graph is parsed and validated.
+- **`runner:phase-enter` / `runner:phase-exit`** – payload includes `{ phase, turnId, possessionId }`.
+- **`runner:step-start` / `runner:step-complete`** – includes `{ nodeId, stepIndex, activePlayers }`.
+- **`runner:ball-transfer`** – fired whenever ball ownership changes, including rebounds and steals.
+- **`runner:possession-complete`** – final summary with scoreboard deltas and the announced `expectedNextType`.
+
+Consumers (HUD, overlays, debug panels) should subscribe to these events instead of tapping internal tween helpers. Each hook logs through `DEBUG_ANIM` when animation debugging is enabled to maintain a single source of truth for timeline tracing.
+
 ## Risk & Mitigation
 - **Complexity risk:** The runner introduces new abstractions—mitigate by shipping instrumentation and feature flags first.
 - **Regression risk:** Incremental rollout with baseline recordings lets us compare old vs. new flows turn by turn.
@@ -60,4 +83,4 @@ The backend simulation already emits authoritative `turns[]` with ordered `steps
 - When should we expose developer tooling (e.g., playback scrubber) to accelerate regression testing once the runner is in place?
 
 Document owner: Frontend Animation Team
-Last updated: 2025-09-20
+Last updated: 2025-10-21


### PR DESCRIPTION
## Summary
- document the normalized possession graph format and runner event hooks in the animation roadmap
- add usage notes for enabling DEBUG_ANIM and FEATURE_POSSESSION_RUNNER plus guidance for interpreting new runner logs

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68cffe0b3b348328b1ca2d21305b0c88