### PR TITLE
Add Phaser timeline polyfill fallback

### DIFF
--- a/FrontEnd/static/js/phaser/animation/__tests__/PossessionRunner.test.js
+++ b/FrontEnd/static/js/phaser/animation/__tests__/PossessionRunner.test.js
@@ -226,3 +226,187 @@ test('PossessionRunner schedules frames and emits debug events', async () => {
 
   globalThis.DEBUG_ANIM = false;
 });
+
+test('PossessionRunner uses polyfill timeline when tween manager lacks factory', async () => {
+  globalThis.DEBUG_ANIM = true;
+  const { PossessionRunner } = await runnerPromise;
+  const { States, transitions } = await statePromise;
+
+  const delayCalls = [];
+  const time = {
+    delayedCall(delay, callback) {
+      const record = {
+        delay,
+        callback,
+        cancelled: false,
+      };
+      delayCalls.push(record);
+      return {
+        remove() {
+          record.cancelled = true;
+        },
+        destroy() {
+          record.cancelled = true;
+        },
+      };
+    },
+  };
+
+  const tweenCalls = [];
+  const scene = {
+    tweens: {
+      add: createTweenStub(tweenCalls),
+    },
+    time,
+    events: {
+      emitted: [],
+      emit(event, payload) {
+        this.emitted.push({ event, payload });
+      },
+    },
+    game: { config: { width: 94, height: 50 } },
+  };
+
+  const stateMachine = {
+    state: States.Inbound,
+    transitionCalls: [],
+    transition(next, payload = {}) {
+      const allowed = transitions[this.state] || [];
+      if (!allowed.includes(next)) {
+        throw new Error(`Invalid transition: ${this.state} -> ${next}`);
+      }
+      this.transitionCalls.push({ next, payload, from: this.state });
+      this.state = next;
+    },
+    is(value) {
+      return this.state === value;
+    },
+  };
+
+  scene.stateMachine = stateMachine;
+
+  const ballSprite = {
+    setPosition(x, y) {
+      this.x = x;
+      this.y = y;
+    },
+    setVisible() {},
+    setDepth() {},
+  };
+
+  const playerSprites = {
+    pg: {
+      playerId: 'pg',
+      setPosition(x, y) {
+        this.x = x;
+        this.y = y;
+      },
+    },
+  };
+
+  const helpers = {
+    attachBallToPlayer() {},
+    runPass() {
+      return Promise.resolve();
+    },
+    animateRebound() {
+      return Promise.resolve();
+    },
+    shootBall() {
+      return Promise.resolve();
+    },
+  };
+
+  const graph = {
+    context: {
+      possessionId: 'pos-2',
+      turnId: 'turn-2',
+      turnIndex: 0,
+    },
+    setup: {
+      ball: { ownerId: 'pg', coords: { x: 20, y: 20 } },
+      players: {
+        pg: { x: 20, y: 20, hasBall: true, teamId: 'HOME', position: 'PG' },
+      },
+      order: ['pg'],
+    },
+    timeline: {
+      frames: [
+        {
+          timestamp: 0,
+          duration: 120,
+          players: {
+            pg: { x: 22, y: 22, hasBall: true, teamId: 'HOME', position: 'PG' },
+          },
+        },
+        {
+          timestamp: 120,
+          duration: 150,
+          players: {
+            pg: { x: 30, y: 25, hasBall: true, teamId: 'HOME', position: 'PG' },
+          },
+        },
+      ],
+    },
+    terminal: {},
+  };
+
+  const runner = new PossessionRunner({
+    scene,
+    ballSprite,
+    playerSprites,
+    graph,
+    config: { helpers },
+  });
+
+  const startOrder = [];
+  const completeOrder = [];
+  const originalStart = runner.onFrameStart.bind(runner);
+  runner.onFrameStart = function onFrameStart(frame, index, duration) {
+    startOrder.push({ index, duration });
+    return originalStart(frame, index, duration);
+  };
+
+  const originalComplete = runner.onFrameComplete.bind(runner);
+  runner.onFrameComplete = function onFrameComplete(frame, index) {
+    completeOrder.push(index);
+    return originalComplete(frame, index);
+  };
+
+  const runPromise = runner.run();
+
+  for (let i = 0; i < 5 && delayCalls.length === 0; i += 1) {
+    await Promise.resolve();
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+
+  assert.equal(delayCalls.length, 1);
+  assert.equal(delayCalls[0].delay, graph.timeline.frames[0].duration);
+
+  while (delayCalls.length) {
+    const call = delayCalls.shift();
+    if (!call.cancelled) {
+      call.callback();
+    }
+    await Promise.resolve();
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+
+  await runPromise;
+
+  assert.deepEqual(
+    startOrder.map((entry) => entry.index),
+    [0, 1]
+  );
+  assert.deepEqual(
+    startOrder.map((entry) => entry.duration),
+    graph.timeline.frames.map((frame) => frame.duration)
+  );
+  assert.deepEqual(completeOrder, [0, 1]);
+  assert.equal(scene.__activeTimeline, null);
+  assert.ok(
+    scene.events.emitted.some((evt) => evt.event === 'possessionRunner:step')
+  );
+
+  globalThis.DEBUG_ANIM = false;
+});

--- a/FrontEnd/static/js/phaser/animation/animationTimeline.js
+++ b/FrontEnd/static/js/phaser/animation/animationTimeline.js
@@ -1,4 +1,5 @@
 import * as Phaser from "https://cdn.jsdelivr.net/npm/phaser@3.60.0/dist/phaser.esm.js";
+import { createTimelinePolyfill } from "./timelinePolyfill.js";
 
 // Simple wrapper around Phaser's timeline creation. Ensures any previously
 // active timeline on the scene is stopped before creating a new one so that
@@ -27,6 +28,13 @@ export function createAnimationTimeline(scene) {
     }
   }
 
+  if (!timeline) {
+    console.warn(
+      "Phaser tween timeline unavailable; using timeline polyfill fallback"
+    );
+    timeline = createTimelinePolyfill(scene);
+  }
+
   if (!timeline) return null;
   scene.__activeTimeline = timeline;
 
@@ -35,6 +43,14 @@ export function createAnimationTimeline(scene) {
       scene.__activeTimeline = null;
     }
   });
