### PR TITLE
FTE v2 follow-up 2: tutorial copy + UI polish (stacked on PR 521)

### DIFF
--- a/FrontEnd/static/franchise-select-team.js
+++ b/FrontEnd/static/franchise-select-team.js
@@ -28,6 +28,21 @@ const taglines = {
   'South Lancaster': 'Us vs The World'
 };
 
+// Mascots (collective noun) for the username-modal copy interpolation —
+// "you're now coaching the {mascot}". Authoritative on teams collection
+// (team_doc.mascot) but hardcoded here to avoid a round-trip on a single
+// modal render. Keep in sync if any team mascot ever changes.
+const mascots = {
+  'Bentley-Truman': 'Knights',
+  'Lancaster': 'Johnnies',
+  'Four Corners': 'Harvest',
+  'Ocean City': 'Admirals',
+  'Morristown': 'Pirates',
+  'Little York': 'Minute Men',
+  'Xavien': 'Elm Trees',
+  'South Lancaster': 'Bulldogs'
+};
+
 const teamContainer = document.getElementById("team-container");
 const errorHost = document.getElementById("team-select-error");
 const loadingOverlay = document.getElementById("team-select-loading");
@@ -133,8 +148,11 @@ async function selectTutorialTeam(team) {
     return;
   }
 
