### PR TITLE
FTE v2 staging-walkthrough fixes

### DIFF
--- a/BackEnd/utils/tutorial_game.py
+++ b/BackEnd/utils/tutorial_game.py
@@ -111,11 +111,25 @@ def prepare_tutorial_team_attributes(user_team_side: Optional[str]):
     return home_attrs, away_attrs
 
 
-def _apply_stat_overlay_to_team(team, side: str) -> None:
-    """Rank `team.players` by position_ratings, then apply slot stat overlays.
+# Map from starting-slot keys to the position strings used by team.lineup.
+_STARTING_SLOT_TO_POSITION = {
+    "starting_pg": "PG",
+    "starting_sg": "SG",
+    "starting_sf": "SF",
+    "starting_pf": "PF",
+    "starting_c":  "C",
+}
 
-    Mutates each player's stats["game"] and metadata["fouls"] in place.
-    Also sets NG (energy) to the tutorial boot value for every player.
+
+def _apply_stat_overlay_to_team(team, side: str) -> None:
+    """Rank `team.players` by position_ratings, then apply slot stat overlays
+    AND assign the top-ranked five players to team.lineup. Mutates in place.
+
+    - player.stats["game"] gets the Section 5 stat overlay.
+    - player.metadata["fouls"] is mirrored from the overlay (does NOT reset per Q).
+    - player.NG is set to TUTORIAL_NG_AT_BOOT for every player on the team.
+    - team.lineup is populated {PG, SG, SF, PF, C} → Player objects so the engine
+      knows which 5 are on the court at boot (and so set-lineup can render them).
     """
     if not getattr(team, "players", None):
         logger.warning("[TUTORIAL] team %s has no players to overlay", getattr(team, "name", "?"))
@@ -130,6 +144,7 @@ def _apply_stat_overlay_to_team(team, side: str) -> None:
         })
     ranked = rank_roster(ranking_payload)
 
+    # Stat overlay + foul mirror.
     for slot, pid in ranked:
         player = team.players.get(pid)
         if not player:
@@ -144,15 +159,30 @@ def _apply_stat_overlay_to_team(team, side: str) -> None:
         for key, value in overlay.items():
             player.stats["game"][key] = value
 
-        # Mirror personal fouls onto player.metadata["fouls"] (does not reset per Q).
         if "F" in overlay:
             existing_meta = getattr(player, "metadata", None) or {}
             try:
                 player.metadata = dict(existing_meta)
                 player.metadata["fouls"] = int(overlay["F"])
             except Exception:
-                # Player implementation may not allow attribute assignment; skip silently.
                 pass
+
+    # Assign top-ranked starters to team.lineup so the engine boots with the
+    # correct 5 on the court (and set-lineup renders them when it loads the
+    # game doc). team.lineup expects Player objects keyed by position string.
+    new_lineup = {}
+    for slot, pid in ranked:
+        pos = _STARTING_SLOT_TO_POSITION.get(slot)
+        if not pos:
+            continue
+        player = team.players.get(pid)
+        if player is not None:
+            new_lineup[pos] = player
+    if new_lineup:
+        try:
+            team.lineup = new_lineup
+        except Exception as e:
+            logger.warning("[TUTORIAL] could not assign team.lineup for %s: %s", team.name, e)
 
     # Set NG (energy) on every player on this team.
     for player in team.players.values():
@@ -252,37 +282,66 @@ def apply_tutorial_initial_state(
     gm.game_state["timeout_offense_team_id"] = gm.offense_team.team_id
 
     # --- Mirror everything back into the summary that gets persisted to mongo ---
+    # NOTE: summarize_game_state ran BEFORE this helper with an empty lineup and
+    # zero scores, so the captured summary has stale per-team and per-player
+    # data. We update the SPECIFIC summary keys that summarize wrote, using the
+    # canonical schema (see BackEnd/utils/shared.py:1828+):
+    #   - top-level: score, clock, time_remaining, shot_clock_remaining,
+    #     timeout_next_play_type, timeout_offense_team_id, quarter,
+    #     game_stats_initialized
+    #   - summary["teams"][team_id]: score, points_by_quarter, team_fouls, timeouts
+    #   - summary["players"] (flat list): pos + stats for each affected player
+    home_id = home_team.team_id
+    away_id = away_team.team_id
+
     summary["quarter"] = TUTORIAL_QUARTER
     summary["score"] = {home_name: TUTORIAL_SCORE, away_name: TUTORIAL_SCORE}
-    if isinstance(summary.get("home_team"), dict):
-        summary["home_team"]["score"] = TUTORIAL_SCORE
-        summary["home_team"]["points_by_quarter"] = list(home_pbq)
-        summary["home_team"]["team_fouls"] = TUTORIAL_TEAM_FOULS
-        summary["home_team"]["timeouts"] = TUTORIAL_TIMEOUTS_REMAINING
-    if isinstance(summary.get("away_team"), dict):
-        summary["away_team"]["score"] = TUTORIAL_SCORE
-        summary["away_team"]["points_by_quarter"] = list(away_pbq)
-        summary["away_team"]["team_fouls"] = TUTORIAL_TEAM_FOULS
-        summary["away_team"]["timeouts"] = TUTORIAL_TIMEOUTS_REMAINING
+    summary["clock"] = TUTORIAL_CLOCK_DISPLAY
+    summary["time_remaining"] = TUTORIAL_TIME_REMAINING
+    summary["shot_clock_remaining"] = TUTORIAL_SHOT_CLOCK
     summary["game_stats_initialized"] = True
+    summary["timeout_next_play_type"] = "SIDE_INBOUND"
+    summary["timeout_offense_team_id"] = gm.offense_team.team_id
 
-    # game_state is typically nested under summary; sync if present.
-    if isinstance(summary.get("game_state"), dict):
-        gs = summary["game_state"]
-        gs["quarter"] = TUTORIAL_QUARTER
-        gs["time_remaining"] = TUTORIAL_TIME_REMAINING
-        gs["clock"] = TUTORIAL_CLOCK_DISPLAY
-        gs["shot_clock_remaining"] = TUTORIAL_SHOT_CLOCK
-        gs["offense_team"] = gm.offense_team.name
-        gs["defense_team"] = gm.defense_team.name
-        gs["offensive_state"] = TUTORIAL_OFFENSIVE_STATE
-        gs["defense_playcall"] = TUTORIAL_DEFENSE_PLAYCALL
-        gs["team_fouls"] = {home_name: TUTORIAL_TEAM_FOULS, away_name: TUTORIAL_TEAM_FOULS}
-        gs["team_timeouts"] = {home_name: TUTORIAL_TIMEOUTS_REMAINING, away_name: TUTORIAL_TIMEOUTS_REMAINING}
-        gs["home_crowd_factor"] = TUTORIAL_HOME_CROWD_FACTOR
-        gs["game_stats_initialized"] = True
-        gs["timeout_next_play_type"] = "SIDE_INBOUND"
-        gs["timeout_offense_team_id"] = gm.offense_team.team_id
+    teams_obj = summary.get("teams")
+    if isinstance(teams_obj, dict):
+        for tid, pbq, in [(home_id, home_pbq), (away_id, away_pbq)]:
+            team_rec = teams_obj.get(tid) if tid is not None else None
+            if isinstance(team_rec, dict):
+                team_rec["score"] = TUTORIAL_SCORE
+                team_rec["points_by_quarter"] = list(pbq)
+                team_rec["team_fouls"] = TUTORIAL_TEAM_FOULS
+                team_rec["timeouts"] = TUTORIAL_TIMEOUTS_REMAINING
+
+    # summary["players"] entries need their `pos` and `stats` fields updated to
+    # reflect the post-tutorial state (team.lineup was empty at summarize time;
+    # _apply_stat_overlay_to_team mutated player.stats["game"] AFTER summarize).
+    pid_to_info = {}
+    for team_obj in (home_team, away_team):
+        # Position info: only for the 5 starters in the post-overlay lineup.
+        lineup_for_team = getattr(team_obj, "lineup", None) or {}
+        for pos, player in lineup_for_team.items():
+            pid = getattr(player, "player_id", None) or getattr(player, "_id", None)
+            if pid is None:
+                continue
+            pid_to_info.setdefault(str(pid), {})["pos"] = pos
+        # Stats info: for every player on the team (starters + bench).
+        for pid, player in (getattr(team_obj, "players", None) or {}).items():
+            game_stats = dict(getattr(player, "stats", {}).get("game") or {})
+            if game_stats:
+                pid_to_info.setdefault(str(pid), {})["stats"] = game_stats
+
+    players_list = summary.get("players")
+    if isinstance(players_list, list):
+        for entry in players_list:
+            pid_str = str(entry.get("playerId") or entry.get("player_id") or "")
+            if not pid_str or pid_str not in pid_to_info:
+                continue
+            info = pid_to_info[pid_str]
+            if "pos" in info:
+                entry["pos"] = info["pos"]
+            if "stats" in info:
+                entry["stats"] = info["stats"]
 
     logger.warning(
         "✅ [TUTORIAL] applied initial state: Q%d %s, %s vs %s, offense=%s, user_side=%s",

--- a/FrontEnd/static/franchise-select-team.css
+++ b/FrontEnd/static/franchise-select-team.css
@@ -137,6 +137,18 @@ input[type="reset"] {
   transition: opacity 0.18s ease, transform 0.18s ease;
 }
 
+/* FTE v2 tutorial: only the Select action is rendered. Center it in the
+   overlay instead of leaving a phantom Scout slot. */
+.team-card-overlay.is-single-action {
+  grid-template-columns: 1fr;
+  justify-items: center;
+}
+
+.team-card-overlay.is-single-action > .team-card-action {
+  min-width: 40%;
+  max-width: 60%;
+}
+
 .team-card:hover .team-card-overlay {
   opacity: 1;
   transform: translateY(0);

--- a/FrontEnd/static/franchise-select-team.js
+++ b/FrontEnd/static/franchise-select-team.js
@@ -79,11 +79,12 @@ function createButtons() {
       ? `<button class="team-card-action team-card-action-select" type="button">Select</button>`
       : `<button class="team-card-action team-card-action-scout" type="button">Scout</button>
          <button class="team-card-action team-card-action-select" type="button">Select</button>`;
+    const overlayClass = TUTORIAL_MODE ? 'team-card-overlay is-single-action' : 'team-card-overlay';
     card.innerHTML = `
       <div class="team-card-banner">
         <img src="${typeof getTeamAssetPath === 'function' ? getTeamAssetPath(team, 'banner_primary') : '/images/teams/general/general_banner_primary.jpg'}" alt="${team}">
         <div class="team-card-tagline">${taglines[team] || team}</div>
-        <div class="team-card-overlay">
+        <div class="${overlayClass}">
           ${overlayHtml}
         </div>
       </div>
@@ -194,13 +195,22 @@ document.addEventListener("DOMContentLoaded", function () {
   } catch (e) {}
 
   if (TUTORIAL_MODE) {
-    // Tutorial flow: no back link (per spec, user is locked in after team pick,
-    // but more importantly there's no mode-select to return to pre-onboarding).
+    // Tutorial flow: no back link, strict header, no subtitle. The greeting
+    // lives in the Sammy intro modal that fires below.
     if (backLink) backLink.style.display = 'none';
     const title = document.getElementById('page-title');
     const subtitle = document.getElementById('page-subtitle');
-    if (title) title.textContent = 'Pick Your Program, Coach.';
-    if (subtitle) subtitle.textContent = "It's your first game. Choose the team you want to lead onto the court.";
+    if (title) title.textContent = 'Pick Your Program';
+    if (subtitle) subtitle.style.display = 'none';
+
+    // One-shot Sammy intro modal — Coach feedback from staging walkthrough.
+    import('/js/shared/sammyModal.js').then(({ showSammyModal }) => {
+      showSammyModal({
+        body: "Hey Coach! It's your first game! Choose your squad you want to lead onto the court.",
+        ctaLabel: "Let's go",
+        onCta: () => {},
+      });
+    }).catch((e) => console.warn('[tutorial] could not load sammyModal:', e));
   } else if (backLink) {
     backLink.addEventListener("click", function (event) {
       event.preventDefault();

--- a/FrontEnd/static/js/phaser/utils/defenseMatchupsPopup.js
+++ b/FrontEnd/static/js/phaser/utils/defenseMatchupsPopup.js
@@ -54,6 +54,16 @@ function markDefenseMatchupAnnouncePlayed(gameId) {
 }
 
 export async function showDefenseMatchupsPopup(gameId, scene) {
+    // FTE v2 tutorial: behave as if "Don't show again" was checked. The
+    // tutorial flow is intentionally minimal and the matchups popup adds
+    // friction we don't want for first-time users. Per Coach feedback (Q2).
+    if (typeof window !== 'undefined') {
+        const urlMode = new URLSearchParams(window.location.search).get('mode');
+        if (urlMode === 'tutorial') {
+            return Promise.resolve();
+        }
+    }
+
     // Check if user has checked "Don't show again this game" (in-memory or persisted across page reloads)
     const persisted = typeof sessionStorage !== 'undefined' && gameId && sessionStorage.getItem(SESSION_STORAGE_KEY_PREFIX + gameId) === '1';
     if (dontShowAgainThisGame || persisted) {

--- a/FrontEnd/static/js/shared/attributeTooltips.js
+++ b/FrontEnd/static/js/shared/attributeTooltips.js
@@ -15,16 +15,16 @@ const ATTRIBUTE_NAMES = {
   RB: 'Rebounding',
   ST: 'Strength',
   AG: 'Agility',
-  FT: 'Free Throw',
+  FT: 'Free Throws',
   ND: 'Endurance',
   IQ: 'Basketball IQ',
   CH: 'Clutch',
   EM: 'Emotion',
   MO: 'Momentum',
   NG: 'Energy',
-  
-  // Other abbreviations
-  POS: 'Position',
+
+  // Other abbreviations (Pos intentionally omitted per Coach feedback —
+  // the column header is already self-descriptive)
   HT: 'Height',
   WT: 'Weight',
   RT: 'Rating'

--- a/FrontEnd/static/js/shared/sammyModal.js
+++ b/FrontEnd/static/js/shared/sammyModal.js
@@ -61,7 +61,7 @@ function buildBodyNode(body) {
  * @param {string} [opts.eyebrow]
  * @param {string|HTMLElement} opts.body
  * @param {string} opts.ctaLabel
- * @param {Function} opts.onCta            - signature: (inputValue?) => void | Promise
+ * @param {Function} [opts.onCta]          - signature: (inputValue?) => void | Promise. Defaults to no-op for ack-only modals.
  * @param {string} [opts.secondaryLabel]
  * @param {Function} [opts.onSecondary]
  * @param {boolean} [opts.dismissOnCta=true]
@@ -70,9 +70,12 @@ function buildBodyNode(body) {
  * @returns {{ close: Function, setError: Function, setBusy: Function, element: HTMLElement }}
  */
 export function showSammyModal(opts) {
-  if (!opts || typeof opts.ctaLabel !== 'string' || typeof opts.onCta !== 'function') {
-    throw new Error('showSammyModal: ctaLabel (string) and onCta (function) are required');
+  if (!opts || typeof opts.ctaLabel !== 'string') {
+    throw new Error('showSammyModal: ctaLabel (string) is required');
   }
+  // onCta defaults to a no-op so simple acknowledge-only modals
+  // ("Got it" / "Let's go") don't need to wire a handler.
+  const onCta = typeof opts.onCta === 'function' ? opts.onCta : (() => {});
 
   ensureStylesheetLoaded();
 
@@ -198,7 +201,7 @@ export function showSammyModal(opts) {
     }
     try {
       setBusy(true);
-      await opts.onCta(value);
+      await onCta(value);
       if (dismissOnCta) close();
     } catch (e) {
       // onCta may set its own error message via the returned handle.

--- a/FrontEnd/static/set-lineup.html
+++ b/FrontEnd/static/set-lineup.html
@@ -68,7 +68,7 @@
                 <table class="roster-table gob-data-grid">
                   <thead>
                     <tr>
-                      <th class="player-header-cell"><span>Player Name</span><span>RT</span></th>
+                      <th class="player-header-cell"><span>Player Name</span><span class="attr-label" data-attr="RT">RT</span></th>
                       <th>Pos</th>
                       <th>HT</th>
                       <th>WT</th>

--- a/FrontEnd/static/set-lineup.js
+++ b/FrontEnd/static/set-lineup.js
@@ -1999,11 +1999,12 @@ async function init() {
     autosetBtn.addEventListener('click', autosetLineup);
   }
 
-  // FTE v2 tutorial: auto-fill the lineup on first load + show the Sammy intro
-  // modal. User can still tweak before hitting Play. modeParam comes from the
-  // module-level URL snapshot; ?mode=tutorial originates from tutorial-situation.html.
+  // FTE v2 tutorial: init-game has already run on the situation page, so the
+  // lineup is in the URL (restoreLineupFromUrl populates it above). We do NOT
+  // call autoset here — the engine assigned the tutorial-roster starters
+  // (rank_roster + Section 5 templates) and we want to honor that exactly.
+  // Just show the Sammy intro modal so the user knows to tweak if desired.
   if (modeParam === 'tutorial') {
-    try { await autosetLineup(); } catch (e) { console.warn('[tutorial] autoset on load failed:', e); }
     import('/js/shared/sammyModal.js').then(({ showSammyModal }) => {
       showSammyModal({
         body: "I've set your lineup, feel free to make any changes as you see fit.",
@@ -2041,15 +2042,15 @@ async function init() {
       
       // ✅ PHASE 1.1: Ensure game_id exists before navigating (same as Game Plan / Playbooks)
       // PLAY GAME bypasses game plan; if user clicks before init-game completes, we'd navigate without game_id
-      // FTE v2 tutorial: also runs through this branch (mode === 'tutorial') so the
-      // backend init_game can apply the Q4 4:00 60-60 state injection.
-      if (!currentGameId && homeTeam && awayTeam && !resumeFromTimeout &&
-          (modeParam === 'single' || modeParam === 'tutorial') && quarter === 1) {
+      // (FTE v2 tutorial mode is NOT here — init-game runs earlier on the
+      // situation page so the engine state + roster are available when this
+      // page loads. By the time the user hits Play, game_id is already in URL.)
+      if (!currentGameId && homeTeam && awayTeam && !resumeFromTimeout && modeParam === 'single' && quarter === 1) {
         if (!initGameInProgress) {
           console.log('⏳ [SET-LINEUP] PLAY GAME: game_id not found, calling init-game...');
           initGameInProgress = true;
           try {
-            const initPayload = { home_team: homeTeam, away_team: awayTeam, mode: modeParam };
+            const initPayload = { home_team: homeTeam, away_team: awayTeam, mode: 'single' };
             if (myTeamSide) initPayload.user_team_side = myTeamSide;
             const initRes = await fetch(API_CONFIG.buildUrl('/api/init-game'), {
               method: 'POST',
@@ -2939,9 +2940,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (typeof initAttributeTooltips !== 'undefined') {
       const thead = document.querySelector('#roster-attributes-pane .roster-table thead');
       if (thead) {
-        initAttributeTooltips(thead, ['th']);
-        
-        // Tooltips initialized (verification logs removed for cleaner console)
+        // Include [data-attr] so the RT span nested inside the Player Name
+        // header (which would otherwise read as "Player NameRT" and miss the
+        // map) gets its own tooltip wiring.
+        initAttributeTooltips(thead, ['th', '[data-attr]']);
       } else {
         console.warn('[TOOLTIP] thead element not found');
       }

--- a/FrontEnd/static/tutorial-situation.js
+++ b/FrontEnd/static/tutorial-situation.js
@@ -60,12 +60,70 @@ async function advanceToSetLineup() {
 }
 
 
-function gotoSetLineup(userTeam, opponent) {
+// Returns the initialized game_id, or null on failure.
+async function initTutorialGame(userTeam, opponent) {
+  try {
+    const res = await fetch(API_CONFIG.buildUrl('/api/init-game'), {
+      method: 'POST',
+      headers: { ...API_CONFIG.getAuthHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        home_team: userTeam,
+        away_team: opponent,
+        mode: 'tutorial',
+        user_team_side: 'home',
+      }),
+    });
+    if (!res.ok) {
+      console.error('[tutorial] init-game failed:', res.status, await res.text().catch(() => ''));
+      return null;
+    }
+    const data = await res.json();
+    return data.game_id || null;
+  } catch (e) {
+    console.error('[tutorial] init-game threw:', e);
+    return null;
+  }
+}
+
+
+// Returns { PG, SG, SF, PF, C } → player_id strings, or {} on failure.
+async function fetchUserLineupFromGame(gameId) {
+  try {
+    const res = await fetch(API_CONFIG.buildUrl(`/api/game/${gameId}`), {
+      headers: API_CONFIG.getAuthHeaders(),
+    });
+    if (!res.ok) return {};
+    const game = await res.json();
+    const homeTeam = game?.home_team;
+    if (!homeTeam || typeof homeTeam !== 'object') return {};
+    const rawLineup = homeTeam.lineup || {};
+    const out = {};
+    ['PG', 'SG', 'SF', 'PF', 'C'].forEach(pos => {
+      const slot = rawLineup[pos];
+      if (!slot) return;
+      const pid = typeof slot === 'string'
+        ? slot
+        : (slot._id || slot.player_id || slot.playerId);
+      if (pid) out[pos] = String(pid);
+    });
+    return out;
+  } catch (e) {
+    console.warn('[tutorial] could not fetch user lineup:', e);
+    return {};
+  }
+}
+
+
+function gotoSetLineup(userTeam, opponent, gameId, lineup) {
   const params = new URLSearchParams({
     mode: 'tutorial',
     home: userTeam,
     away: opponent,
     my_team: 'home',
+  });
+  if (gameId) params.set('game_id', gameId);
+  ['PG', 'SG', 'SF', 'PF', 'C'].forEach(pos => {
+    if (lineup[pos]) params.set(`home_${pos.toLowerCase()}`, lineup[pos]);
   });
   window.location.href = `/set-lineup.html?${params.toString()}`;
 }
@@ -97,13 +155,26 @@ async function main() {
 
   const opponent = deriveOpponent(teamPick);
 
-  showSammyModal({
+  const modal = showSammyModal({
     body: situationBody(opponent),
     ctaLabel: 'Set Lineup',
     dismissOnCta: false,
     onCta: async () => {
+      // Order matters: init-game first (the heaviest call; without it,
+      // set-lineup has nothing to display). Then advance state. Then fetch
+      // the lineup the engine assigned. Then navigate.
+      const gameId = await initTutorialGame(teamPick, opponent);
+      if (!gameId) {
+        modal.setError && modal.setError('');
+        // Surface a degraded error via the modal body — no setError for
+        // non-input modals, so console + alert is the path.
+        console.error('[tutorial] init-game returned no game_id');
+        window.alert('Could not start the tutorial game. Please refresh and try again.');
+        return;
+      }
       await advanceToSetLineup();
-      gotoSetLineup(teamPick, opponent);
+      const lineup = await fetchUserLineupFromGame(gameId);
+      gotoSetLineup(teamPick, opponent, gameId, lineup);
     },
   });
 }


### PR DESCRIPTION
## Summary
Fixes for all the issues Coach hit on the first staging walkthrough of the FTE v2 tutorial flow. Five logical commits, all tightly scoped.

### Commits

| Commit | Fixes |
|---|---|
| `4fc17a0` | **Fix-1 / Team-select UX** — Sammy intro modal ("Hey Coach! It's your first game!"), strict header "Pick Your Program", subtitle hidden, Select button centered when alone |
| `cd065f7` | **Fix-2 / showSammyModal defensive** — `onCta` now optional (default no-op). The missing intro modal on set-lineup was a silent throw because I'd omitted `onCta`. |
| `6bd6f6c` | **Fix-3/4/7 / Architecture + summary structure** — moves init-game from set-lineup PLAY click → tutorial-situation "Set Lineup" click. Backend `apply_tutorial_initial_state` now assigns `team.lineup` and writes to the correct summary keys. This is the **load-bearing fix** — addresses wrong starters, missing stats, score reset 60→0, AND the SIP→HCO bug (timeout_next_play_type now persists). |
| `19a79f9` | **Fix-5 / Attribute tooltips** — RT in player-name header gets its own data-attr span (was being skipped due to "Player NameRT" concat). FT → "Free Throws" plural. Pos removed (self-descriptive). Applies globally, not tutorial-only. |
| `134ef5d` | **Fix-6 / Skip Defense Matchups popup** — early return when `?mode=tutorial`. |

### What this fixes from your walkthrough

| Issue | Fix |
|---|---|
| Wrong lineup (Hawkins/Gregory/Bonner/Castor/DeGroot) | rank_roster now drives the engine lineup AND set-lineup reads from the same game doc, so you get the position-rating-derived starters (should be Hawkins/Nelson/Gregory/Castor/Bonner if your DB rankings match Coach's expectations) |
| Empty player stats tab | set-lineup line 656 already fetches /api/game/{id} and merges stats — works now that the persisted doc actually has the stat overlays |
| Missing "I've set your lineup" Sammy modal | Now fires; previously broken by the silent throw from missing onCta |
| Tooltip on RT header missing | Wrapped in `<span class="attr-label" data-attr="RT">` |
| FT tooltip said "Free Throw" | Now "Free Throws" |
| Pos tooltip showing | Removed from map |
| Defense Matchups popup in tutorial | Skipped |
| Slow transition set-lineup → court | Mitigated: init-game work moves to situation page CTA; set-lineup loads near-instantly |
| Score reset 60-60 → 0-something | summary["teams"][team_id]["score"] = 60 now persists (was writing to non-existent summary["home_team"]["score"]) |
| HCO first turn instead of SIP | summary["timeout_next_play_type"] = "SIDE_INBOUND" now persists (was writing to non-existent summary["game_state"]["timeout_next_play_type"]) |

### Root cause on the score/SIP bugs

`apply_tutorial_initial_state` ran AFTER `summarize_game_state`. My in-memory mutations to `gm` were correct, but my summary mutations targeted keys (`summary["home_team"]`, `summary["game_state"]`) that don't exist in the canonical summary structure (see [BackEnd/utils/shared.py:1828+](BackEnd/utils/shared.py#L1828)). The correct keys are:
- Top-level scalars: `score`, `clock`, `time_remaining`, `shot_clock_remaining`, `timeout_next_play_type`, `timeout_offense_team_id`, `quarter`
- Nested: `summary["teams"][team_id]["score"]` etc.
- Flat list: `summary["players"]` with `pos` + `stats` per entry

Rewrite addresses this.

### Test plan after merge + Netlify deploy
- [ ] Fresh signup → walks through team-select with new Sammy intro + strict header + centered Select button
- [ ] Tutorial situation page → "Set Lineup" CTA initiates init-game (slight delay), then navigates to set-lineup
- [ ] Set-lineup shows the correct rank_roster starters (e.g. Morristown: Hawkins/Nelson/Gregory/Castor/Bonner)
- [ ] Stats tab populates with Section 5 overlay (e.g. user PG: 9 PTS, 1 REB, 6 AST, 4 FGM/10 FGA)
- [ ] Sammy "I've set your lineup" modal appears
- [ ] Attribute tooltips fire on hover for RT, HT, WT, SC, SH, ID, OD, PS, BH, RB, ST, AG, ND, IQ, FT (says "Free Throws"), NG. Pos shows no tooltip.
- [ ] Click Play → tutorial game boots into Q4, 4:00, 60-60. First turn is **SIP** (Side Inbound Pass).
- [ ] Defense Matchups popup does NOT appear.
- [ ] After playing through, score stays consistent (60-60 + your earned points), time counts down from 4:00.
- [ ] End-game flow reaches post-game modal (the original walkthrough cliffed before this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)