### PR TITLE
Extract username modal to sammyModal (FTE v2 PR 2b)

### DIFF
--- a/FrontEnd/static/js/shared/authBarInit.js
+++ b/FrontEnd/static/js/shared/authBarInit.js
@@ -84,32 +84,8 @@
     }
   ];
 
-  function ensureUsernameModal() {
-    if (document.getElementById('fte-username-backdrop')) return;
-    var backdrop = document.createElement('div');
-    backdrop.id = 'fte-username-backdrop';
-    backdrop.className = 'fte-username-backdrop';
-    backdrop.setAttribute('role', 'dialog');
-    backdrop.setAttribute('aria-modal', 'true');
-    backdrop.setAttribute('aria-labelledby', 'fte-username-title');
-    backdrop.innerHTML = [
-      '<div class="fte-modal">',
-      '  <div class="fte-content">',
-      '    <img src="/images/sammy_tutorial.png" alt="" class="fte-content-img">',
-      '    <div class="fte-content-main">',
-      '      <p id="fte-username-title">Choose a username</p>',
-      '      <p class="fte-username-hint">No spaces • Letters, numbers, underscores only • 3-24 characters</p>',
-      '      <input type="text" id="fte-username-input" class="fte-username-input" placeholder="Username" maxlength="24" autocomplete="username">',
-      '      <div id="fte-username-error" class="fte-username-error" role="alert" style="display: none;"></div>',
-      '    </div>',
-      '  </div>',
-      '  <div class="fte-footer">',
-      '    <button type="button" id="fte-username-submit" class="fte-btn fte-btn-next">Continue</button>',
-      '  </div>',
-      '</div>'
-    ].join('');
-    document.body.appendChild(backdrop);
-  }
+  // Username modal lives in /js/shared/usernameModal.js (FTE v2 chrome).
+  // Loaded on demand via dynamic import — see openUsernameModal() below.
 
   function ensureAccountSettingsModal() {
     if (document.getElementById('account-settings-backdrop')) return;
@@ -184,90 +160,21 @@
     primaryBtn.textContent = step.primaryLabel;
   }
 
-  function validateUsername(value) {
-    var v = (value || '').trim();
-    if (v.length < 3) return 'Username must be at least 3 characters';
-    if (v.length > 24) return 'Username must be at most 24 characters';
-    if (/[\s]/.test(v)) return 'No spaces allowed';
-    if (!/^[a-zA-Z0-9_]+$/.test(v)) return 'Only letters, numbers, and underscores';
-    return null;
-  }
-
+  // Username modal: delegated to /js/shared/usernameModal.js (FTE v2 chrome).
+  // Loaded on demand so this classic script doesn't need to be a module.
+  // Signature preserved (positional `onSuccess` callback) so existing callers
+  // continue to work unchanged.
   function openUsernameModal(onSuccess) {
-    ensureUsernameModal();
-    var backdrop = document.getElementById('fte-username-backdrop');
-    var input = document.getElementById('fte-username-input');
-    var errorEl = document.getElementById('fte-username-error');
-    var submitBtn = document.getElementById('fte-username-submit');
-    if (!backdrop || !input || !submitBtn) return;
-
-    errorEl.style.display = 'none';
-    errorEl.textContent = '';
-    input.value = '';
-    backdrop.classList.add('open');
-    input.focus();
-
-    function closeUsernameModal() {
-      backdrop.classList.remove('open');
-    }
-
-    submitBtn.onclick = function () {
-      var username = (input.value || '').trim();
-      var err = validateUsername(username);
-      if (err) {
-        errorEl.textContent = err;
-        errorEl.style.display = 'block';
-        return;
-      }
-      errorEl.style.display = 'none';
-      errorEl.textContent = '';
-
-      if (typeof API_CONFIG === 'undefined' || typeof API_CONFIG.buildUrl !== 'function' || typeof API_CONFIG.getAuthHeaders !== 'function') {
-        closeUsernameModal();
-        if (onSuccess) onSuccess();
-        return;
-      }
-
-      submitBtn.disabled = true;
-      fetch(API_CONFIG.buildUrl('/api/auth/set-username'), {
-        method: 'POST',
-        headers: Object.assign({ 'Content-Type': 'application/json' }, API_CONFIG.getAuthHeaders()),
-        body: JSON.stringify({ username: username })
+    import('/js/shared/usernameModal.js')
+      .then(function (mod) {
+        mod.openUsernameModal({ onSuccess: onSuccess });
       })
-        .then(function (res) {
-          return res.json().then(function (data) {
-            if (res.ok) {
-              try {
-                var authUser = localStorage.getItem('auth_user');
-                if (authUser) {
-                  var user = JSON.parse(authUser);
-                  user.username = data.username;
-                  localStorage.setItem('auth_user', JSON.stringify(user));
-                }
-              } catch (e) {}
-              var authUserEmail = document.getElementById('auth-user-email');
-              if (authUserEmail) authUserEmail.textContent = data.username;
-              closeUsernameModal();
-              if (onSuccess) onSuccess();
-            } else {
-              errorEl.textContent = data.detail || 'This username is already taken';
-              errorEl.style.display = 'block';
-            }
-          });
-        })
-        .catch(function () {
-          errorEl.textContent = 'Something went wrong. Try again.';
-          errorEl.style.display = 'block';
-        })
-        .then(function () {
-          submitBtn.disabled = false;
-        });
-    };
+      .catch(function (e) {
+        console.error('[authBarInit] Failed to load usernameModal.js:', e);
+      });
   }
 
   function openFTESteps() {
-    var usernameBackdrop = document.getElementById('fte-username-backdrop');
-    if (usernameBackdrop) usernameBackdrop.classList.remove('open');
     ensureFTEModal();
     var backdrop = document.getElementById('fte-backdrop');
     var backBtn = document.getElementById('fte-btn-back');
@@ -337,8 +244,6 @@
       });
       return;
     }