-  // Step 2: open the username modal with team-aware copy.
-  const prompt = `You're now coaching the ${team}. What's your name, Coach?`;
+  // Step 2: open the username modal with team-aware copy. Use the mascot
+  // (collective noun) so the sentence reads naturally — "the Johnnies",
+  // "the Pirates" — instead of grammatically broken "the Lancaster".
+  const mascot = mascots[team] || team;
+  const prompt = `You're now coaching the ${mascot}. What's your name, Coach?`;
   const { openUsernameModal } = await import('/js/shared/usernameModal.js');
   openUsernameModal({
     prompt,
@@ -195,22 +213,17 @@ document.addEventListener("DOMContentLoaded", function () {
   } catch (e) {}
 
   if (TUTORIAL_MODE) {
-    // Tutorial flow: no back link, strict header, no subtitle. The greeting
-    // lives in the Sammy intro modal that fires below.
+    // Tutorial flow: strict header + a single supporting subhead. No intro
+    // modal (Coach feedback: don't block team selection with a modal).
     if (backLink) backLink.style.display = 'none';
     const title = document.getElementById('page-title');
     const subtitle = document.getElementById('page-subtitle');
     if (title) title.textContent = 'Pick Your Program';
-    if (subtitle) subtitle.style.display = 'none';
-
-    // One-shot Sammy intro modal — Coach feedback from staging walkthrough.
-    import('/js/shared/sammyModal.js').then(({ showSammyModal }) => {
-      showSammyModal({
-        body: "Hey Coach! It's your first game! Choose your squad you want to lead onto the court.",
-        ctaLabel: "Let's go",
-        onCta: () => {},
-      });
-    }).catch((e) => console.warn('[tutorial] could not load sammyModal:', e));
+    // Existing #page-subtitle styling (Inter 15px, 66% white) already reads
+    // as supporting text. No extra class needed.
+    if (subtitle) {
+      subtitle.textContent = "Your first game starts now. (Don't sweat it too much — you can pick your franchise team after.)";
+    }
   } else if (backLink) {
     backLink.addEventListener("click", function (event) {
       event.preventDefault();

--- a/FrontEnd/static/js/shared/authBarInit.js
+++ b/FrontEnd/static/js/shared/authBarInit.js
@@ -44,9 +44,18 @@
 
   function shouldShowAuthBar() {
     var path = window.location.pathname || '';
-    return !PAGES_WITHOUT_AUTH_BAR.some(function (p) {
-      return path.indexOf(p) !== -1;
-    });
+    if (PAGES_WITHOUT_AUTH_BAR.some(function (p) { return path.indexOf(p) !== -1; })) {
+      return false;
+    }
+    // FTE v2: any page loaded with ?mode=tutorial is part of the immersive
+    // onboarding funnel — suppress the auth bar across the whole flow
+    // (team-select most notably; situation + set-lineup are already in
+    // PAGES_WITHOUT_AUTH_BAR above).
+    try {
+      var urlMode = new URLSearchParams(window.location.search).get('mode');
+      if (urlMode === 'tutorial') return false;
+    } catch (_) {}
+    return true;
   }
 
   function ensureAuthBarStyles() {

--- a/FrontEnd/static/set-lineup.css
+++ b/FrontEnd/static/set-lineup.css
@@ -209,6 +209,53 @@ body.set-lineup-page .resource-page-container.fcc-brand-page-shell.set-lineup-sh
   background: rgba(13, 16, 24, 0.97);
 }
 
+/* FTE v2 tutorial: compact mid-game state header above the roster section.
+   Shows Q · Clock and Team Score — Team Score in two stacked rows. */
+.tutorial-lineup-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 10px 14px 12px;
+  margin: 0 0 12px;
+  background: rgba(8, 11, 22, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  color: #ffffff;
+  font-family: 'Bebas Neue', sans-serif;
+  letter-spacing: 0.05em;
+}
+.tutorial-lineup-header[hidden] { display: none; }
+.tutorial-lineup-header-quarter {
+  font-size: 22px;
+  color: #34EC27;
+  line-height: 1;
+}
+.tutorial-lineup-header-sep {
+  margin: 0 6px;
+  color: rgba(255, 255, 255, 0.45);
+}
+.tutorial-lineup-header-score {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  font-size: 18px;
+  font-family: 'Inter', sans-serif;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: rgba(255, 255, 255, 0.92);
+}
+.tutorial-lineup-header-score-value {
+  font-family: 'Bebas Neue', sans-serif;
+  font-size: 28px;
+  line-height: 1;
+  color: #ffffff;
+}
+.tutorial-lineup-header-score-sep {
+  color: rgba(255, 255, 255, 0.55);
+  font-family: 'Inter', sans-serif;
+}
+
 .lineup-roster-section {
   flex: 1 1 auto;
   display: flex;

--- a/FrontEnd/static/set-lineup.html
+++ b/FrontEnd/static/set-lineup.html
@@ -54,6 +54,23 @@
 
     <div class="lineup-main">
       <div class="lineup-left-panel">
+        <!-- FTE v2 tutorial: compact mid-game state header above the roster
+             section. Hidden in non-tutorial modes; populated by setHeader()
+             from the game doc when mode=tutorial. -->
+        <section id="tutorial-lineup-header" class="tutorial-lineup-header" hidden>
+          <div class="tutorial-lineup-header-quarter">
+            <span id="tutorial-lineup-header-quarter-label">Q4</span>
+            <span class="tutorial-lineup-header-sep">·</span>
+            <span id="tutorial-lineup-header-clock">4:00</span>
+          </div>
+          <div class="tutorial-lineup-header-score">
+            <span id="tutorial-lineup-header-home-team">Home</span>
+            <span class="tutorial-lineup-header-score-value" id="tutorial-lineup-header-home-score">60</span>
+            <span class="tutorial-lineup-header-score-sep">—</span>
+            <span class="tutorial-lineup-header-score-value" id="tutorial-lineup-header-away-score">60</span>
+            <span id="tutorial-lineup-header-away-team">Away</span>
+          </div>
+        </section>
         <section class="lineup-roster-section">
           <div class="lineup-roster-header-row">
             <div class="lineup-roster-label">Roster — click or drag to assign</div>

--- a/FrontEnd/static/set-lineup.js
+++ b/FrontEnd/static/set-lineup.js
@@ -1747,6 +1747,32 @@ async function setHeader() {
   if (playBtn) {
     playBtn.textContent = isPregame ? 'Play Game' : 'Return to Game';
   }
+
+  // FTE v2 tutorial: populate the compact left-panel header above the roster
+  // section with mid-game state from the loaded game doc (Q4 4:00 60-60 per
+  // apply_tutorial_initial_state). Hidden in non-tutorial modes.
+  const tutHeader = document.getElementById('tutorial-lineup-header');
+  if (tutHeader) {
+    if (modeParam === 'tutorial' && gameData) {
+      const docQuarter = parseInt(gameData.quarter, 10) || currentQuarter;
+      const docClock = gameData.clock || formattedClock;
+      const tutQuarterEl = document.getElementById('tutorial-lineup-header-quarter-label');
+      const tutClockEl = document.getElementById('tutorial-lineup-header-clock');
+      const tutHomeTeamEl = document.getElementById('tutorial-lineup-header-home-team');
+      const tutAwayTeamEl = document.getElementById('tutorial-lineup-header-away-team');
+      const tutHomeScoreEl = document.getElementById('tutorial-lineup-header-home-score');
+      const tutAwayScoreEl = document.getElementById('tutorial-lineup-header-away-score');
+      if (tutQuarterEl) tutQuarterEl.textContent = `Q${docQuarter}`;
+      if (tutClockEl) tutClockEl.textContent = docClock;
+      if (tutHomeTeamEl) tutHomeTeamEl.textContent = displayUserTeamName;
+      if (tutAwayTeamEl) tutAwayTeamEl.textContent = displayOpponentTeamName;
+      if (tutHomeScoreEl) tutHomeScoreEl.textContent = String(userTeamScore);
+      if (tutAwayScoreEl) tutAwayScoreEl.textContent = String(opponentTeamScore);
+      tutHeader.hidden = false;
+    } else {
+      tutHeader.hidden = true;
+    }
+  }
 }
 
 function restoreLineupFromUrl() {
@@ -2020,7 +2046,7 @@ async function init() {
   if (modeParam === 'tutorial') {
     import('/js/shared/sammyModal.js').then(({ showSammyModal }) => {
       showSammyModal({
-        body: "I've set your lineup, feel free to make any changes as you see fit.",
+        body: "I've set your lineup — tweak it if you like, and hover any attribute to see what it means.",
         ctaLabel: 'Got it',
       });
     }).catch((e) => console.warn('[tutorial] could not load sammyModal:', e));

--- a/FrontEnd/static/tutorial-situation.js
+++ b/FrontEnd/static/tutorial-situation.js
@@ -25,9 +25,8 @@ function deriveOpponent(userTeam) {
 
 
 function situationBody(opponent) {
-  // Copy locked by Coach in PR 2c spec discussion.
-  return `Ok Coach, let's play ball. You're playing ${opponent}, ` +
-         `and the score is tied 60-60 with 4 minutes remaining. Let's win this!`;
+  // Copy locked by Coach. En-dash (–) between scores, not a hyphen.
+  return `${opponent}. Tied 60–60. 4 minutes left in the 4th. Win it, Coach.`;
 }
 
 


### PR DESCRIPTION
## Summary
Seven copy/UI fixes from your second staging review. **Stacked on PR 521** (which fixes the lineup-propagation bug) — merging both lands the full set.

| # | Fix |
|---|---|
| 1 | Removed the "Hey Coach!" intro modal on team-select. Land directly on team picker, no modal blocking. |
| 2 | Added tutorial subhead under "PICK YOUR PROGRAM": *"Your first game starts now. (Don't sweat it too much — you can pick your franchise team after.)"* — gated on `?mode=tutorial`, non-tutorial visitors unchanged. |
| 3 | Username modal interpolates the **mascot** (collective noun): *"You're now coaching the Johnnies. What's your name, Coach?"* — 8-team mapping hardcoded (Knights / Johnnies / Harvest / Admirals / Pirates / Minute Men / Elm Trees / Bulldogs). |
| 4 | Situation card copy locked: *"Xavien. Tied 60–60. 4 minutes left in the 4th. Win it, Coach."* (en-dash) |
| 5 | Set-lineup Sammy copy: *"I've set your lineup — tweak it if you like, and hover any attribute to see what it means."* (em-dash). Tooltips already wired in PR 520. |
| 6 | Auth bar hidden across the whole tutorial funnel. `shouldShowAuthBar()` returns false when `?mode=tutorial` on URL. |
| 7 | New compact mid-game state header in `lineup-left-panel`, above the roster: `Q4 · 4:00` and `LANCASTER 60 — 60 XAVIEN`. Reads from the game doc (`gameData.quarter` + `gameData.clock`) so it shows the engine's actual state. Hidden in non-tutorial modes. |

## PR stacking note
- **Base:** `fte-v2-followup-fixes-1` (PR 521)
- **Head:** `fte-v2-followup-fixes-2`

If you merge PR 521 first, GitHub will auto-rebase this PR onto `develop`. Alternatively, you can merge this PR's commit (`a070d86`) into PR 521's branch and merge both as one.

## Test plan (third walkthrough)
- [ ] Team-select: no intro modal. Header reads "PICK YOUR PROGRAM" with subhead below. Auth bar gone.
- [ ] Pick Lancaster → username modal: *"You're now coaching the Johnnies. What's your name, Coach?"*
- [ ] Pick Bentley-Truman → *"the Knights"*. Morristown → *"the Pirates"*. Etc.
- [ ] Situation card shows updated copy with en-dash. No auth bar.
- [ ] Set-lineup: shows the tutorial header at top-left (Q4 · 4:00 / LANCASTER 60 — 60 XAVIEN). Sammy modal copy updated.
- [ ] Hover over RT, HT, WT, SC, SH, ID, OD, PS, BH, RB, ST, AG, ND, IQ, FT (says "Free Throws"), NG → tooltips show. Pos shows no tooltip.
- [ ] Auth bar hidden throughout the funnel.
- [ ] Returning user starts a new franchise (no `?mode=tutorial`): auth bar present, original subtitle "You're building this program from the ground up. Choose wisely.", Scout button shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)