### PR TITLE
Add Sammy modal component (FTE v2 PR 2a)

### DIFF
--- a/FrontEnd/static/css/sammy-modal.css
+++ b/FrontEnd/static/css/sammy-modal.css
@@ -1,0 +1,193 @@
+/**
+ * Sammy Modal — design-system chrome shared by all FTE v2 tutorial modals.
+ * Mirrors the standard post-game modal (gameCompletionPopup) so onboarding
+ * lives in the same visual world as gameplay. Sammy headshot at top, single
+ * vertical column. Used by username, situation card, set-lineup intro, and
+ * the tutorial post-game modal.
+ */
+@import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;600;700&display=swap');
+
+.sammy-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.65);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  padding: 18px;
+}
+.sammy-modal-backdrop.open {
+  display: flex;
+}
+
+.sammy-modal-backdrop.open .sammy-modal {
+  animation: sammy-modal-in 200ms ease both;
+}
+@keyframes sammy-modal-in {
+  from { opacity: 0; transform: scale(0.96); }
+  to   { opacity: 1; transform: scale(1); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .sammy-modal-backdrop.open .sammy-modal {
+    animation: sammy-modal-fade 150ms ease-out both;
+  }
+}
+@keyframes sammy-modal-fade {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.sammy-modal {
+  background-color: rgba(13, 17, 36, 0.97);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 16px;
+  padding: 26px 28px 28px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
+  width: min(520px, 100%);
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.5);
+  color: #fff;
+  text-align: center;
+}
+
+.sammy-modal-eyebrow {
+  font-family: 'Bebas Neue', sans-serif;
+  font-size: 18px;
+  color: rgba(255, 255, 255, 0.5);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  line-height: 1;
+  margin: 0;
+}
+
+.sammy-modal-image {
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid rgba(255, 255, 255, 0.18);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+  flex-shrink: 0;
+}
+
+.sammy-modal-body {
+  font-family: 'Inter', sans-serif;
+  font-size: 1rem;
+  font-weight: 500;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.92);
+  margin: 0;
+  max-width: 100%;
+}
+.sammy-modal-body p {
+  margin: 0;
+}
+.sammy-modal-body p + p {
+  margin-top: 0.6em;
+}
+
+/* Optional input area (used by username modal in PR 2b). */
+.sammy-modal-input-wrap {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  text-align: left;
+}
+.sammy-modal-input {
+  width: 100%;
+  padding: 11px 14px;
+  font-family: 'Inter', sans-serif;
+  font-size: 1rem;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 8px;
+  color: #fff;
+  box-sizing: border-box;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+.sammy-modal-input:focus {
+  outline: none;
+  border-color: rgba(52, 236, 39, 0.6);
+  box-shadow: 0 0 0 2px rgba(52, 236, 39, 0.2);
+}
+.sammy-modal-input::placeholder {
+  color: rgba(255, 255, 255, 0.35);
+}
+.sammy-modal-hint {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.5);
+  margin: 0;
+}
+.sammy-modal-error {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #ff6d6d;
+  margin: 0;
+  min-height: 1em;
+}
+
+.sammy-modal-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  width: 100%;
+  flex-wrap: wrap;
+}
+
+.sammy-modal-btn {
+  font-family: 'Bebas Neue', sans-serif;
+  font-size: 16px;
+  letter-spacing: 0.08em;
+  padding: 10px 22px;
+  border-radius: 8px;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: filter 120ms ease, transform 120ms ease;
+  min-width: 140px;
+}
+.sammy-modal-btn:hover {
+  filter: brightness(1.08);
+  transform: translateY(-1px);
+}
+.sammy-modal-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+  filter: none;
+}
+
+.sammy-modal-btn-primary {
+  background: #34EC27;
+  color: #15181f;
+  border-color: rgba(52, 236, 39, 0.5);
+}
+.sammy-modal-btn-secondary {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.85);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+@media (max-width: 760px) {
+  .sammy-modal {
+    padding: 22px 18px 20px;
+    gap: 14px;
+  }
+  .sammy-modal-image {
+    width: 80px;
+    height: 80px;
+  }
+  .sammy-modal-actions {
+    flex-direction: column-reverse;
+  }
+  .sammy-modal-btn {
+    width: 100%;
+  }
+}

