### PR TITLE
FTE v2 follow-up 4: tooltip wipe + mode propagation + copy

### DIFF
--- a/FrontEnd/static/franchise-select-team.js
+++ b/FrontEnd/static/franchise-select-team.js
@@ -222,7 +222,7 @@ document.addEventListener("DOMContentLoaded", function () {
     // Existing #page-subtitle styling (Inter 15px, 66% white) already reads
     // as supporting text. No extra class needed.
     if (subtitle) {
-      subtitle.textContent = "Your first game starts now. (Don't sweat it too much, this is your 'lean the ropes' game — you pick your franchise team after.)";
+      subtitle.textContent = "Don't sweat it too much. This is your 'learn the ropes' game — you pick your franchise team after.";
     }
   } else if (backLink) {
     backLink.addEventListener("click", function (event) {

--- a/FrontEnd/static/js/phaser/gameScene.js
+++ b/FrontEnd/static/js/phaser/gameScene.js
@@ -2606,7 +2606,10 @@ export function createGameScene(Phaser) {
         // Show game completion popup (absolute path for Netlify/module resolution)
         const base = (typeof window !== 'undefined' && window.API_CONFIG) ? window.API_CONFIG.getStaticPath() : '';
         const { showGameCompletionPopup } = await import(`${base}/js/phaser/utils/gameCompletionPopup.js`);
-        const mode = this.tournamentId ? 'tournament' : (this.franchiseId ? 'franchise' : 'single');
+        // Prefer this.mode (set from game data at scene init) so 'tutorial'
+        // mode propagates correctly. Fall back to the tournament/franchise/
+        // single derivation for older scenes that don't set this.mode.
+        const mode = this.mode || (this.tournamentId ? 'tournament' : (this.franchiseId ? 'franchise' : 'single'));
         showGameCompletionPopup({
           gameId: this.gameId || simData.game_id,
           mode: mode,

--- a/FrontEnd/static/set-lineup.js
+++ b/FrontEnd/static/set-lineup.js
@@ -1080,6 +1080,18 @@ function renderRosterAttributes() {
       sortRoster(columnNames[index]);
     });
   });
+
+  // Re-attach attribute tooltips after the sort-handler clone loop above.
+  // cloneNode(true) does NOT copy event listeners, so any mouseenter/mouseleave
+  // handlers attached by initAttributeTooltips on the original th elements get
+  // wiped when the headers are replaced. We re-attach here so the tooltips
+  // survive every re-render (initial paint, sort clicks, autoset, etc.).
+  if (typeof initAttributeTooltips !== 'undefined') {
+    const thead = document.querySelector('#roster-attributes-pane .roster-table thead');
+    if (thead) {
+      initAttributeTooltips(thead, ['th', '[data-attr]']);
+    }
+  }
 }
 
 function renderRosterStats() {

--- a/FrontEnd/static/tutorial-situation.js
+++ b/FrontEnd/static/tutorial-situation.js
@@ -26,7 +26,7 @@ function deriveOpponent(userTeam) {
 
 function situationBody(opponent) {
   // Copy locked by Coach. En-dash (–) between scores, not a hyphen.
-  return `You're playing against ${opponent}. Tied 60–60. 4 minutes left in the 4th. Go win it, Coach.`;
+  return `You're playing against ${opponent}. Tied 60–60. 4 minutes left in the 4th. Go win it, Coach!`;
 }
 
 


### PR DESCRIPTION
## Summary
Four fixes. The first two are real bug-finds (tooltips were getting wiped by a cloneNode pattern; tutorial mode was being downgraded to 'single' before the post-game popup ran). The last two are copy nits.

| # | Fix |
|---|---|
| 1 | **Tooltips on set-lineup column headers — actually fixed.** `renderRosterAttributes` at [set-lineup.js:1071](FrontEnd/static/set-lineup.js#L1071) clones each `<th>` to attach sort handlers. `cloneNode(true)` doesn't copy event listeners, so the mouseenter/mouseleave attached by `initAttributeTooltips` get wiped. Re-attach at the end of `renderRosterAttributes` so tooltips survive every re-render. **This was a pre-existing bug** — likely why they never worked reliably. |
| 2 | **gameScene mode propagation** — line 2609 hardcoded mode to `single` if not franchise/tournament, so tutorial games hit the post-game popup with mode='single'. Caused: (a) Box Score button still visible, (b) tutorial-complete + debut publish never fired, (c) routeToTutorial bounced the user back to /tutorial-situation on the next mode-select load (which is the bug you saw from the box-score back button). Now reads from `this.mode` first. |
| 3 | Subhead copy: *"Don't sweat it too much. This is your 'learn the ropes' game — you pick your franchise team after."* |
| 4 | Situation modal end: period → exclamation. |

## Test plan
- [ ] Hover any column header on set-lineup (RT, HT, WT, SC, SH, ID, OD, PS, BH, RB, ST, AG, ND, IQ, FT, NG) → tooltip appears with the full attribute name
- [ ] Click a column header to sort, hover again → tooltip still appears (regression test for the cloneNode wipe)
- [ ] Walk tutorial to end. Post-game popup shows **no Box Score button** (only "Go To Locker Room")
- [ ] Click Go To Locker Room → lands on mode-select WITH the gold-border debut row in the Live Feed
- [ ] Reload mode-select → no routing back to tutorial (fte_v2_complete=true now persists)

## Still pending (need Coach input)
- **Playcall center "standard preloads"** — see message after this PR for what I need to know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)