-    var usernameBackdrop = document.getElementById('fte-username-backdrop');
-    if (usernameBackdrop) usernameBackdrop.classList.remove('open');
     openFTESteps();
   }
 

--- a/FrontEnd/static/js/shared/usernameModal.js
+++ b/FrontEnd/static/js/shared/usernameModal.js
@@ -1,0 +1,110 @@
+/**
+ * Username Modal — FTE v2 design.
+ *
+ * Wraps showSammyModal() with username-specific config:
+ *   - Validation: 3-24 chars, no spaces, [a-zA-Z0-9_] only
+ *   - POST /api/auth/set-username
+ *   - On success: update localStorage.auth_user, refresh auth-bar display, close
+ *   - On failure: show inline error
+ *
+ * Replaces the inline username modal previously defined in authBarInit.js
+ * (ensureUsernameModal + openUsernameModal). In PR 2b this is invoked by the
+ * legacy FTE v1 entry path; in PR 2c it'll also be the username step of the
+ * new tutorial funnel.
+ *
+ * Usage:
+ *   import { openUsernameModal } from '/js/shared/usernameModal.js';
+ *   openUsernameModal({ onSuccess: () => { ... } });
+ */
+
+import { showSammyModal } from '/js/shared/sammyModal.js';
+
+
+const USERNAME_HINT = '3-24 characters. Letters, numbers, and underscores only — no spaces.';
+const USERNAME_PROMPT = 'Choose a username, Coach.';
+
+
+function validateUsername(value) {
+  const v = (value || '').trim();
+  if (v.length < 3) return 'Username must be at least 3 characters';
+  if (v.length > 24) return 'Username must be at most 24 characters';
+  if (/\s/.test(v)) return 'No spaces allowed';
+  if (!/^[a-zA-Z0-9_]+$/.test(v)) return 'Only letters, numbers, and underscores';
+  return null;
+}
+
+
+function persistUsernameLocally(username) {
+  try {
+    const raw = localStorage.getItem('auth_user');
+    if (raw) {
+      const user = JSON.parse(raw);
+      user.username = username;
+      localStorage.setItem('auth_user', JSON.stringify(user));
+    }
+  } catch (_) {
+    // Best-effort; ignore parse/storage failures.
+  }
+  const emailDisplay = document.getElementById('auth-user-email');
+  if (emailDisplay) emailDisplay.textContent = username;
+}
+
+
+/**
+ * Open the username modal.
+ * @param {Object} opts
+ * @param {Function} [opts.onSuccess]  - called after the username is persisted server-side
+ * @returns {{ close: Function }}      - handle to dismiss the modal early if needed
+ */
+export function openUsernameModal(opts = {}) {
+  const onSuccess = typeof opts.onSuccess === 'function' ? opts.onSuccess : null;
+
+  const handle = showSammyModal({
+    body: USERNAME_PROMPT,
+    ctaLabel: 'Continue',
+    dismissOnCta: false,  // we control dismissal — wait for API success
+    input: {
+      placeholder: 'Username',
+      hint: USERNAME_HINT,
+      validate: validateUsername,
+    },
+    onCta: async (username) => {
+      const trimmed = (username || '').trim();
+
+      // Fallback when API_CONFIG isn't loaded (e.g., on a public-only page) —
+      // dismiss without making the request so the caller isn't stranded.
+      if (typeof API_CONFIG === 'undefined' ||
+          typeof API_CONFIG.buildUrl !== 'function' ||
+          typeof API_CONFIG.getAuthHeaders !== 'function') {
+        handle.close();
+        if (onSuccess) onSuccess();
+        return;
+      }
+
+      let res;
+      let data;
+      try {
+        res = await fetch(API_CONFIG.buildUrl('/api/auth/set-username'), {
+          method: 'POST',
+          headers: Object.assign({ 'Content-Type': 'application/json' }, API_CONFIG.getAuthHeaders()),
+          body: JSON.stringify({ username: trimmed }),
+        });
+        data = await res.json();
+      } catch (_) {
+        handle.setError('Something went wrong. Try again.');
+        return;
+      }
+
+      if (!res.ok) {
+        handle.setError((data && data.detail) || 'This username is already taken');
+        return;
+      }
+
+      persistUsernameLocally(data.username);
+      handle.close();
+      if (onSuccess) onSuccess();
+    },
+  });
+
+  return handle;
+}