--- a/FrontEnd/static/js/shared/sammyModal.js
+++ b/FrontEnd/static/js/shared/sammyModal.js
@@ -1,0 +1,246 @@
+/**
+ * Sammy Modal — reusable modal component for the FTE v2 tutorial flow.
+ *
+ * Design baseline: standard post-game modal (gameCompletionPopup). Single
+ * vertical column, dark chrome, Sammy headshot at top. Stylesheet:
+ * /css/sammy-modal.css (auto-loaded if missing).
+ *
+ * Used by: username, situation card, set-lineup intro, tutorial post-game.
+ *
+ * Usage:
+ *   import { showSammyModal } from '/js/shared/sammyModal.js';
+ *
+ *   const handle = showSammyModal({
+ *     eyebrow: 'Your Debut',                   // optional uppercase chip
+ *     body: 'Ok Coach, let\'s play ball...',   // string or HTMLElement
+ *     ctaLabel: 'Set Lineup',                  // primary button
+ *     onCta: () => { ... },                    // primary click handler
+ *     secondaryLabel: null,                    // optional secondary button
+ *     onSecondary: null,                       // optional secondary handler
+ *     dismissOnCta: true,                      // close after onCta (default true)
+ *     input: null,                             // optional input config (see below)
+ *     imageSrc: '/images/sammy_tutorial.png',  // override Sammy image if needed
+ *   });
+ *
+ *   // Input config (used by username modal in PR 2b):
+ *   input: {
+ *     placeholder: 'CoachJamie',
+ *     hint: '3-24 characters. Letters, numbers, underscores.',
+ *     initialValue: '',
+ *     validate: (value) => null | 'error message',  // sync validator
+ *   }
+ *   // When `input` is provided, onCta receives the input value as its first arg.
+ *
+ *   // Returned handle:
+ *   handle.close();          // dismiss the modal
+ *   handle.setError(msg);    // show an error under the input (input mode only)
+ *   handle.setBusy(bool);    // disable buttons + input (e.g., during async submit)
+ */
+
+const STYLESHEET_HREF = '/css/sammy-modal.css';
+const DEFAULT_IMAGE_SRC = '/images/sammy_tutorial.png';
+
+function ensureStylesheetLoaded() {
+  const existing = document.querySelector(`link[href="${STYLESHEET_HREF}"]`);
+  if (existing) return;
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = STYLESHEET_HREF;
+  document.head.appendChild(link);
+}
+
+function buildBodyNode(body) {
+  if (body instanceof HTMLElement) return body;
+  const p = document.createElement('p');
+  p.textContent = String(body ?? '');
+  return p;
+}
+
+/**
+ * @param {Object} opts
+ * @param {string} [opts.eyebrow]
+ * @param {string|HTMLElement} opts.body
+ * @param {string} opts.ctaLabel
+ * @param {Function} opts.onCta            - signature: (inputValue?) => void | Promise
+ * @param {string} [opts.secondaryLabel]
+ * @param {Function} [opts.onSecondary]
+ * @param {boolean} [opts.dismissOnCta=true]
+ * @param {Object} [opts.input]            - { placeholder, hint, initialValue, validate }
+ * @param {string} [opts.imageSrc]
+ * @returns {{ close: Function, setError: Function, setBusy: Function, element: HTMLElement }}
+ */
+export function showSammyModal(opts) {
+  if (!opts || typeof opts.ctaLabel !== 'string' || typeof opts.onCta !== 'function') {
+    throw new Error('showSammyModal: ctaLabel (string) and onCta (function) are required');
+  }
+
+  ensureStylesheetLoaded();
+
+  const backdrop = document.createElement('div');
+  backdrop.className = 'sammy-modal-backdrop';
+  backdrop.setAttribute('role', 'presentation');
+
+  const modal = document.createElement('div');
+  modal.className = 'sammy-modal';
+  modal.setAttribute('role', 'dialog');
+  modal.setAttribute('aria-modal', 'true');
+
+  // Eyebrow (optional).
+  if (opts.eyebrow) {
+    const eyebrow = document.createElement('div');
+    eyebrow.className = 'sammy-modal-eyebrow';
+    eyebrow.textContent = opts.eyebrow;
+    modal.appendChild(eyebrow);
+  }
+
+  // Sammy image.
+  const img = document.createElement('img');
+  img.className = 'sammy-modal-image';
+  img.src = opts.imageSrc || DEFAULT_IMAGE_SRC;
+  img.alt = '';
+  modal.appendChild(img);
+
+  // Body.
+  const bodyWrap = document.createElement('div');
+  bodyWrap.className = 'sammy-modal-body';
+  bodyWrap.appendChild(buildBodyNode(opts.body));
+  modal.appendChild(bodyWrap);
+
+  // Optional input area.
+  let inputEl = null;
+  let errorEl = null;
+  if (opts.input && typeof opts.input === 'object') {
+    const wrap = document.createElement('div');
+    wrap.className = 'sammy-modal-input-wrap';
+
+    inputEl = document.createElement('input');
+    inputEl.type = 'text';
+    inputEl.className = 'sammy-modal-input';
+    inputEl.placeholder = opts.input.placeholder || '';
+    inputEl.value = opts.input.initialValue || '';
+    inputEl.autocomplete = 'off';
+    wrap.appendChild(inputEl);
+
+    if (opts.input.hint) {
+      const hint = document.createElement('p');
+      hint.className = 'sammy-modal-hint';
+      hint.textContent = opts.input.hint;
+      wrap.appendChild(hint);
+    }
+
+    errorEl = document.createElement('p');
+    errorEl.className = 'sammy-modal-error';
+    errorEl.textContent = '';
+    wrap.appendChild(errorEl);
+
+    modal.appendChild(wrap);
+  }
+
+  // Actions row.
+  const actions = document.createElement('div');
+  actions.className = 'sammy-modal-actions';
+
+  let secondaryBtn = null;
+  if (opts.secondaryLabel && typeof opts.onSecondary === 'function') {
+    secondaryBtn = document.createElement('button');
+    secondaryBtn.type = 'button';
+    secondaryBtn.className = 'sammy-modal-btn sammy-modal-btn-secondary';
+    secondaryBtn.textContent = opts.secondaryLabel;
+    actions.appendChild(secondaryBtn);
+  }
+
+  const primaryBtn = document.createElement('button');
+  primaryBtn.type = 'button';
+  primaryBtn.className = 'sammy-modal-btn sammy-modal-btn-primary';
+  primaryBtn.textContent = opts.ctaLabel;
+  actions.appendChild(primaryBtn);
+
+  modal.appendChild(actions);
+  backdrop.appendChild(modal);
+  document.body.appendChild(backdrop);
+
+  // Force reflow so the entrance animation runs.
+  // eslint-disable-next-line no-unused-expressions
+  backdrop.offsetHeight;
+  backdrop.classList.add('open');
+
+  const dismissOnCta = opts.dismissOnCta !== false;
+
+  function close() {
+    if (!backdrop.parentNode) return;
+    backdrop.parentNode.removeChild(backdrop);
+  }
+
+  function setError(msg) {
+    if (!errorEl) return;
+    errorEl.textContent = msg || '';
+  }
+
+  function setBusy(busy) {
+    primaryBtn.disabled = !!busy;
+    if (secondaryBtn) secondaryBtn.disabled = !!busy;
+    if (inputEl) inputEl.disabled = !!busy;
+  }
+
+  async function handlePrimary() {
+    let value;
+    if (inputEl) {
+      value = inputEl.value.trim();
+      if (opts.input?.validate) {
+        const err = opts.input.validate(value);
+        if (err) {
+          setError(err);
+          inputEl.focus();
+          return;
+        }
+      }
+      setError('');
+    }
+    try {
+      setBusy(true);
+      await opts.onCta(value);
+      if (dismissOnCta) close();
+    } catch (e) {
+      // onCta may set its own error message via the returned handle.
+      // Re-throw so the caller can log if desired.
+      throw e;
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  primaryBtn.addEventListener('click', () => {
+    // Don't await — let promise rejections surface as unhandled if the caller
+    // doesn't handle them. setBusy/finally still runs in handlePrimary.
+    handlePrimary().catch((e) => console.error('[sammyModal] onCta threw:', e));
+  });
+
+  if (secondaryBtn) {
+    secondaryBtn.addEventListener('click', () => {
+      try {
+        opts.onSecondary();
+      } finally {
+        if (dismissOnCta) close();
+      }
+    });
+  }
+
+  // Enter key submits primary action when an input is present.
+  if (inputEl) {
+    inputEl.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        primaryBtn.click();
+      }
+    });
+    // Autofocus the input on next tick.
+    setTimeout(() => inputEl.focus(), 0);
+  }
+
+  return {
+    close,
+    setError,
+    setBusy,
+    element: modal,
+  };
+}


