### PR TITLE
FTE v2: restore game-plan read-only + Sammy intro fires once

### DIFF
--- a/FrontEnd/static/game-plan.css
+++ b/FrontEnd/static/game-plan.css
@@ -90,6 +90,19 @@ input[type="reset"] {
 }
 .tutorial-readonly-subhead[hidden] { display: none; }
 
+/* Visual treatment for read-only sliders in tutorial mode. Applied as a
+   class on .sliders-container so users can tell at a glance the page
+   isn't editable (the input[disabled] state alone is too subtle). */
+.sliders-container.tutorial-readonly {
+  opacity: 0.62;
+}
+.sliders-container.tutorial-readonly input[type="range"] {
+  cursor: not-allowed;
+}
+.sliders-container.tutorial-readonly .strategy-slider-node {
+  filter: grayscale(0.5);
+}
+
 .game-plan-card {
   margin-top: 0;
 }

--- a/FrontEnd/static/game-plan.js
+++ b/FrontEnd/static/game-plan.js
@@ -138,16 +138,26 @@ if (modeParam === 'tutorial') {
     teamId = teamIdParam;
     teamName = teamIdParam;
   }
-  // DOM not yet ready when this module-level code runs — defer to load.
-  document.addEventListener('DOMContentLoaded', () => {
+  // game-plan.js is loaded dynamically by the HTML AFTER DOMContentLoaded
+  // already fired (see game-plan.html: script.onload manually calls init()
+  // when document.readyState !== 'loading'). So we can't wait for that
+  // event — it'll never re-fire. Use readyState to branch.
+  const applyReadOnly = () => {
     const subhead = document.getElementById('tutorial-readonly-subhead');
     if (subhead) subhead.hidden = false;
     document.querySelectorAll('.strategy-slider').forEach((el) => {
       el.disabled = true;
     });
+    const slidersContainer = document.querySelector('.sliders-container');
+    if (slidersContainer) slidersContainer.classList.add('tutorial-readonly');
     const saveBtn = document.getElementById('btn-save-game-plan');
     if (saveBtn) saveBtn.style.display = 'none';
-  });
+  };
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', applyReadOnly);
+  } else {
+    applyReadOnly();
+  }
 }
 
 // State

--- a/FrontEnd/static/set-lineup.js
+++ b/FrontEnd/static/set-lineup.js
@@ -2033,14 +2033,24 @@ async function init() {
   // lineup is in the URL (restoreLineupFromUrl populates it above). We do NOT
   // call autoset here — the engine assigned the tutorial-roster starters
   // (rank_roster + Section 5 templates) and we want to honor that exactly.
-  // Just show the Sammy intro modal so the user knows to tweak if desired.
+  // Show the Sammy intro modal ONCE per tutorial run (keyed by game_id so
+  // a re-entry from game-plan or a page reload doesn't re-fire it).
   if (modeParam === 'tutorial') {
-    import('/js/shared/sammyModal.js').then(({ showSammyModal }) => {
-      showSammyModal({
-        body: "I've set your lineup — tweak it if you like, and hover any attribute to see what it means.",
-        ctaLabel: 'Got it',
-      });
-    }).catch((e) => console.warn('[tutorial] could not load sammyModal:', e));
+    const introKey = gameId
+      ? `fteV2TutorialLineupIntroShown_${gameId}`
+      : 'fteV2TutorialLineupIntroShown';
+    const alreadyShown = (() => {
+      try { return sessionStorage.getItem(introKey) === '1'; } catch (_) { return false; }
+    })();
+    if (!alreadyShown) {
+      try { sessionStorage.setItem(introKey, '1'); } catch (_) {}
+      import('/js/shared/sammyModal.js').then(({ showSammyModal }) => {
+        showSammyModal({
+          body: "I've set your lineup — tweak it if you like, and hover any attribute to see what it means.",
+          ctaLabel: 'Got it',
+        });
+      }).catch((e) => console.warn('[tutorial] could not load sammyModal:', e));
+    }
   }
 
   const btn = document.getElementById('play-now');


### PR DESCRIPTION
## Summary
Two staging-walkthrough bugs.

| # | Bug | Root cause | Fix |
|---|---|---|---|
| 1 | Game-plan read-only treatment missing (sliders active, no subhead, Save visible) | Used `document.addEventListener('DOMContentLoaded', ...)` but game-plan.js loads dynamically *after* `DOMContentLoaded` already fired ([game-plan.html:240-245](FrontEnd/static/game-plan.html#L240-L245)). Listener attached to dead event. | Branch on `document.readyState`. Run immediately if not 'loading'. Plus added a `.tutorial-readonly` CSS class on `.sliders-container` for a visible greyed-out treatment (opacity 0.62, not-allowed cursor, grayscale balls). |
| 2 | "I've set your lineup" Sammy modal fires on every set-lineup load | No "shown once" guard. | sessionStorage flag keyed by `game_id`. Once shown, suppress for the rest of the session. |

## Test plan
- [ ] Tutorial → set-lineup → Game Plan: subhead "Read-only for onboarding game." visible, sliders all greyed/disabled, no Save button, sliders show HCT at 1 / FCP at 1 / all others at 2
- [ ] Click "Back to Lineup": no "I've set your lineup" modal re-appears
- [ ] Reload set-lineup: no modal re-appears
- [ ] Fresh tutorial signup (new session): modal appears once, as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)