### PR TITLE
FTE v2: read-only game plan in tutorial + team_id propagation

### DIFF
--- a/BackEnd/api/gameplan_routes.py
+++ b/BackEnd/api/gameplan_routes.py
@@ -1367,11 +1367,18 @@ def ensure_team_objects_exist(mode: str, doc_id: str, team_id: str, franchise_do
 def get_gameplan(mode: str, team_id: str, franchise_id: str = None, tournament_id: str = None, game_id: str = None, source: str = None):
     """
     Get game plan settings for a team in the specified mode.
-    
+
     Args:
         source: Optional source parameter. If "db", always reads from database (for lineup screen consistency).
                 If None or "cache", checks cache first for performance during active gameplay, but DB is always available as fallback.
     """
+    # FTE v2 tutorial games are structurally identical to single-mode games
+    # (same games_collection doc, same ongoing_games cache, same game_id
+    # format). Aliasing to "single" lets every downstream mode == "single"
+    # branch in this function work for tutorial too. Saving is gated on the
+    # frontend (tutorial mode hides the Save button + disables sliders).
+    if mode == "tutorial":
+        mode = "single"
     try:
         logger.warning(f"🔍 [GET GAMEPLAN] query: mode={mode!r}, team_id={team_id!r}, franchise_id={franchise_id!r}, tournament_id={tournament_id!r}, game_id={game_id!r}")
         # ✅ PHASE 5.5: Use helper to get collection and doc_id (simplifies mode handling)
@@ -1761,7 +1768,14 @@ def get_gameplan(mode: str, team_id: str, franchise_id: str = None, tournament_i
 def update_gameplan(request: GamePlanUpdateRequest):
     """Update game plan settings for a team in the specified mode."""
     from BackEnd.utils.team_settings_manager import save_team_settings
-    
+
+    # FTE v2 tutorial: defense-in-depth alias. The Save button is hidden in
+    # tutorial mode on the frontend, but if any code path triggers this PUT
+    # (auto-save, dirty-state flush, etc.), treat tutorial like single — the
+    # write goes to the throwaway game doc and disappears on completion.
+    if request.mode == "tutorial":
+        request.mode = "single"
+
     logger.warning(
         f"🔍 [UPDATE GAMEPLAN] request: mode={request.mode!r}, team_id={request.team_id!r}, "
         f"franchise_id={request.franchise_id!r}, tournament_id={request.tournament_id!r}, game_id={request.game_id!r}"

--- a/FrontEnd/static/game-plan.css
+++ b/FrontEnd/static/game-plan.css
@@ -77,6 +77,19 @@ input[type="reset"] {
   margin: 0;
 }
 
+/* FTE v2 tutorial: read-only subhead under the page title, surfaced when
+   game-plan is opened via ?mode=tutorial. */
+.tutorial-readonly-subhead {
+  margin: 4px 0 0;
+  font-family: 'Inter', sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.66);
+  text-align: center;
+  letter-spacing: 0.02em;
+}
+.tutorial-readonly-subhead[hidden] { display: none; }
+
 .game-plan-card {
   margin-top: 0;
 }

--- a/FrontEnd/static/game-plan.html
+++ b/FrontEnd/static/game-plan.html
@@ -30,6 +30,7 @@
         <header class="game-plan-page-header">
           <img id="team-logo" alt="team logo" class="team-logo" hidden>
           <h1 id="page-title">Set Your Game Plan</h1>
+          <p id="tutorial-readonly-subhead" class="tutorial-readonly-subhead" hidden>Read-only for onboarding game.</p>
         </header>
         <div class="sliders-container">
           <!-- Left Column: Offense -->

--- a/FrontEnd/static/game-plan.js
+++ b/FrontEnd/static/game-plan.js
@@ -129,6 +129,27 @@ if (modeParam === 'single') {
   }
 }
 
+// FTE v2 tutorial: team_id is passed as the user team name (matches the
+// single-mode handling — backend resolves via gm.<team>.name == team_id).
+// Page is read-only: sliders disabled, Save hidden, subhead shown.
+if (modeParam === 'tutorial') {
+  const teamIdParam = urlParams.get('team_id');
+  if (teamIdParam) {
+    teamId = teamIdParam;
+    teamName = teamIdParam;
+  }
+  // DOM not yet ready when this module-level code runs — defer to load.
+  document.addEventListener('DOMContentLoaded', () => {
+    const subhead = document.getElementById('tutorial-readonly-subhead');
+    if (subhead) subhead.hidden = false;
+    document.querySelectorAll('.strategy-slider').forEach((el) => {
+      el.disabled = true;
+    });
+    const saveBtn = document.getElementById('btn-save-game-plan');
+    if (saveBtn) saveBtn.style.display = 'none';
+  });
+}
+
 // State
 let currentSettings = {
   strategy_settings: {}

--- a/FrontEnd/static/tutorial-situation.js
+++ b/FrontEnd/static/tutorial-situation.js
@@ -106,6 +106,11 @@ function gotoSetLineup(userTeam, opponent, gameId, lineup) {
     away: opponent,
     my_team: 'home',
     quarter: '4',
+    // team_id is the user team name. Single-mode game-plan / playbooks
+    // endpoints resolve it via gm.home_team.name == team_id fallback
+    // (gameplan_routes.py). Without this, game-plan can't compute
+    // team_id from the URL (no home_id/team_id present in tutorial nav).
+    team_id: userTeam,
   });
   if (gameId) params.set('game_id', gameId);
   ['PG', 'SG', 'SF', 'PF', 'C'].forEach(pos => {


### PR DESCRIPTION
## Summary
Makes the game-plan page read-only in tutorial mode (per Coach option **b**). User can browse to confirm the preset strategy_settings (2/2/2 except hc_trap=1, fc_press=1) but can't tweak. Also fixes the URL-back-nav wonkiness Coach observed by propagating `team_id` through the tutorial nav chain.

## Changes

| Change | File |
|---|---|
| Backend: `get_gameplan` aliases `mode=tutorial` → `single` (same pattern as `get_playbooks` PR 526). `update_gameplan` also aliased as defense-in-depth in case any auto-save fires. | `BackEnd/api/gameplan_routes.py` |
| Subhead element under page title: *"Read-only for onboarding game."* | `FrontEnd/static/game-plan.html` |
| Subhead styling (Inter 14, 66% white, centered) | `FrontEnd/static/game-plan.css` |
| Tutorial-mode detection: reads `team_id` from URL, shows subhead, disables every `.strategy-slider`, hides `#btn-save-game-plan` | `FrontEnd/static/game-plan.js` |
| `team_id=userTeam` added to tutorial-situation's nav URL — propagates through `buildGameNavigationParams` to set-lineup → game-plan → court and back | `FrontEnd/static/tutorial-situation.js` |

## Why team_id matters

Backend `get_gameplan` resolves the team via `gm.<team>.name == team_id` fallback ([gameplan_routes.py:1400](BackEnd/api/gameplan_routes.py#L1400)). Tutorial URLs only have `home`/`away` (team names), not `home_id`/`team_id` like franchise/tournament. Without explicitly setting `team_id`, game-plan can't compute it from the URL → the GET errors. (This explains Coach's "error message that disappeared after a beat" — get_gameplan 400'd silently and the page rendered fallback values.)

`buildGameNavigationParams` already preserves `team_id` through every navigation (line 65-87 of `timeoutNavigationHelper.js`), so once it's in the URL at the situation page, it carries through set-lineup ↔ game-plan ↔ court with no further changes.

## Test plan
- [ ] Fresh tutorial signup → set-lineup → press **Game Plan**
- [ ] Page loads with no error. Sliders show the presets: Offense 2, Inside 2, Attack 2, Outside 2, Fast Break 2, Defense 2, Aggression 2, **HC Trap 1**, **FC Press 1**, Rebounding 2
- [ ] Sliders are visibly disabled (greyed/uninteractive)
- [ ] Subhead under title reads: *"Read-only for onboarding game."*
- [ ] Save button is gone
- [ ] Click "Back To Lineup" → returns to set-lineup with all params intact (Q4, 4:00, 60–60, lineup populated, no flash of Pre-Game / 0-0)
- [ ] Existing franchise/single game-plan flow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)