### PR TITLE
FTE v2: include game_id in tutorial /api/gameplan request

### DIFF
--- a/FrontEnd/static/game-plan.js
+++ b/FrontEnd/static/game-plan.js
@@ -415,7 +415,9 @@ async function loadSettings() {
     } else if (mode === 'tournament' && tournamentId) {
       params.set('tournament_id', tournamentId);
       if (gameId) params.set('game_id', gameId);
-    } else if (mode === 'single' && gameId) {
+    } else if ((mode === 'single' || mode === 'tutorial') && gameId) {
+      // Tutorial games are stored in games_collection like single mode; the
+      // backend aliases mode=tutorial → single and requires game_id.
       params.set('game_id', gameId);
     }
     


### PR DESCRIPTION
## Summary
One-line fix for the *"Failed to load game plan settings. game_id required for single mode"* error Coach hit on entering game plan in tutorial mode.

## Root cause
`loadSettings()` in [game-plan.js:412-420](FrontEnd/static/game-plan.js#L412-L420) builds the API request URL with mode-specific branches for `franchise` / `tournament` / `single` — **no branch for `tutorial`**. So `game_id` never got added.

Backend then aliases `mode=tutorial → single` (per my prior fix), but with no `game_id` present, it returns 400 *"game_id required for single mode"*.

Frontend caught the 400 → showed the error popup → fell back to default slider values (all 2s), which is why HCT and FCP rendered as 2 instead of their tutorial preset of 1.

## Fix
Extend the `single` branch to also handle `tutorial`:

```js
} else if ((mode === 'single' || mode === 'tutorial') && gameId) {
  params.set('game_id', gameId);
}
```

Single line. Tutorial games are stored in `games_collection` identically to single — same game_id required, same code path.

## What this fixes
- Error popup on game-plan page entry → gone
- Sliders show actual engine values: Offense 2, Inside 2, Attack 2, Outside 2, Fast Break 2, Defense 2, Aggression 2, **HC Trap 1**, **FC Press 1**, Rebounding 2

PUT path (Save) was already correct (line 537-539 unconditionally includes `game_id`). Save button is hidden in tutorial mode anyway.

## Test plan
- [ ] Walk tutorial → set-lineup → Game Plan
- [ ] No error popup
- [ ] All 10 sliders render. **HC Trap and FC Press positioned at 1**, all others at 2
- [ ] Back to Lineup → state intact (no flash of Pre-Game / 0-0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)