### PR TITLE
FTE v2: fetch mascot from /teams + copy nit

### DIFF
--- a/BackEnd/api/api.py
+++ b/BackEnd/api/api.py
@@ -1489,7 +1489,7 @@ try:
     @app.get("/teams")
     def get_team_names():
         teams = teams_collection.find(
-            {}, {"name": 1, "primary_color": 1, "secondary_color": 1, "_id": 0}
+            {}, {"name": 1, "primary_color": 1, "secondary_color": 1, "mascot": 1, "_id": 0}
         )
         return sorted(
             [
@@ -1497,6 +1497,7 @@ try:
                     "name": team.get("name"),
                     "primary_color": team.get("primary_color"),
                     "secondary_color": team.get("secondary_color"),
+                    "mascot": team.get("mascot"),
                 }
                 for team in teams
             ],

--- a/FrontEnd/static/franchise-select-team.js
+++ b/FrontEnd/static/franchise-select-team.js
@@ -28,21 +28,6 @@ const taglines = {
   'South Lancaster': 'Us vs The World'
 };
 
-// Mascots (collective noun) for the username-modal copy interpolation —
-// "you're now coaching the {mascot}". Authoritative on teams collection
-// (team_doc.mascot) but hardcoded here to avoid a round-trip on a single
-// modal render. Keep in sync if any team mascot ever changes.
-const mascots = {
-  'Bentley-Truman': 'Knights',
-  'Lancaster': 'Johnnies',
-  'Four Corners': 'Harvest',
-  'Ocean City': 'Admirals',
-  'Morristown': 'Pirates',
-  'Little York': 'Minute Men',
-  'Xavien': 'Elm Trees',
-  'South Lancaster': 'Bulldogs'
-};
-
 const teamContainer = document.getElementById("team-container");
 const errorHost = document.getElementById("team-select-error");
 const loadingOverlay = document.getElementById("team-select-loading");
@@ -53,6 +38,34 @@ const backLink = document.getElementById("team-select-back-link");
 // FTE v2 tutorial branch: when ?mode=tutorial is present, this page is the
 // first step of the new-user funnel rather than a franchise-creation entry.
 const TUTORIAL_MODE = new URLSearchParams(window.location.search).get("mode") === "tutorial";
+
+// Mascot map (team name → mascot string) loaded on demand from /teams.
+// Single source of truth = team_doc.mascot in the teams collection. Used by
+// the username modal copy ("you're now coaching the {mascot}, Coach"). Fired
+// once at module load when in tutorial mode so the click handler can await
+// without an extra round-trip mid-click.
+let mascotMapPromise = null;
+function fetchMascotMap() {
+  if (mascotMapPromise) return mascotMapPromise;
+  mascotMapPromise = fetch(API_CONFIG.buildUrl('/teams'), { headers: API_CONFIG.getAuthHeaders() })
+    .then(res => res.ok ? res.json() : [])
+    .then(teams => {
+      const map = {};
+      for (const t of teams || []) {
+        if (t && t.name && t.mascot) map[t.name] = t.mascot;
+      }
+      return map;
+    })
+    .catch(err => {
+      console.warn('[franchise-select-team] could not load mascots:', err);
+      return {};
+    });
+  return mascotMapPromise;
+}
+if (TUTORIAL_MODE) {
+  // Prefetch so the click handler's await is effectively free.
+  fetchMascotMap();
+}
 
 function buildReturnUrl() {
   return window.location.pathname + window.location.search;
@@ -149,10 +162,13 @@ async function selectTutorialTeam(team) {
   }
 
   // Step 2: open the username modal with team-aware copy. Use the mascot
-  // (collective noun) so the sentence reads naturally — "the Johnnies",
-  // "the Pirates" — instead of grammatically broken "the Lancaster".
-  const mascot = mascots[team] || team;
-  const prompt = `You're now coaching the ${mascot}. What's your name, Coach?`;
+  // (collective noun) so the sentence reads naturally — "the Sterling
+  // Knights", "the Pirates" — instead of grammatically broken "the Lancaster".
+  // Mascot string sourced from team_doc.mascot in the teams collection
+  // (single source of truth), fetched at module load.
+  const mascotMap = await fetchMascotMap();
+  const mascot = mascotMap[team] || team;
+  const prompt = `You're now coaching the ${mascot}. What's your username, Coach?`;
   const { openUsernameModal } = await import('/js/shared/usernameModal.js');
   openUsernameModal({
     prompt,


### PR DESCRIPTION
## Summary
Right-fix for the mascot drift Coach caught (Bentley-Truman showed "Knights" instead of "Sterling Knights"). Plus a one-word copy update on the username modal.

## Changes

| Change | File |
|---|---|
| `/teams` endpoint includes `mascot` in projection + response | `BackEnd/api/api.py` |
| Hardcoded mascots dict removed | `FrontEnd/static/franchise-select-team.js` |
| `fetchMascotMap()` helper: fetches `/teams`, caches promise, builds name → mascot map. Prefetched at module load in tutorial mode | `FrontEnd/static/franchise-select-team.js` |
| `selectTutorialTeam` awaits the map before building the prompt | `FrontEnd/static/franchise-select-team.js` |
| Copy: *"What's your name, Coach?"* → *"What's your username, Coach?"* | `FrontEnd/static/franchise-select-team.js` |

## What gets fixed

Verified against staging:

| Team | Was (hardcoded) | Now (from DB) |
|---|---|---|
| Bentley-Truman | Knights | **Sterling Knights** |
| Little York | Minute Men | **Minutemen** |
| Lancaster | Johnnies | Johnnies ✓ |
| Four Corners | Harvest | Harvest ✓ |
| Ocean City | Admirals | Admirals ✓ |
| Morristown | Pirates | Pirates ✓ |
| Xavien | Elm Trees | Elm Trees ✓ |
| South Lancaster | Bulldogs | Bulldogs ✓ |

Going forward, any mascot edit in `teams.team_doc.mascot` automatically surfaces in the modal — no JS to update.

## Test plan
- [ ] Tutorial signup → pick Bentley-Truman → username modal reads: *"You're now coaching the Sterling Knights. What's your username, Coach?"*
- [ ] Pick Little York → *"...the Minutemen..."* (one word)
- [ ] Other 6 teams unchanged
- [ ] `/teams` response on any other consumer (mode-select, etc.) is unchanged structurally — just has an additional `mascot` field they can ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)