### PR DESCRIPTION
## Summary
- New reusable modal component for all FTE v2 tutorial-flow screens.
- **Pure additive change** — no existing surface is touched. Two new files only.
- Visual integration / behavior cutover happens in PR 2b → 2c → 2d.

### Files

| File | Purpose |
|---|---|
| `FrontEnd/static/css/sammy-modal.css` | Design-system chrome (mirrors standard post-game modal) |
| `FrontEnd/static/js/shared/sammyModal.js` | `showSammyModal({...})` API + handle |

### Design baseline

Mirrors the standard post-game modal (`gameCompletionPopup`) so onboarding lives in the same visual world as gameplay:
- Dark background `rgba(13, 17, 36, 0.97)` + 1px white border, 16px radius
- Bebas Neue eyebrow + button copy, Inter body
- Green primary CTA (`#34EC27`) on dark text
- Scale + fade entrance, `prefers-reduced-motion` fallback
- Single vertical column with Sammy headshot at top (96px circular)
- Max-width 520px, mobile fallback layout (column-reverse actions, smaller image)

### API

```js
import { showSammyModal } from '/js/shared/sammyModal.js';

const handle = showSammyModal({
  eyebrow: 'Your Debut',                    // optional uppercase chip
  body: "Ok Coach, let's play ball...",     // string or HTMLElement
  ctaLabel: 'Set Lineup',
  onCta: () => { /* ... */ },
  secondaryLabel: null,                     // optional secondary button
  onSecondary: null,
  dismissOnCta: true,                       // default true
  input: null,                              // optional input config
  imageSrc: '/images/sammy_tutorial.png',   // override Sammy if needed
});

// handle: { close, setError, setBusy, element }
```