+
+  if (typeof timeline.once === "function") {
+    timeline.once("stop", () => {
+      if (scene.__activeTimeline === timeline) {
+        scene.__activeTimeline = null;
+      }
+    });
+  }
   return timeline;
 }
 

--- a/FrontEnd/static/js/phaser/animation/animationTimeline.stub.js
+++ b/FrontEnd/static/js/phaser/animation/animationTimeline.stub.js
@@ -1,24 +1,47 @@
+import { createTimelinePolyfill } from "./timelinePolyfill.js";
+
 export function createAnimationTimeline(scene) {
-  const callbacks = new Map();
-  const steps = [];
-  return {
-    add(config = {}) {
-      steps.push(config);
-      return this;
-    },
-    once(event, handler) {
-      if (!callbacks.has(event)) callbacks.set(event, []);
-      callbacks.get(event).push(handler);
-      return this;
-    },
-    play() {
-      for (const step of steps) {
-        step.onStart?.();
-        step.onComplete?.();
-      }
-      (callbacks.get('complete') || []).forEach((handler) => handler?.());
-    },
-  };
+  if (!scene || !scene.tweens) return null;
+
+  if (scene.__activeTimeline) {
+    scene.__activeTimeline.stop?.();
+    scene.__activeTimeline = null;
+  }
+
+  const { tweens } = scene;
+  let timeline = null;
+
+  if (typeof tweens.createTimeline === "function") {
+    timeline = tweens.createTimeline();
+  } else if (typeof tweens.timeline === "function") {
+    timeline = tweens.timeline();
+  } else if (typeof tweens.addTimeline === "function") {
+    timeline = tweens.addTimeline();
+  }
+
+  if (!timeline) {
+    timeline = createTimelinePolyfill(scene);
+  }
+
+  if (!timeline) return null;
+
+  scene.__activeTimeline = timeline;
+
+  timeline.once?.("complete", () => {
+    if (scene.__activeTimeline === timeline) {
+      scene.__activeTimeline = null;
+    }
+  });
+
+  timeline.once?.("stop", () => {
+    if (scene.__activeTimeline === timeline) {
+      scene.__activeTimeline = null;
+    }
+  });
+
+  return timeline;
 }
+
+export { createTimelinePolyfill };
 
 export default createAnimationTimeline;

