### PR TITLE
FTE v2 follow-up 3: quarter=4 propagation + copy + tooltip fix

### DIFF
--- a/FrontEnd/static/franchise-select-team.js
+++ b/FrontEnd/static/franchise-select-team.js
@@ -222,7 +222,7 @@ document.addEventListener("DOMContentLoaded", function () {
     // Existing #page-subtitle styling (Inter 15px, 66% white) already reads
     // as supporting text. No extra class needed.
     if (subtitle) {
-      subtitle.textContent = "Your first game starts now. (Don't sweat it too much — you can pick your franchise team after.)";
+      subtitle.textContent = "Your first game starts now. (Don't sweat it too much, this is your 'lean the ropes' game — you pick your franchise team after.)";
     }
   } else if (backLink) {
     backLink.addEventListener("click", function (event) {

--- a/FrontEnd/static/js/shared/attributeTooltips.js
+++ b/FrontEnd/static/js/shared/attributeTooltips.js
@@ -37,8 +37,11 @@ function createTooltipElement() {
   if (!tooltipElement) {
     tooltipElement = document.createElement('div');
     tooltipElement.id = 'attribute-tooltip-bubble';
+    // position: fixed — the positioning math below uses window.innerHeight -
+    // rect.top, which is viewport-relative. Absolute positioning was unreliable
+    // when the page was scrolled.
     tooltipElement.style.cssText = `
-      position: absolute;
+      position: fixed;
       padding: 6px 10px;
       background: rgba(0, 0, 0, 0.95);
       color: #fff;

--- a/FrontEnd/static/set-lineup.css
+++ b/FrontEnd/static/set-lineup.css
@@ -209,53 +209,6 @@ body.set-lineup-page .resource-page-container.fcc-brand-page-shell.set-lineup-sh
   background: rgba(13, 16, 24, 0.97);
 }
 
-/* FTE v2 tutorial: compact mid-game state header above the roster section.
-   Shows Q · Clock and Team Score — Team Score in two stacked rows. */
-.tutorial-lineup-header {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 4px;
-  padding: 10px 14px 12px;
-  margin: 0 0 12px;
-  background: rgba(8, 11, 22, 0.85);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 10px;
-  color: #ffffff;
-  font-family: 'Bebas Neue', sans-serif;
-  letter-spacing: 0.05em;
-}
-.tutorial-lineup-header[hidden] { display: none; }
-.tutorial-lineup-header-quarter {
-  font-size: 22px;
-  color: #34EC27;
-  line-height: 1;
-}
-.tutorial-lineup-header-sep {
-  margin: 0 6px;
-  color: rgba(255, 255, 255, 0.45);
-}
-.tutorial-lineup-header-score {
-  display: flex;
-  align-items: baseline;
-  gap: 10px;
-  font-size: 18px;
-  font-family: 'Inter', sans-serif;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  color: rgba(255, 255, 255, 0.92);
-}
-.tutorial-lineup-header-score-value {
-  font-family: 'Bebas Neue', sans-serif;
-  font-size: 28px;
-  line-height: 1;
-  color: #ffffff;
-}
-.tutorial-lineup-header-score-sep {
-  color: rgba(255, 255, 255, 0.55);
-  font-family: 'Inter', sans-serif;
-}
-
 .lineup-roster-section {
   flex: 1 1 auto;
   display: flex;

--- a/FrontEnd/static/set-lineup.html
+++ b/FrontEnd/static/set-lineup.html
@@ -54,23 +54,6 @@
 
     <div class="lineup-main">
       <div class="lineup-left-panel">
-        <!-- FTE v2 tutorial: compact mid-game state header above the roster
-             section. Hidden in non-tutorial modes; populated by setHeader()
-             from the game doc when mode=tutorial. -->
-        <section id="tutorial-lineup-header" class="tutorial-lineup-header" hidden>
-          <div class="tutorial-lineup-header-quarter">
-            <span id="tutorial-lineup-header-quarter-label">Q4</span>
-            <span class="tutorial-lineup-header-sep">·</span>
-            <span id="tutorial-lineup-header-clock">4:00</span>
-          </div>
-          <div class="tutorial-lineup-header-score">
-            <span id="tutorial-lineup-header-home-team">Home</span>
-            <span class="tutorial-lineup-header-score-value" id="tutorial-lineup-header-home-score">60</span>
-            <span class="tutorial-lineup-header-score-sep">—</span>
-            <span class="tutorial-lineup-header-score-value" id="tutorial-lineup-header-away-score">60</span>
-            <span id="tutorial-lineup-header-away-team">Away</span>
-          </div>
-        </section>
         <section class="lineup-roster-section">
           <div class="lineup-roster-header-row">
             <div class="lineup-roster-label">Roster — click or drag to assign</div>

--- a/FrontEnd/static/set-lineup.js
+++ b/FrontEnd/static/set-lineup.js
@@ -1704,6 +1704,11 @@ async function setHeader() {
       clockTime = gameData.clock;
     }
   }
+  // FTE v2 tutorial: prefer the game doc's clock (4:00 set by
+  // apply_tutorial_initial_state) over the quarter-break default ('8:00').
+  if (modeParam === 'tutorial' && gameData && gameData.clock) {
+    clockTime = gameData.clock;
+  }
  
   let formattedClock = '--:--';
   if (clockTime) {
@@ -1746,32 +1751,6 @@ async function setHeader() {
 
   if (playBtn) {
     playBtn.textContent = isPregame ? 'Play Game' : 'Return to Game';
-  }
-
-  // FTE v2 tutorial: populate the compact left-panel header above the roster
-  // section with mid-game state from the loaded game doc (Q4 4:00 60-60 per
-  // apply_tutorial_initial_state). Hidden in non-tutorial modes.
-  const tutHeader = document.getElementById('tutorial-lineup-header');
-  if (tutHeader) {
-    if (modeParam === 'tutorial' && gameData) {
-      const docQuarter = parseInt(gameData.quarter, 10) || currentQuarter;
-      const docClock = gameData.clock || formattedClock;
-      const tutQuarterEl = document.getElementById('tutorial-lineup-header-quarter-label');
-      const tutClockEl = document.getElementById('tutorial-lineup-header-clock');
-      const tutHomeTeamEl = document.getElementById('tutorial-lineup-header-home-team');
-      const tutAwayTeamEl = document.getElementById('tutorial-lineup-header-away-team');
-      const tutHomeScoreEl = document.getElementById('tutorial-lineup-header-home-score');
-      const tutAwayScoreEl = document.getElementById('tutorial-lineup-header-away-score');
-      if (tutQuarterEl) tutQuarterEl.textContent = `Q${docQuarter}`;
-      if (tutClockEl) tutClockEl.textContent = docClock;
-      if (tutHomeTeamEl) tutHomeTeamEl.textContent = displayUserTeamName;
-      if (tutAwayTeamEl) tutAwayTeamEl.textContent = displayOpponentTeamName;
-      if (tutHomeScoreEl) tutHomeScoreEl.textContent = String(userTeamScore);
-      if (tutAwayScoreEl) tutAwayScoreEl.textContent = String(opponentTeamScore);
-      tutHeader.hidden = false;
-    } else {
-      tutHeader.hidden = true;
-    }
   }
 }
 

--- a/FrontEnd/static/tutorial-situation.js
+++ b/FrontEnd/static/tutorial-situation.js
@@ -26,7 +26,7 @@ function deriveOpponent(userTeam) {
 
 function situationBody(opponent) {
   // Copy locked by Coach. En-dash (–) between scores, not a hyphen.
-  return `${opponent}. Tied 60–60. 4 minutes left in the 4th. Win it, Coach.`;
+  return `You're playing against ${opponent}. Tied 60–60. 4 minutes left in the 4th. Go win it, Coach.`;
 }
 
 
@@ -95,11 +95,17 @@ async function initTutorialGame(userTeam, opponent) {
 
 
 function gotoSetLineup(userTeam, opponent, gameId, lineup) {
+  // quarter=4 is critical: without it, set-lineup's module-level `quarter`
+  // defaults to 1, and the /api/game fetch passes ?quarter=1 — which the
+  // backend treats as a "new game scenario" (request Q1 + saved Q4) and
+  // returns empty stats. With quarter=4 in the URL, the fetch returns the
+  // real Q4 60-60 state populated by apply_tutorial_initial_state.
   const params = new URLSearchParams({
     mode: 'tutorial',
     home: userTeam,
     away: opponent,
     my_team: 'home',
+    quarter: '4',
   });
   if (gameId) params.set('game_id', gameId);
   ['PG', 'SG', 'SF', 'PF', 'C'].forEach(pos => {


### PR DESCRIPTION
## Summary
Third round of fixes from your staging walkthrough. The big one is the **quarter=4 propagation** — root cause of both the wrong scores/Pre-Game display AND the court "game_id missing" error.

## Root cause (the load-bearing fix)

Tutorial URL going to set-lineup had no `quarter` param. Set-lineup's module-level `quarter` defaulted to 1. `setHeader` then fetched `/api/game?quarter=1`. The backend has [logic](BackEnd/api/api.py#L1709-L1712) that treats "request Q1 + saved Q4" as a **"new game scenario"** and returns empty stats/scores. So the display showed 0-0 / PRE-GAME / 12:00 even though `apply_tutorial_initial_state` correctly persisted Q4/60-60/4:00 to the doc. The court URL also inherited the wrong quarter and lost the game_id propagation chain.

**Fix:** Put `quarter=4` in the URL from tutorial-situation onward. Everything downstream flows correctly.

## Changes

| # | Fix |
|---|---|
| 1 | `tutorial-situation.js`: gotoSetLineup adds `quarter=4` to URL. |
| 2 | `set-lineup.js`: clock falls back to `gameData.clock` (4:00) for tutorial mode instead of the standard 8:00 default. |
| 3 | Removed my redundant `tutorial-lineup-header` section in left-panel (HTML/CSS/JS). The existing top scoreboard surfaces score/quarter/clock — once data is correct (after fix #1), it displays right. **Net -76 lines.** |
| 4 | Subhead copy update: *"Your first game starts now. (Don't sweat it too much, this is your 'lean the ropes' game — you pick your franchise team after.)"* |
| 5 | Situation modal copy: *"You're playing against Xavien. Tied 60–60. 4 minutes left in the 4th. Go win it, Coach."* |
| 6 | `attributeTooltips.js`: position changed from `absolute` → `fixed`. The positioning math (`window.innerHeight - rect.top`) is viewport-relative — absolute was unreliable when the page was scrolled. Likely why your hover wasn't surfacing tooltips. |

## Test plan (fourth walkthrough)
- [ ] Set-lineup top scoreboard shows: `LANCASTER 60 — 60 XAVIEN  Q4  4:00` (not 0-0 / PRE-GAME / ---)
- [ ] No extra header in left panel (removed)
- [ ] Hover RT/HT/WT/SC/SH/etc. on column headers → tooltip bubble appears above the header
- [ ] Click Play → court boots with game_id in URL, no error alert
- [ ] Court Q4 4:00 60-60 SIP first turn (same as before — should still work)
- [ ] Subhead reads with the new copy on team-select
- [ ] Situation card reads with the new copy

If tooltips still don't appear after the position:fixed change, that points to a different issue (perhaps timing of init or stylesheet load). Let me know what console shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)