### PR TITLE
FTE v2: tutorial playcall preloads (8 default offensive plays)

### DIFF
--- a/BackEnd/api/gameplan_routes.py
+++ b/BackEnd/api/gameplan_routes.py
@@ -397,9 +397,14 @@ def get_collection_and_doc_id(mode: str, franchise_id: str = None, tournament_id
         if not tournament_id:
             raise HTTPException(status_code=400, detail="tournament_id required for tournament mode")
         return db.tournaments, tournament_id
-    elif mode == "single":
+    elif mode in ("single", "tutorial"):
+        # FTE v2 tutorial games are stored in the games collection like single
+        # mode (throwaway, deleted on completion). They use the same lookup
+        # by game_id. apply_tutorial_initial_state writes playbook_settings
+        # to the game doc so this endpoint returns the Coach-specified
+        # 8-playcall preloads.
         if not game_id:
-            raise HTTPException(status_code=400, detail="game_id required for single game mode")
+            raise HTTPException(status_code=400, detail=f"game_id required for {mode} mode")
         from BackEnd.utils.game_id_utils import normalize_game_id
         normalized_game_id = normalize_game_id(game_id)
         return db.games, normalized_game_id
@@ -1682,19 +1687,19 @@ def get_gameplan(mode: str, team_id: str, franchise_id: str = None, tournament_i
         # Get settings or return defaults
         # ✅ SS&S: Use GameManager settings if available (single source of truth during gameplay)
         defaults = get_default_settings()
-        if mode == "single" and use_gamemanager_settings and gm:
+        if mode in ("single", "tutorial") and use_gamemanager_settings and gm:
             # Use GameManager settings (already verified above)
             target_team = None
             if gm.home_team.team_id == team_id or gm.home_team.name == team_id:
                 target_team = gm.home_team
             elif gm.away_team.team_id == team_id or gm.away_team.name == team_id:
                 target_team = gm.away_team
-            
+
             if target_team and hasattr(target_team, 'strategy_settings') and target_team.strategy_settings:
                 strategy_settings = target_team.strategy_settings
             else:
                 strategy_settings = team_obj.get("strategy_settings", defaults["strategy_settings"])
-        elif mode == "single" and not use_gamemanager_settings:
+        elif mode in ("single", "tutorial") and not use_gamemanager_settings:
             # ✅ SS&S: GameManager not available - use load_team_settings_from_doc() (same as simulate_quarter_endpoint)
             from BackEnd.api.api import load_team_settings_from_doc
             settings = load_team_settings_from_doc(mode, doc_id, team_id, team_id)
@@ -1826,6 +1831,14 @@ def get_playbooks(
         result["profile_summary"] = profile_summary
         return result
     endpoint_start = time.time()
+    # FTE v2 tutorial games are structurally identical to single-mode games
+    # (same games_collection doc, same ongoing_games cache, same game_id
+    # format). Normalize to "single" so we don't have to extend every
+    # `mode == "single"` branch in this 1000-line function. The cleanups
+    # specific to tutorial (game doc deletion, tutorial-complete, debut
+    # publish) happen in other endpoints, not here.
+    if mode == "tutorial":
+        mode = "single"
     try:
         use_gamemanager_settings = False  # set True in single-mode cache branch; franchise/tournament stay False here
         _dpc_log = debug_pc if isinstance(debug_pc, str) else None
@@ -1851,8 +1864,10 @@ def get_playbooks(
         if mode == "single" and game_id and game_id != doc_id:
             logger.warning(f"🔍 [NORMALIZE] GET /api/playbooks - Normalized game_id from '{game_id}' to '{doc_id}'")
         
-        # ✅ PHASE 5.5: Use normalized doc_id for single mode cache lookup
-        if mode == "single":
+        # ✅ PHASE 5.5: Use normalized doc_id for single/tutorial mode cache lookup
+        # (tutorial games are stored in games_collection like single mode and
+        # the ongoing_games cache holds the same gm reference.)
+        if mode in ("single", "tutorial"):
             game_id = doc_id  # Use normalized game_id for cache lookup
             
             # ✅ PHASE 3.2: Cache is performance mirror, DB is always available as fallback
@@ -1997,8 +2012,10 @@ def get_playbooks(
         # If not loading from game doc, load from master doc (existing logic)
         if not load_from_game_doc:
             # ✅ PERFORMANCE: Load document with projection (only needed fields) to reduce data transfer
-            # For single game mode, try both UUID string and ObjectId formats
-            if mode == "single":
+            # For single game / tutorial mode, try both UUID string and ObjectId formats
+            # (tutorial docs are structured like single — playbook_settings on
+            # summary["teams"][team_id] populated by apply_tutorial_initial_state)
+            if mode in ("single", "tutorial"):
                 # ✅ PERFORMANCE: Add projection for Single Game mode - only fetch teams, home_team_id, away_team_id
                 # This reduces data transfer by 70-90% for game documents (especially after Q1+)
                 doc = collection.find_one(

--- a/BackEnd/utils/tutorial_game.py
+++ b/BackEnd/utils/tutorial_game.py
@@ -81,6 +81,104 @@ TUTORIAL_POINTS_BY_QUARTER_OPPONENT = [18, 15, 27, 0]
 TUTORIAL_NG_AT_BOOT = 0.95
 
 
+# Coach-specified default offensive playcall order for the user team's
+# in-game playcall center. Slot 1 → 8 from top of list. shooter_target on
+# each play is left at the DB default (we don't override).
+TUTORIAL_USER_OFFENSE_PLAYCALLS = [
+    "3-2 Motion",
+    "4-1 Motion",
+    "5-0 Motion",
+    "PF Post Motion",
+    "Base Post Play",
+    "Pick & Roll - Entry Pass",
+    "Iso",
+    "Double Screen Three - Wing",
+]
+
+
+def build_tutorial_pc_order_offense() -> list[str]:
+    """Look up the Coach-specified default playcalls in the plays collection
+    and return them as a list of play_id strings in slot order.
+
+    Returns at most len(TUTORIAL_USER_OFFENSE_PLAYCALLS) ids. Any play whose
+    name doesn't resolve in the DB is skipped with a warning so the rest of
+    the slots still populate.
+    """
+    from BackEnd.db import plays_collection
+
+    docs = list(plays_collection.find(
+        {"name": {"$in": TUTORIAL_USER_OFFENSE_PLAYCALLS}},
+        {"_id": 1, "name": 1, "play_id": 1},
+    ))
+    # Build name -> id map. Prefer the canonical play_id field when present,
+    # falling back to _id (matches the lookup pattern used by
+    # normalize_pc_order in playbook_settings_utils).
+    by_name: dict = {}
+    for doc in docs:
+        name = doc.get("name")
+        if not name:
+            continue
+        pid = doc.get("play_id") or doc.get("_id")
+        if pid is None:
+            continue
+        by_name[name] = str(pid)
+
+    ordered: list = []
+    for name in TUTORIAL_USER_OFFENSE_PLAYCALLS:
+        pid = by_name.get(name)
+        if pid is None:
+            logger.warning(
+                "[TUTORIAL] play name not found in plays collection — skipping: %r",
+                name,
+            )
+            continue
+        ordered.append(pid)
+    return ordered
+
+
+def _apply_tutorial_playbook_to_user_team(
+    summary: dict, user_team_id, gm
+) -> None:
+    """Set the user team's playbook_settings.pc_order.offense in BOTH the
+    summary (persisted to mongo) and the in-memory GameManager so the
+    in-game playcall center boots with Coach's 8 default playcalls.
+
+    Defense pc_order, motion/set_plays/fast_breaks percentages, and the
+    computer team's playbook are left at engine defaults (per Coach scope).
+    """
+    ordered_ids = build_tutorial_pc_order_offense()
+    if not ordered_ids:
+        logger.warning("[TUTORIAL] no playbook play_ids resolved — playcall center will be empty")
+        return
+
+    teams_obj = summary.get("teams")
+    if not isinstance(teams_obj, dict) or user_team_id is None:
+        logger.warning("[TUTORIAL] summary.teams missing or no user_team_id — skipping playbook")
+        return
+    team_rec = teams_obj.get(user_team_id)
+    if not isinstance(team_rec, dict):
+        logger.warning("[TUTORIAL] no team record for user_team_id=%s — skipping playbook", user_team_id)
+        return
+
+    existing_pb = team_rec.get("playbook_settings") if isinstance(team_rec.get("playbook_settings"), dict) else {}
+    existing_pc_order = existing_pb.get("pc_order") if isinstance(existing_pb.get("pc_order"), dict) else {}
+    new_pb = dict(existing_pb)
+    new_pb["pc_order"] = {
+        "offense": list(ordered_ids),
+        "defense": list(existing_pc_order.get("defense") or []),
+    }
+    team_rec["playbook_settings"] = new_pb
+
+    # Also mirror onto the in-memory GameManager team so any code path that
+    # reads from gm.user_team.playbook_settings (rather than the doc) sees
+    # the same data.
+    try:
+        user_team = gm.home_team if gm.home_team.team_id == user_team_id else gm.away_team
+        user_team.playbook_settings = dict(new_pb)
+    except Exception as e:
+        logger.warning("[TUTORIAL] could not mirror playbook_settings onto gm: %s", e)
+
+
 def _side_for(user_team_side: str, team_role: str) -> str:
     """Return 'user' or 'computer' for a team given which side the user controls.
 
@@ -342,6 +440,14 @@ def apply_tutorial_initial_state(
                 entry["pos"] = info["pos"]
             if "stats" in info:
                 entry["stats"] = info["stats"]
+
+    # User-team playcall center preloads (Coach's 8 default offensive plays).
+    # Writes pc_order.offense to summary["teams"][user_team_id]["playbook_settings"]
+    # and mirrors onto gm.user_team.playbook_settings.
+    user_team_id_for_pb = (
+        home_team.team_id if (user_team_side or "home") == "home" else away_team.team_id
+    )
+    _apply_tutorial_playbook_to_user_team(summary, user_team_id_for_pb, gm)
 
     logger.warning(
         "✅ [TUTORIAL] applied initial state: Q%d %s, %s vs %s, offense=%s, user_side=%s",


### PR DESCRIPTION
## Summary
Wires the user team's in-game playcall center with Coach's 8 default offensive plays for tutorial mode. Fixes the 400 Bad Request on `/api/playbooks?mode=tutorial` that left the offense slots empty.

## Plays (in slot order)

| Slot | Play |
|---|---|
| 1 | 3-2 Motion |
| 2 | 4-1 Motion |
| 3 | 5-0 Motion |
| 4 | PF Post Motion |
| 5 | Base Post Play |
| 6 | Pick & Roll - Entry Pass |
| 7 | Iso |
| 8 | Double Screen Three - Wing |

Verified all 8 resolve in the staging plays collection. `shooter_target` left at the DB default per Coach instruction.

### Name corrections vs original spec
- *"Pick & Roll Wing Entry"* → **`Pick & Roll - Entry Pass`** (Coach confirmed via Q)
- *"Double Screen Three -- Wing"* (double dash) → **`Double Screen Three - Wing`** (single hyphen)

## Implementation

| Change | File |
|---|---|
| `TUTORIAL_USER_OFFENSE_PLAYCALLS` constant + `build_tutorial_pc_order_offense()` helper (DB lookup) | `BackEnd/utils/tutorial_game.py` |
| `_apply_tutorial_playbook_to_user_team()` writes `pc_order.offense` to summary + gm | `BackEnd/utils/tutorial_game.py` |
| `apply_tutorial_initial_state()` calls the helper at the end | `BackEnd/utils/tutorial_game.py` |
| `get_collection_and_doc_id` accepts `mode=tutorial` (treats as single) | `BackEnd/api/gameplan_routes.py` |
| `get_playbooks` normalizes `tutorial → single` at the top — tutorial games are structurally identical (same doc shape, same cache, same game_id format), so the rest of the ~1000-line endpoint works unchanged. Avoids extending ~12 individual `mode == "single"` checks. | `BackEnd/api/gameplan_routes.py` |

## What's NOT in this PR (per scope confirmed with Coach)

- Defense `pc_order` — left at engine default
- `motion` / `set_plays` / `fast_breaks` / `zone_defense` / `man_defense` percentages — left at engine defaults
- Computer team playbook — left at engine defaults
- `shooter_target` overrides — DB defaults

## Test plan
After merge + Railway redeploy:
- [ ] Fresh tutorial signup → walk to court
- [ ] Court playcall center shows 8 offensive plays in the listed order
- [ ] Console no longer shows `[PLAYCALL CENTER] No team_id...` warning followed by 400
- [ ] Railway log shows `GET /api/playbooks?mode=tutorial&...&game_id=... → 200 OK` (no 400)
- [ ] Play through tutorial — playcalls work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)