### PR TITLE
Scale possession frame durations and enforce minimums

### DIFF
--- a/FrontEnd/static/js/phaser/animation/__tests__/normalizeTurn.test.js
+++ b/FrontEnd/static/js/phaser/animation/__tests__/normalizeTurn.test.js
@@ -2,6 +2,7 @@ const { test } = require('node:test');
 const assert = require('node:assert/strict');
 
 const normalizerPromise = import('../possession/normalizeTurn.js');
+const animationConfigPromise = import('../animation_config.js');
 
 function baseSimData() {
   return {
@@ -163,6 +164,9 @@ test('normalizeTurn infers passes and fast break metadata', async () => {
 
 test('normalizeTurn captures offensive rebound context', async () => {
   const { normalizeTurn } = await normalizerPromise;
+  const { default: animationConfig } = await animationConfigPromise;
+  const minFrameDuration =
+    animationConfig.possession?.minFrameDurationMs ?? animationConfig.pass?.duration ?? 0;
 
   const turn = {
     id: 'turn-or',
@@ -216,6 +220,80 @@ test('normalizeTurn captures offensive rebound context', async () => {
   assert.equal(normalized.terminal.rebound.timestamp, 900);
   const finalFrame = normalized.timeline.frames[normalized.timeline.frames.length - 1];
   assert.equal(finalFrame.timestamp, 1100);
-  assert.equal(finalFrame.duration, 0);
+  assert.ok(finalFrame.duration >= minFrameDuration);
   assert.ok(finalFrame.actions.some(action => action.action === 'shoot'));
+});
+
+test('normalizeTurn enforces minimum frame and pass durations', async () => {
+  const { normalizeTurn } = await normalizerPromise;
+  const { default: animationConfig } = await animationConfigPromise;
+  const minFrameDuration =
+    animationConfig.possession?.minFrameDurationMs ?? animationConfig.pass?.duration ?? 0;
+  const minPassDuration =
+    animationConfig.possession?.minPassDurationMs ??
+    animationConfig.pass?.duration ??
+    minFrameDuration;
+
+  const turn = {
+    id: 'turn-mini',
+    possession_id: 'pos-mini',
+    possession_team_id: 'HOME',
+    result_type: 'MAKE',
+    shooter_id: 'sg',
+    passes: [{ timestamp: 1, fromId: 'pg', toId: 'sg', duration: 1 }],
+    animations: [
+      {
+        playerId: 'pg',
+        teamId: 'HOME',
+        position: 'PG',
+        hasBallAtStep: [true, false, false],
+        movement: [
+          { timestamp: 0, coords: { x: 30, y: 20 }, action: 'handle_ball' },
+          { timestamp: 1, coords: { x: 31, y: 20 }, action: 'pass' },
+          { timestamp: 2, coords: { x: 32, y: 20 }, action: 'space' },
+        ],
+      },
+      {
+        playerId: 'sg',
+        teamId: 'HOME',
+        position: 'SG',
+        movement: [
+          { timestamp: 0, coords: { x: 40, y: 22 }, action: 'wait' },
+          { timestamp: 1, coords: { x: 40, y: 22 }, action: 'receive' },
+          { timestamp: 2, coords: { x: 42, y: 22 }, action: 'shoot' },
+        ],
+      },
+      {
+        playerId: 'ball',
+        hasBallAtStep: [true, false, false],
+        movement: [
+          { timestamp: 0, coords: { x: 30, y: 20 } },
+          { timestamp: 1, coords: { x: 40, y: 22 } },
+          { timestamp: 2, coords: { x: 42, y: 22 }, action: 'shoot' },
+        ],
+      },
+    ],
+  };
+
+  const normalized = normalizeTurn(turn, baseSimData());
+
+  const frameDurations = normalized.timeline.frames.map(frame => frame.duration);
+  assert.ok(
+    frameDurations.every(duration => duration >= minFrameDuration),
+    `expected every frame duration >= ${minFrameDuration}, got ${frameDurations.join(', ')}`
+  );
+
+  const globalPassDurations = normalized.timeline.passes.map(pass => pass.duration);
+  assert.ok(
+    globalPassDurations.every(duration => duration >= minPassDuration),
+    `expected timeline pass durations >= ${minPassDuration}, got ${globalPassDurations.join(', ')}`
+  );
+
+  const framePassDurations = normalized.timeline.frames.flatMap(frame =>
+    (frame.passes || []).map(pass => pass.duration)
+  );
+  assert.ok(
+    framePassDurations.every(duration => duration >= minPassDuration),
+    `expected frame pass durations >= ${minPassDuration}, got ${framePassDurations.join(', ')}`
+  );
 });

--- a/FrontEnd/static/js/phaser/animation/animation_config.js
+++ b/FrontEnd/static/js/phaser/animation/animation_config.js
@@ -54,6 +54,11 @@ const defaults = {
   },
   offensiveRebound: { pauseMs: 1000 },
   putback: { duration: 500, easing: 'Sine.easeInOut' },
+  possession: {
+    msPerTick: 1,
+    minFrameDurationMs: 120,
+    minPassDurationMs: 150,
+  },
 };
 
 const overrides =
@@ -88,6 +93,18 @@ export const animationConfig = {
     ...(overrides.offensiveRebound || {}),
   },
   putback: { ...defaults.putback, ...(overrides.putback || {}) },
+  possession: {
+    msPerTick: overrides.possession?.msPerTick ?? defaults.possession.msPerTick,
+    minFrameDurationMs:
+      overrides.possession?.minFrameDurationMs ??
+      overrides.possession?.minDurationMs ??
+      defaults.possession.minFrameDurationMs,
+    minPassDurationMs:
+      overrides.possession?.minPassDurationMs ??
+      overrides.possession?.minFrameDurationMs ??
+      overrides.possession?.minDurationMs ??
+      defaults.possession.minPassDurationMs,
+  },
 };
 
 animationConfig.outletSetup = {

--- a/FrontEnd/static/js/phaser/animation/possession/normalizeTurn.js
+++ b/FrontEnd/static/js/phaser/animation/possession/normalizeTurn.js
@@ -1,3 +1,5 @@
+import animationConfig from "../animation_config.js";
+
 const BALL_PLAYER_ID = "ball";
 const PASS_ACTION = "pass";
 const RECEIVE_ACTION = "receive";
@@ -10,6 +12,36 @@ function toNumber(value) {
   if (value == null) return null;
   const coerced = Number(value);
   return Number.isFinite(coerced) ? coerced : null;
+}
+
+const POSSESSION_TIMING = animationConfig?.possession ?? {};
+const PASS_CONFIG = animationConfig?.pass ?? {};
+const resolvedMsPerTick = toNumber(POSSESSION_TIMING.msPerTick);
+const MS_PER_TICK = resolvedMsPerTick != null && resolvedMsPerTick > 0 ? resolvedMsPerTick : 1;
+const resolvedMinFrameDuration = toNumber(POSSESSION_TIMING.minFrameDurationMs);
+const MIN_FRAME_DURATION_MS =
+  resolvedMinFrameDuration != null && resolvedMinFrameDuration >= 0
+    ? resolvedMinFrameDuration
+    : 120;
+const MIN_PASS_DURATION_MS = (() => {
+  const configValue = toNumber(POSSESSION_TIMING.minPassDurationMs);
+  if (configValue != null && configValue >= 0) {
+    return Math.max(MIN_FRAME_DURATION_MS, configValue);
+  }
+  const passConfigDuration = toNumber(PASS_CONFIG.duration);
+  if (passConfigDuration != null && passConfigDuration >= 0) {
+    return Math.max(MIN_FRAME_DURATION_MS, passConfigDuration);
+  }
+  return MIN_FRAME_DURATION_MS;
+})();
+
+function scaleDurationFromTicks(ticks, { minMs = MIN_FRAME_DURATION_MS } = {}) {
+  const numeric = toNumber(ticks);
+  if (numeric == null) return Math.max(0, minMs ?? 0);
+  const scaled = numeric * MS_PER_TICK;
+  if (!Number.isFinite(scaled)) return Math.max(0, minMs ?? 0);
+  const sanitized = Math.max(0, scaled);
+  return minMs != null ? Math.max(minMs, sanitized) : sanitized;
 }
 
 function compactObject(value) {
@@ -140,21 +172,39 @@ function buildPassKey(timestamp, fromId, toId) {
 function normalizeExplicitPasses(passes = [], defaultDuration = 250) {
   if (!Array.isArray(passes)) return [];
   const results = [];
+  const defaultDurationTicks = Math.max(0, toNumber(defaultDuration) ?? 0);
   for (const entry of passes) {
     const timestamp = toNumber(entry?.timestamp ?? entry?.start ?? entry?.startTimestamp);
     const fromId = entry?.fromId ?? entry?.from_id ?? entry?.source ?? null;
     const toId = entry?.toId ?? entry?.to_id ?? entry?.target ?? null;
-    const duration = toNumber(entry?.duration);
-    const completionTimestamp =
-      toNumber(entry?.completionTimestamp ?? entry?.endTimestamp ?? entry?.completeTimestamp) ??
-      (timestamp != null && duration != null ? timestamp + duration : null);
-    const resolvedDuration =
-      duration ??
-      (timestamp != null && completionTimestamp != null ? Math.max(0, completionTimestamp - timestamp) : defaultDuration);
+    const explicitDuration = toNumber(entry?.duration);
+    let completionTimestamp = toNumber(
+      entry?.completionTimestamp ?? entry?.endTimestamp ?? entry?.completeTimestamp
+    );
+
+    let resolvedDurationTicks = null;
+    if (explicitDuration != null && explicitDuration >= 0) {
+      resolvedDurationTicks = explicitDuration;
+      if (completionTimestamp == null && timestamp != null) {
+        completionTimestamp = timestamp + resolvedDurationTicks;
+      }
+    } else if (timestamp != null && completionTimestamp != null) {
+      resolvedDurationTicks = Math.max(0, completionTimestamp - timestamp);
+    } else {
+      resolvedDurationTicks = defaultDurationTicks;
+      if (timestamp != null && completionTimestamp == null) {
+        completionTimestamp = timestamp + resolvedDurationTicks;
+      }
+    }
+
+    const durationMs = scaleDurationFromTicks(resolvedDurationTicks, {
+      minMs: MIN_PASS_DURATION_MS,
+    });
+
     results.push({
       timestamp,
       completionTimestamp,
-      duration: resolvedDuration ?? defaultDuration,
+      duration: durationMs,
       fromId,
       toId,
       source: "explicit",
@@ -167,6 +217,7 @@ function normalizeExplicitPasses(passes = [], defaultDuration = 250) {
 function inferPassesFromTracks(tracks = [], knownKeys = new Set(), defaultDuration = 250) {
   const passes = [];
   const receiveLookup = new Map();
+  const defaultDurationTicks = Math.max(0, toNumber(defaultDuration) ?? 0);
 
   for (const track of tracks) {
     if (track.playerId === BALL_PLAYER_ID) continue;
@@ -198,27 +249,31 @@ function inferPassesFromTracks(tracks = [], knownKeys = new Set(), defaultDurati
       if (key && knownKeys.has(key)) continue;
 
       let completionTimestamp = null;
-      let duration = defaultDuration;
+      let durationTicks = defaultDurationTicks;
       if (receiver?.step?.timestamp != null && receiver.step.timestamp > step.timestamp) {
         completionTimestamp = receiver.step.timestamp;
-        duration = receiver.step.timestamp - step.timestamp;
+        durationTicks = Math.max(0, receiver.step.timestamp - step.timestamp);
       } else if (receiver?.step?.raw) {
         const raw = receiver.step.raw;
         const inferredEnd = toNumber(raw?.completionTimestamp ?? raw?.endTimestamp ?? raw?.timestampComplete);
         if (inferredEnd != null && inferredEnd >= step.timestamp) {
           completionTimestamp = inferredEnd;
-          duration = inferredEnd - step.timestamp;
+          durationTicks = Math.max(0, inferredEnd - step.timestamp);
         }
       }
 
-      if (completionTimestamp == null && duration != null && step.timestamp != null) {
-        completionTimestamp = step.timestamp + duration;
+      if (completionTimestamp == null && durationTicks != null && step.timestamp != null) {
+        completionTimestamp = step.timestamp + durationTicks;
       }
+
+      const durationMs = scaleDurationFromTicks(durationTicks, {
+        minMs: MIN_PASS_DURATION_MS,
+      });
 
       passes.push({
         timestamp: step.timestamp,
         completionTimestamp,
-        duration: duration ?? defaultDuration,
+        duration: durationMs,
         fromId: track.playerId,
         toId: receiver?.playerId ?? null,
         source: "inferred",
@@ -302,12 +357,16 @@ function buildFrames({ tracks, timestamps, passes, defaultFrameDuration = 0 }) {
       framePlayers[track.playerId] = payload;
     }
 
+    const rawDurationTicks =
+      nextTimestamp != null && Number.isFinite(nextTimestamp)
+        ? Math.max(0, nextTimestamp - timestamp)
+        : defaultFrameDuration;
+
     const frame = {
       timestamp,
-      duration:
-        nextTimestamp != null && Number.isFinite(nextTimestamp)
-          ? Math.max(0, nextTimestamp - timestamp)
-          : defaultFrameDuration,
+      duration: scaleDurationFromTicks(rawDurationTicks, {
+        minMs: MIN_FRAME_DURATION_MS,
+      }),
       players: framePlayers,
     };
 


### PR DESCRIPTION
## Summary
- add possession timing knobs to `animation_config` so normalizeTurn can translate ticks into milliseconds
- scale frame and pass durations in normalizeTurn and propagate them to PossessionRunner consumers
- extend the normalizeTurn spec with minimum-duration expectations for frames and passes

## Testing
- node --test FrontEnd/static/js/phaser/animation/__tests__/normalizeTurn.test.js
- node --test FrontEnd/static/js/phaser/animation/__tests__/PossessionRunner.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d06dd4ea4883289daa47cb110fa696