### PR TITLE
Add FTE v2 tutorial funnel pages (PR 2c)

### DIFF
--- a/FrontEnd/static/franchise-select-team.js
+++ b/FrontEnd/static/franchise-select-team.js
@@ -35,6 +35,10 @@ const loadingBanner = document.getElementById("team-select-loading-banner");
 const loadingSubline = document.getElementById("team-select-loading-subline");
 const backLink = document.getElementById("team-select-back-link");
 
+// FTE v2 tutorial branch: when ?mode=tutorial is present, this page is the
+// first step of the new-user funnel rather than a franchise-creation entry.
+const TUTORIAL_MODE = new URLSearchParams(window.location.search).get("mode") === "tutorial";
+
 function buildReturnUrl() {
   return window.location.pathname + window.location.search;
 }
@@ -70,13 +74,17 @@ function createButtons() {
   teams.forEach(team => {
     const card = document.createElement("div");
     card.className = "team-card";
+    // Tutorial flow shows only the Select action — no scouting before first game.
+    const overlayHtml = TUTORIAL_MODE
+      ? `<button class="team-card-action team-card-action-select" type="button">Select</button>`
+      : `<button class="team-card-action team-card-action-scout" type="button">Scout</button>
+         <button class="team-card-action team-card-action-select" type="button">Select</button>`;
     card.innerHTML = `
       <div class="team-card-banner">
         <img src="${typeof getTeamAssetPath === 'function' ? getTeamAssetPath(team, 'banner_primary') : '/images/teams/general/general_banner_primary.jpg'}" alt="${team}">
         <div class="team-card-tagline">${taglines[team] || team}</div>
         <div class="team-card-overlay">
-          <button class="team-card-action team-card-action-scout" type="button">Scout</button>
-          <button class="team-card-action team-card-action-select" type="button">Select</button>
+          ${overlayHtml}
         </div>
       </div>
     `;
@@ -91,10 +99,59 @@ function createButtons() {
     if (selectBtn) {
       selectBtn.addEventListener("click", () => {
         playSound("click-beep.wav");
-        selectTeam(team);
+        if (TUTORIAL_MODE) {
+          selectTutorialTeam(team);
+        } else {
+          selectTeam(team);
+        }
       });
     }
     teamContainer.appendChild(card);
+  });
+}
+
+// FTE v2 tutorial flow: team selection records the pick in tutorial_state,
+// opens the username modal with team-aware copy, and on submit routes to the
+// situation card page. No franchise is created here — the tutorial game is
+// throwaway (single mode behind the scenes).
+async function selectTutorialTeam(team) {
+  hideError();
+  try {
+    // Step 1: persist the team pick + advance tutorial_state to "username".
+    const advanceRes = await fetch(API_CONFIG.buildUrl('/api/auth/tutorial-advance'), {
+      method: 'POST',
+      headers: { ...API_CONFIG.getAuthHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({ step: 'username', team_pick: team }),
+    });
+    if (!advanceRes.ok) {
+      throw new Error('Could not start tutorial');
+    }
+  } catch (err) {
+    console.error('[tutorial] team-pick advance failed:', err);
+    showError(err.message || 'Could not start tutorial');
+    return;
+  }
+
+  // Step 2: open the username modal with team-aware copy.
+  const prompt = `You're now coaching the ${team}. What's your name, Coach?`;
+  const { openUsernameModal } = await import('/js/shared/usernameModal.js');
+  openUsernameModal({
+    prompt,
+    onSuccess: async () => {
+      // Step 3: advance to "situation" and navigate to the situation card.
+      try {
+        await fetch(API_CONFIG.buildUrl('/api/auth/tutorial-advance'), {
+          method: 'POST',
+          headers: { ...API_CONFIG.getAuthHeaders(), 'Content-Type': 'application/json' },
+          body: JSON.stringify({ step: 'situation' }),
+        });
+      } catch (e) {
+        // Don't block the user on a non-critical step advance — the situation
+        // page will be safe to re-enter and will see the prior step in state.
+        console.warn('[tutorial] could not advance to situation step:', e);
+      }
+      window.location.href = '/tutorial-situation.html';
+    },
   });
 }
 
@@ -135,7 +192,16 @@ document.addEventListener("DOMContentLoaded", function () {
     lobbyMusic.volume = 0.4;
     lobbyMusic.play().catch(function () {});
   } catch (e) {}
-  if (backLink) {
+
+  if (TUTORIAL_MODE) {
+    // Tutorial flow: no back link (per spec, user is locked in after team pick,
+    // but more importantly there's no mode-select to return to pre-onboarding).
+    if (backLink) backLink.style.display = 'none';
+    const title = document.getElementById('page-title');
+    const subtitle = document.getElementById('page-subtitle');
+    if (title) title.textContent = 'Pick Your Program, Coach.';
+    if (subtitle) subtitle.textContent = "It's your first game. Choose the team you want to lead onto the court.";
+  } else if (backLink) {
     backLink.addEventListener("click", function (event) {
       event.preventDefault();
       window.location.href = '/mode-select.html';

--- a/FrontEnd/static/js/shared/authBarInit.js
+++ b/FrontEnd/static/js/shared/authBarInit.js
@@ -30,6 +30,8 @@
     'play-builder.html',
     'play-builder-v2.html',
     'play-details.html',
+    // FTE v2 tutorial funnel — immersive screens, no auth bar
+    'tutorial-situation.html',
     // Optional non-.html route variants
     '/box-score',
     '/game-plan',

--- a/FrontEnd/static/js/shared/usernameModal.js
+++ b/FrontEnd/static/js/shared/usernameModal.js
@@ -21,7 +21,7 @@ import { showSammyModal } from '/js/shared/sammyModal.js';
 
 
 const USERNAME_HINT = '3-24 characters. Letters, numbers, and underscores only — no spaces.';
-const USERNAME_PROMPT = 'Choose a username, Coach.';
+const DEFAULT_USERNAME_PROMPT = 'Choose a username, Coach.';
 
 
 function validateUsername(value) {
@@ -54,13 +54,17 @@ function persistUsernameLocally(username) {
  * Open the username modal.
  * @param {Object} opts
  * @param {Function} [opts.onSuccess]  - called after the username is persisted server-side
+ * @param {string}   [opts.prompt]     - override the default body copy (e.g., tutorial flow)
  * @returns {{ close: Function }}      - handle to dismiss the modal early if needed
  */
 export function openUsernameModal(opts = {}) {
   const onSuccess = typeof opts.onSuccess === 'function' ? opts.onSuccess : null;
+  const prompt = typeof opts.prompt === 'string' && opts.prompt.trim()
+    ? opts.prompt
+    : DEFAULT_USERNAME_PROMPT;
 
   const handle = showSammyModal({
-    body: USERNAME_PROMPT,
+    body: prompt,
     ctaLabel: 'Continue',
     dismissOnCta: false,  // we control dismissal — wait for API success
     input: {

--- a/FrontEnd/static/set-lineup.js
+++ b/FrontEnd/static/set-lineup.js
@@ -1998,7 +1998,20 @@ async function init() {
   if (autosetBtn) {
     autosetBtn.addEventListener('click', autosetLineup);
   }
-  
+
+  // FTE v2 tutorial: auto-fill the lineup on first load + show the Sammy intro
+  // modal. User can still tweak before hitting Play. modeParam comes from the
+  // module-level URL snapshot; ?mode=tutorial originates from tutorial-situation.html.
+  if (modeParam === 'tutorial') {
+    try { await autosetLineup(); } catch (e) { console.warn('[tutorial] autoset on load failed:', e); }
+    import('/js/shared/sammyModal.js').then(({ showSammyModal }) => {
+      showSammyModal({
+        body: "I've set your lineup, feel free to make any changes as you see fit.",
+        ctaLabel: 'Got it',
+      });
+    }).catch((e) => console.warn('[tutorial] could not load sammyModal:', e));
+  }
+
   const btn = document.getElementById('play-now');
   if (btn) {
     btn.addEventListener('click', async () => {
@@ -2028,12 +2041,15 @@ async function init() {
       
       // ✅ PHASE 1.1: Ensure game_id exists before navigating (same as Game Plan / Playbooks)
       // PLAY GAME bypasses game plan; if user clicks before init-game completes, we'd navigate without game_id
-      if (!currentGameId && homeTeam && awayTeam && !resumeFromTimeout && modeParam === 'single' && quarter === 1) {
+      // FTE v2 tutorial: also runs through this branch (mode === 'tutorial') so the
+      // backend init_game can apply the Q4 4:00 60-60 state injection.
+      if (!currentGameId && homeTeam && awayTeam && !resumeFromTimeout &&
+          (modeParam === 'single' || modeParam === 'tutorial') && quarter === 1) {
         if (!initGameInProgress) {
           console.log('⏳ [SET-LINEUP] PLAY GAME: game_id not found, calling init-game...');
           initGameInProgress = true;
           try {
-            const initPayload = { home_team: homeTeam, away_team: awayTeam, mode: 'single' };
+            const initPayload = { home_team: homeTeam, away_team: awayTeam, mode: modeParam };
             if (myTeamSide) initPayload.user_team_side = myTeamSide;
             const initRes = await fetch(API_CONFIG.buildUrl('/api/init-game'), {
               method: 'POST',
@@ -2111,6 +2127,27 @@ async function init() {
         console.debug('🔀 Redirecting to court.html (bypassing game plan)', { home: homeTeam, away: awayTeam, gameId: currentGameId });
       }
       DEBUG && console.log('[lineup] launching quarter', quarter);
+
+      // FTE v2 tutorial: advance the server-side step to "in_game" before
+      // navigation. Court.html will read resume_from_timeout from URL params
+      // (added by buildGameNavigationParams below) so the engine emits the SIP
+      // first turn per the timeout-resume path in BackEnd/main.py.
+      if (modeParam === 'tutorial') {
+        try {
+          await fetch(API_CONFIG.buildUrl('/api/auth/tutorial-advance'), {
+            method: 'POST',
+            headers: { ...API_CONFIG.getAuthHeaders(), 'Content-Type': 'application/json' },
+            body: JSON.stringify({ step: 'in_game' }),
+          });
+        } catch (e) {
+          console.warn('[tutorial] could not advance to in_game step:', e);
+        }
+        // Force resume_from_timeout=true so the engine routes through the
+        // existing SIP emission path for the first turn (state seeded by
+        // apply_tutorial_initial_state in PR 1).
+        params.set('resume_from_timeout', 'true');
+      }
+
       const finalUrl = `/court.html?${params.toString()}`;
       console.log('🔍 [DEBUG QTR BREAK] set-lineup.js - Navigating to court.html:', finalUrl);
       playSound('confirm-1-lowervol.wav');

--- a/FrontEnd/static/tutorial-situation.html
+++ b/FrontEnd/static/tutorial-situation.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager (production only) -->
+  <script src="/js/shared/gtm-loader.js"></script>
+  <!-- End Google Tag Manager -->
+  <script src="/js/shared/authGuard.js"></script>
+  <script src="/js/shared/sentryInit.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/x-icon" href="/images/favicon.ico">
+  <title>The Situation, Coach</title>
+  <link rel="stylesheet" href="/css/sammy-modal.css">
+  <style>
+    /* Dark backdrop; the situation modal renders on top via sammyModal. */
+    html, body {
+      margin: 0;
+      padding: 0;
+      min-height: 100vh;
+      background: radial-gradient(ellipse at center, #1a2042 0%, #0a0d1c 70%);
+      background-attachment: fixed;
+      font-family: 'Inter', sans-serif;
+    }
+  </style>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K69GQK3D"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+
+  <script src="/js/config/api-config.js"></script>
+  <script type="module" src="/tutorial-situation.js"></script>
+</body>
+</html>

--- a/FrontEnd/static/tutorial-situation.js
+++ b/FrontEnd/static/tutorial-situation.js
@@ -1,0 +1,112 @@
+/**
+ * Tutorial Situation Card — step 3 of the FTE v2 funnel.
+ *
+ * Flow:
+ *   1. Fetch /api/auth/me to read tutorial_state.team_pick (user's picked team)
+ *   2. Derive opponent: Xavien, unless user picked Xavien (then South Lancaster)
+ *   3. Show Sammy modal with the situation copy
+ *   4. CTA: POST /api/auth/tutorial-advance { step: "set_lineup" } and
+ *      navigate to /set-lineup.html?mode=tutorial&home=<user>&away=<opp>&my_team=home
+ *
+ * Per fte_inject_state.md §1-§2, the user is always HOME in the tutorial game.
+ */
+
+import { showSammyModal } from '/js/shared/sammyModal.js';
+
+
+const DEFAULT_OPPONENT = 'Xavien';
+const XAVIEN_FALLBACK_OPPONENT = 'South Lancaster';
+
+
+function deriveOpponent(userTeam) {
+  if (!userTeam) return DEFAULT_OPPONENT;
+  return userTeam === DEFAULT_OPPONENT ? XAVIEN_FALLBACK_OPPONENT : DEFAULT_OPPONENT;
+}
+
+
+function situationBody(opponent) {
+  // Copy locked by Coach in PR 2c spec discussion.
+  return `Ok Coach, let's play ball. You're playing ${opponent}, ` +
+         `and the score is tied 60-60 with 4 minutes remaining. Let's win this!`;
+}
+
+
+async function fetchMe() {
+  if (typeof API_CONFIG === 'undefined' ||
+      typeof API_CONFIG.buildUrl !== 'function' ||
+      typeof API_CONFIG.getAuthHeaders !== 'function') {
+    throw new Error('API_CONFIG unavailable');
+  }
+  const res = await fetch(API_CONFIG.buildUrl('/api/auth/me'), {
+    method: 'GET',
+    headers: API_CONFIG.getAuthHeaders(),
+  });
+  if (!res.ok) throw new Error('Could not load user');
+  return res.json();
+}
+
+
+async function advanceToSetLineup() {
+  try {
+    await fetch(API_CONFIG.buildUrl('/api/auth/tutorial-advance'), {
+      method: 'POST',
+      headers: { ...API_CONFIG.getAuthHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({ step: 'set_lineup' }),
+    });
+  } catch (e) {
+    console.warn('[tutorial] could not advance to set_lineup step:', e);
+    // Continue anyway — server state can be recovered on the next page.
+  }
+}
+
+
+function gotoSetLineup(userTeam, opponent) {
+  const params = new URLSearchParams({
+    mode: 'tutorial',
+    home: userTeam,
+    away: opponent,
+    my_team: 'home',
+  });
+  window.location.href = `/set-lineup.html?${params.toString()}`;
+}
+
+
+async function main() {
+  let me;
+  try {
+    me = await fetchMe();
+  } catch (e) {
+    console.error('[tutorial] failed to load /api/auth/me:', e);
+    // Show a degraded fallback so the user isn't stuck on a black screen.
+    showSammyModal({
+      eyebrow: 'Hmm',
+      body: 'We had trouble loading your tutorial. Please refresh the page.',
+      ctaLabel: 'Reload',
+      dismissOnCta: false,
+      onCta: () => window.location.reload(),
+    });
+    return;
+  }
+
+  const teamPick = me?.tutorial_state?.team_pick;
+  if (!teamPick) {
+    // No team picked yet — bounce back to team-select.
+    window.location.replace('/franchise-select-team.html?mode=tutorial');
+    return;
+  }
+
+  const opponent = deriveOpponent(teamPick);
+
+  showSammyModal({
+    body: situationBody(opponent),
+    ctaLabel: 'Set Lineup',
+    dismissOnCta: false,
+    onCta: async () => {
+      await advanceToSetLineup();
+      gotoSetLineup(teamPick, opponent);
+    },
+  });
+}
+
+
+main();


### PR DESCRIPTION
## Summary
- Three additive funnel pages for the FTE v2 tutorial flow, behind `?mode=tutorial` URL params.
- **No existing user flows changed.** Franchise / single / tournament code paths are untouched.
- Pages exist and are reachable at direct URLs, but signup doesn't yet route to them — that's the PR 2d cutover.

### What's in this PR

| Commit | What |
|---|---|
| `067b076` | `franchise-select-team.js` adds `?mode=tutorial` branch (hides Scout, hides back link, retitles page, routes Select through tutorial-advance + username modal + situation page) |
| `90558fe` | New `tutorial-situation.html` + `.js` — fetches `/api/auth/me`, derives opponent (Xavien or South Lancaster), shows the locked situation Sammy modal, advances to `set-lineup.html?mode=tutorial` |
| `238efb5` | `set-lineup.js` adds tutorial branch: auto-autoset on load, one-shot Sammy intro modal, mode=tutorial through init-game, advance to in_game step + `resume_from_timeout=true` for SIP first turn |

### Flow (after this PR + PR 2d)

```
team-select?mode=tutorial
  ↓ Select Bentley-Truman
  POST /api/auth/tutorial-advance { step: "username", team_pick: "Bentley-Truman" }
  ↓
Sammy username modal: "You're now coaching the Bentley-Truman. What's your name, Coach?"
  ↓ Continue
  POST /api/auth/set-username
  POST /api/auth/tutorial-advance { step: "situation" }
  ↓
/tutorial-situation.html
  ↓ fetch /api/auth/me → team_pick → opponent
  Sammy situation modal: "Ok Coach, let's play ball. You're playing Xavien..."
  ↓ Set Lineup
  POST /api/auth/tutorial-advance { step: "set_lineup" }
  ↓
/set-lineup.html?mode=tutorial&home=Bentley-Truman&away=Xavien&my_team=home
  ↓ auto-autoset + one-shot Sammy intro
  ↓ Play Game
  POST /api/init-game { mode: "tutorial", ... }
  POST /api/auth/tutorial-advance { step: "in_game" }
  ↓
/court.html?mode=tutorial&...&resume_from_timeout=true
  ↓ engine emits SIP first turn (seeded by apply_tutorial_initial_state in PR 1)
```

### What's NOT in this PR

- The cutover in `authBarInit.js` (PR 2d) — signup → mode-select → tutorial routing decision
- `court.html` / `bootGame.js` recognizing `mode=tutorial` (PR 2d) — currently the engine recognizes "tutorial" on the backend, but bootGame's `getMode()` doesn't yet
- Tutorial post-game modal (PR 2d)
- Live Feed debut entry rendering (PR 2d)
- Removal of old FTE v1 4-modal flow (PR 2d cutover)

### Mechanics worth flagging

- `usernameModal.js` got a new optional `prompt` parameter so the tutorial flow can use team-aware copy without forking the module. Default behavior unchanged.
- `tutorial-situation.html` is added to `PAGES_WITHOUT_AUTH_BAR` so the immersive single-modal screen isn't broken up by the top nav.
- `tutorial-situation.html` uses `<script type="module">` for the inline JS so it can `import` from `sammyModal.js`. `franchise-select-team.js` and `set-lineup.js` use dynamic `import()` to stay classic scripts.
- `set-lineup.js` PLAY button now passes `mode: modeParam` instead of hardcoded `'single'`; only tutorial mode is added to the conditional that triggers init-game (line 2031), so franchise/tournament paths still get their game_id from elsewhere as before.

## Test plan (manual on staging once Netlify deploys)
- [ ] Visit `/franchise-select-team.html?mode=tutorial` directly — Scout buttons hidden, back link hidden, new title/subtitle
- [ ] Click Select on a team → Sammy username modal appears with team-aware copy
- [ ] Submit a valid username → redirects to `/tutorial-situation.html`
- [ ] Situation page shows the correct opponent (Xavien for any team except Xavien itself)
- [ ] Click Set Lineup → redirects to `/set-lineup.html?mode=tutorial&home=...&away=...&my_team=home`
- [ ] Set-lineup auto-fills the starting 5 immediately + shows one-shot Sammy intro modal
- [ ] Click Play Game → init-game runs with `mode: "tutorial"`, navigates to `/court.html` with `resume_from_timeout=true`
- [ ] Confirm `GET /api/auth/me` after each step shows correct `tutorial_state.step` advancing forward
- [ ] Verify franchise flow (no `?mode=tutorial`) still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)