### PR DESCRIPTION
## Summary
- First integration of the Sammy modal component from PR 2a.
- Replaces the inline username modal in `authBarInit.js` with a new `usernameModal.js` ES module that wraps `showSammyModal()`.
- **Behavior preserved end-to-end.** Same validation, same API call, same success/error handling, same callback signature.
- **Visual change:** users hitting the username step (`fte: true` + no username) will see the new dark-chrome Sammy modal instead of the old white modal.

### Files

| File | Change |
|---|---|
| `FrontEnd/static/js/shared/usernameModal.js` | **NEW** — `openUsernameModal({ onSuccess })` ES module |
| `FrontEnd/static/js/shared/authBarInit.js` | Replaced 3 inline functions (95 lines deleted) with a thin dynamic-import wrapper |

### Why this is a separate small PR

- Lets us land the chrome change on a low-blast-radius surface (username modal) before the funnel pages (PR 2c) or cutover (PR 2d) need it.
- Gives staging an early look at the new design so we can validate the visual before more code depends on it.
- Easy revert: if the new chrome looks wrong, this is a 2-file rollback.

### Integration mechanics

`authBarInit.js` is a classic IIFE script (not a module). To integrate the new ES-module-based component without changing how `authBarInit` itself is loaded, the wrapper uses dynamic `import()`:

```js
function openUsernameModal(onSuccess) {
  import('/js/shared/usernameModal.js')
    .then(mod => mod.openUsernameModal({ onSuccess }))
    .catch(e => console.error('[authBarInit] Failed to load usernameModal.js:', e));
}
```

Caller signature is preserved (positional `onSuccess` callback) so the FTE v1 flow that follows the username step continues to work.

### What's NOT in this PR

- Removal of the old `.fte-username-*` CSS in `fte.css` (deletion happens in PR 2d cutover when the whole `fte.css` is removed)
- Any change to the 4-step FTE v1 welcome modals (they still fire after username; gone in PR 2d)
- Any tutorial routing or new pages (PR 2c)

## Test plan
- [ ] Sign up a new user on staging → username modal appears with new dark Sammy chrome
- [ ] Enter a valid username → POST succeeds, modal closes, FTE v1 welcome steps appear (still v1 styling)
- [ ] Enter an invalid username (too short / spaces / special chars) → inline error appears inside the new modal
- [ ] Enter a username that's already taken → error message from API surfaces inline
- [ ] Existing alpha user with `username` already set → no username modal (skipped, as before)
- [ ] Grandfathered user (`fte_v2_complete: true`) → no FTE modals fire at all (existing behavior, no change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)