### PR TITLE
FTE v2 follow-up: tutorial lineup propagation + set-lineup guard

### DIFF
--- a/BackEnd/api/api.py
+++ b/BackEnd/api/api.py
@@ -5821,6 +5821,21 @@ try:
         # ✅ REMOVED: Verbose debug log
         
         response_data = {"game_id": game_id}
+        # FTE v2 tutorial: expose the engine-assigned lineup so the situation
+        # page can pass it forward via URL params without a second round-trip
+        # to /api/game (which has a different response schema than expected).
+        if mode == "tutorial":
+            def _lineup_player_ids(team):
+                out = {}
+                for pos, player in (getattr(team, "lineup", None) or {}).items():
+                    pid = getattr(player, "player_id", None) or getattr(player, "_id", None)
+                    if pid is not None:
+                        out[pos] = str(pid)
+                return out
+            response_data["tutorial_lineup"] = {
+                "home": _lineup_player_ids(gm.home_team),
+                "away": _lineup_player_ids(gm.away_team),
+            }
         if profile_summary is not None:
             response_data["profile_summary"] = profile_summary
         total_time = (time.time() - endpoint_start) * 1000

--- a/FrontEnd/static/set-lineup.js
+++ b/FrontEnd/static/set-lineup.js
@@ -585,6 +585,19 @@ async function loadRoster() {
   // ✅ CRITICAL FIX: Don't init if game_id exists in URL (game already exists) or if resuming from timeout
   // This prevents creating a new game when resuming from timeout, which would reset all game state
   const resumeFromTimeout = urlParams.get('resume_from_timeout') === 'true';
+
+  // FTE v2 tutorial: init-game is supposed to run on the tutorial-situation
+  // page (NOT here). If tutorial mode lands on set-lineup without a game_id,
+  // the situation page failed to navigate properly — bounce back so the user
+  // gets a clean retry instead of getting stuck with a half-initialized game
+  // whose game_id never reaches the Play click (race condition we hit on the
+  // second staging walkthrough).
+  if (!gameId && modeParam === 'tutorial' && !resumeFromTimeout) {
+    console.error('[SET-LINEUP][tutorial] No game_id on URL — bouncing to /tutorial-situation.html');
+    window.location.replace('/tutorial-situation.html');
+    return;
+  }
+
   const shouldInitGame = !gameId && homeTeam && awayTeam && !resumeFromTimeout && !initGameInProgress;
   
   if (shouldInitGame) {

--- a/FrontEnd/static/tutorial-situation.js
+++ b/FrontEnd/static/tutorial-situation.js
@@ -60,7 +60,10 @@ async function advanceToSetLineup() {
 }
 
 
-// Returns the initialized game_id, or null on failure.
+// Returns { game_id, home_lineup: { PG, SG, SF, PF, C } } or null on failure.
+// home_lineup is the engine-assigned starting 5 (rank_roster output) which the
+// situation page passes forward as URL params so set-lineup pre-populates with
+// the right players. Backend returns this in the response body when mode=tutorial.
 async function initTutorialGame(userTeam, opponent) {
   try {
     const res = await fetch(API_CONFIG.buildUrl('/api/init-game'), {
@@ -78,38 +81,16 @@ async function initTutorialGame(userTeam, opponent) {
       return null;
     }
     const data = await res.json();
-    return data.game_id || null;
+    if (!data.game_id) return null;
+    const tutorialLineup = (data.tutorial_lineup || {}).home || {};
+    const homeLineup = {};
+    ['PG', 'SG', 'SF', 'PF', 'C'].forEach(pos => {
+      if (tutorialLineup[pos]) homeLineup[pos] = String(tutorialLineup[pos]);
+    });
+    return { game_id: data.game_id, home_lineup: homeLineup };
   } catch (e) {
     console.error('[tutorial] init-game threw:', e);
     return null;
-  }
-}
-
-
-// Returns { PG, SG, SF, PF, C } → player_id strings, or {} on failure.
-async function fetchUserLineupFromGame(gameId) {
-  try {
-    const res = await fetch(API_CONFIG.buildUrl(`/api/game/${gameId}`), {
-      headers: API_CONFIG.getAuthHeaders(),
-    });
-    if (!res.ok) return {};
-    const game = await res.json();
-    const homeTeam = game?.home_team;
-    if (!homeTeam || typeof homeTeam !== 'object') return {};
-    const rawLineup = homeTeam.lineup || {};
-    const out = {};
-    ['PG', 'SG', 'SF', 'PF', 'C'].forEach(pos => {
-      const slot = rawLineup[pos];
-      if (!slot) return;
-      const pid = typeof slot === 'string'
-        ? slot
-        : (slot._id || slot.player_id || slot.playerId);
-      if (pid) out[pos] = String(pid);
-    });
-    return out;
-  } catch (e) {
-    console.warn('[tutorial] could not fetch user lineup:', e);
-    return {};
   }
 }
 
@@ -155,26 +136,23 @@ async function main() {
 
   const opponent = deriveOpponent(teamPick);
 
-  const modal = showSammyModal({
+  showSammyModal({
     body: situationBody(opponent),
     ctaLabel: 'Set Lineup',
     dismissOnCta: false,
     onCta: async () => {
       // Order matters: init-game first (the heaviest call; without it,
-      // set-lineup has nothing to display). Then advance state. Then fetch
-      // the lineup the engine assigned. Then navigate.
-      const gameId = await initTutorialGame(teamPick, opponent);
-      if (!gameId) {
-        modal.setError && modal.setError('');
-        // Surface a degraded error via the modal body — no setError for
-        // non-input modals, so console + alert is the path.
+      // set-lineup has nothing to display). The response includes the
+      // engine-assigned lineup (rank_roster output) so we don't need a
+      // second round-trip. Then advance state. Then navigate.
+      const init = await initTutorialGame(teamPick, opponent);
+      if (!init || !init.game_id) {
         console.error('[tutorial] init-game returned no game_id');
         window.alert('Could not start the tutorial game. Please refresh and try again.');
         return;
       }
       await advanceToSetLineup();
-      const lineup = await fetchUserLineupFromGame(gameId);
-      gotoSetLineup(teamPick, opponent, gameId, lineup);
+      gotoSetLineup(teamPick, opponent, init.game_id, init.home_lineup || {});
     },
   });
 }


### PR DESCRIPTION
## Summary
Targeted fix for the two bugs from your second staging walkthrough.

**Bug 1** (no lineup pre-populated): tutorial-situation.js was reading `game.home_team.lineup` from `/api/game/{id}`, but `summarize_game_state` never writes that key — the canonical structure is `summary["teams"][team_id]` + flat `summary["players"]`. Lineup extraction silently returned `{}` → no URL params → empty slots.

**Bug 2** (`game_id is required for tutorial mode but missing from URL` alert): downstream of Bug 1. With no game_id from situation page navigation, set-lineup's `loadRoster` fallback path created a fresh game and added game_id via `history.replaceState`. If you clicked Play before that completed, `currentGameId` read null → court URL missing game_id → alert.

## Fix shape

| Layer | Change |
|---|---|
| Backend (`api.py` init-game) | Response now includes `tutorial_lineup: { home, away }` when `mode=tutorial`. Sourced directly from `gm.home_team.lineup` and `gm.away_team.lineup` (populated by `apply_tutorial_initial_state`). |
| Frontend (`tutorial-situation.js`) | `initTutorialGame()` reads `home_lineup` from the init-game response directly. The fragile `/api/game/{id}` second fetch is gone. |
| Frontend (`set-lineup.js`) | Defensive guard: if tutorial mode lands here without a game_id, `window.location.replace('/tutorial-situation.html')`. Prevents the loadRoster fallback from creating a second game and racing the Play click. |

## Why this should fix it

- Bug 1 root cause was wrong schema for lineup extraction. Switching to the init-game response (which I control end-to-end) eliminates the schema-guess.
- Bug 2 was a race-condition consequence of Bug 1. With Bug 1 fixed, the loadRoster fallback won't fire. The guard backstops in case something else goes wrong.

## Test plan (third walkthrough)
- [ ] Fresh signup → walk to set-lineup. Slots should show the 5 starters per `rank_roster()` (e.g. Lancaster: whoever ranks highest at PG/SG/SF/PF/C per their position_ratings).
- [ ] Stats tab populated with Section 5 overlay numbers.
- [ ] Sammy intro modal still appears.
- [ ] Click Play → court.html boots into Q4, 4:00, 60-60, SIP first turn.
- [ ] No `game_id required` alert.

If the lineup looks wrong now, that's a position_ratings data issue on those players in the canonical players collection — not a flow bug. Let me know which players come out wrong and we can compare to expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)