--- a/FrontEnd/static/js/phaser/animation/timelinePolyfill.js
+++ b/FrontEnd/static/js/phaser/animation/timelinePolyfill.js
@@ -1,0 +1,161 @@
+const DEFAULT_EVENT_NAMES = {
+  COMPLETE: "complete",
+  STOP: "stop",
+};
+
+function toDuration(value) {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value >= 0 ? value : 0;
+  }
+  const coerced = Number(value);
+  if (!Number.isFinite(coerced) || coerced < 0) {
+    return 0;
+  }
+  return coerced;
+}
+
+function createListenerRegistry() {
+  const callbacks = new Map();
+  return {
+    once(event, handler) {
+      if (typeof handler !== "function") return;
+      if (!callbacks.has(event)) callbacks.set(event, []);
+      callbacks.get(event).push(handler);
+    },
+    dispatch(event, ...args) {
+      const handlers = callbacks.get(event);
+      if (!handlers || handlers.length === 0) return;
+      callbacks.delete(event);
+      handlers.forEach((handler) => {
+        try {
+          handler(...args);
+        } catch (error) {
+          console.error(
+            "timeline polyfill listener threw",
+            error
+          );
+        }
+      });
+    },
+    clear() {
+      callbacks.clear();
+    },
+  };
+}
+
+function scheduleDelay(scene, duration, callback, pendingSet) {
+  const safeDuration = toDuration(duration);
+  let cancelled = false;
+  let cancelFn;
+
+  if (scene?.time?.delayedCall) {
+    const timer = scene.time.delayedCall(safeDuration, () => {
+      if (cancelled) return;
+      pendingSet.delete(cancelFn);
+      callback();
+    });
+    cancelFn = () => {
+      if (cancelled) return;
+      cancelled = true;
+      pendingSet.delete(cancelFn);
+      if (typeof timer?.remove === "function") {
+        timer.remove(false);
+      } else if (typeof timer?.destroy === "function") {
+        timer.destroy();
+      }
+    };
+  } else {
+    const handle = setTimeout(() => {
+      if (cancelled) return;
+      pendingSet.delete(cancelFn);
+      callback();
+    }, safeDuration);
+    cancelFn = () => {
+      if (cancelled) return;
+      cancelled = true;
+      pendingSet.delete(cancelFn);
+      clearTimeout(handle);
+    };
+  }
+
+  pendingSet.add(cancelFn);
+  return cancelFn;
+}
+
+function createTimelinePolyfill(scene) {
+  const steps = [];
+  const listeners = createListenerRegistry();
+  const pendingDelays = new Set();
+  let status = "idle"; // idle -> playing -> completed|stopped
+
+  function clearPendingDelays() {
+    for (const cancel of Array.from(pendingDelays)) {
+      try {
+        cancel();
+      } catch (error) {
+        console.error("failed to cancel timeline delay", error);
+      }
+    }
+    pendingDelays.clear();
+  }
+
+  function runStep(index) {
+    if (status !== "playing") return;
+    if (index >= steps.length) {
+      status = "completed";
+      listeners.dispatch(DEFAULT_EVENT_NAMES.COMPLETE);
+      return;
+    }
+    const step = steps[index] || {};
+    try {
+      step.onStart?.();
+    } catch (error) {
+      console.error("timeline polyfill onStart threw", error);
+    }
+    const duration = toDuration(step.duration);
+    scheduleDelay(scene, duration, () => {
+      if (status !== "playing") return;
+      try {
+        step.onComplete?.();
+      } catch (error) {
+        console.error("timeline polyfill onComplete threw", error);
+      }
+      runStep(index + 1);
+    }, pendingDelays);
+  }
+
+  const timeline = {
+    add(config = {}) {
+      steps.push(config);
+      return timeline;
+    },
+    once(event, handler) {
+      listeners.once(event, handler);
+      return timeline;
+    },
+    play() {
+      if (status === "playing") return timeline;
+      clearPendingDelays();
+      if (steps.length === 0) {
+        status = "completed";
+        listeners.dispatch(DEFAULT_EVENT_NAMES.COMPLETE);
+        return timeline;
+      }
+      status = "playing";
+      runStep(0);
+      return timeline;
+    },
+    stop() {
+      if (status !== "playing") return timeline;
+      status = "stopped";
+      clearPendingDelays();
+      listeners.dispatch(DEFAULT_EVENT_NAMES.STOP);
+      return timeline;
+    },
+  };
+
+  return timeline;
+}
+
+export { createTimelinePolyfill };
+export default createTimelinePolyfill;


### PR DESCRIPTION
## Summary
- add a Phaser timeline polyfill fallback that warns when used and clears active timelines on stop/complete
- share the polyfill between runtime and test stub so the synthetic timeline honors durations while playing
- extend the PossessionRunner test suite to cover the polyfill execution path

## Testing
- node --test FrontEnd/static/js/phaser/animation/__tests__/PossessionRunner.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d07eb2ef5c8328b74bdf4acef54d36