Input mode (used by username modal in PR 2b) supports placeholder, hint, initial value, sync validator, error display, and Enter-to-submit. `setBusy(true)` disables buttons + input during async submits.

Stylesheet auto-loaded via `<link>` injection if not already present, so callers don't need to wire it into every page that uses the component.

### What's NOT in this PR

- Any integration into existing pages (`authBarInit.js`, set-lineup, etc.)
- Tutorial routing decisions
- Old `fte.css` deletion (happens in PR 2d cutover)
- Funnel pages (PR 2c)
- Tutorial post-game modal (PR 2d)

## Test plan
- [ ] Review the design baseline matches `gameCompletionPopup` chrome (dark bg, Bebas eyebrow, green CTA)
- [ ] Confirm no existing JS imports `sammyModal.js` yet (this is purely additive)
- [ ] (Optional) Manual smoke: open any logged-in page, run `import('/js/shared/sammyModal.js').then(({showSammyModal}) => showSammyModal({ eyebrow: 'TEST', body: 'Hello coach', ctaLabel: 'OK', onCta: () => {} }))` in the console — modal should appear with correct chrome
- [ ] (Optional) Run the same with `input: { placeholder: 'Name', hint: 'Try it', validate: v => v.length < 3 ? 'too short' : null }` to verify input mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)