### PR TITLE
FTE v2: tutorial Scout button + th tooltips on team pages

### DIFF
--- a/FrontEnd/static/franchise-command-center.js
+++ b/FrontEnd/static/franchise-command-center.js
@@ -2001,9 +2001,9 @@ function renderRecruits(data) {
     tbody.appendChild(tr);
   });
   
-  // Initialize tooltips for table cells
+  // Initialize tooltips for table cells (and headers)
   if (typeof initAttributeTooltips !== 'undefined') {
-    initAttributeTooltips(tbody, ['td']);
+    initAttributeTooltips(tbody.closest('table') || tbody, ['td', 'th']);
   }
 }
 
@@ -2166,15 +2166,16 @@ function renderTeam(data) {
       addCell(displayVal);
     });
     addCell(p.rt ?? '-');
-    
+
     tbody.appendChild(tr);
   });
-  
-  // Initialize tooltips for table cells
+
+  // Initialize tooltips. Scope to the parent table so the SC/SH/ID/… column
+  // headers also get tooltips, not only the cells under them.
   if (typeof initAttributeTooltips !== 'undefined') {
-    initAttributeTooltips(tbody, ['td']);
+    initAttributeTooltips(tbody.closest('table') || tbody, ['td', 'th']);
   }
-  
+
   // Add click handlers to sortable headers
   const sortableHeaders = document.querySelectorAll('#roster-tab .roster-table thead th');
   let rosterSortColumn = 'RT';
@@ -2439,12 +2440,12 @@ function sortRosterTable(columnName, direction) {
       addCell(displayVal);
     });
     addCell(p.rt ?? '-');
-    
+
     tbody.appendChild(tr);
   });
-  
+
   if (typeof initAttributeTooltips !== 'undefined') {
-    initAttributeTooltips(tbody, ['td']);
+    initAttributeTooltips(tbody.closest('table') || tbody, ['td', 'th']);
   }
 }
 

--- a/FrontEnd/static/franchise-select-team.js
+++ b/FrontEnd/static/franchise-select-team.js
@@ -102,12 +102,9 @@ function createButtons() {
   teams.forEach(team => {
     const card = document.createElement("div");
     card.className = "team-card";
-    // Tutorial flow shows only the Select action — no scouting before first game.
-    const overlayHtml = TUTORIAL_MODE
-      ? `<button class="team-card-action team-card-action-select" type="button">Select</button>`
-      : `<button class="team-card-action team-card-action-scout" type="button">Scout</button>
-         <button class="team-card-action team-card-action-select" type="button">Select</button>`;
-    const overlayClass = TUTORIAL_MODE ? 'team-card-overlay is-single-action' : 'team-card-overlay';
+    const overlayHtml = `<button class="team-card-action team-card-action-scout" type="button">Scout</button>
+       <button class="team-card-action team-card-action-select" type="button">Select</button>`;
+    const overlayClass = 'team-card-overlay';
     card.innerHTML = `
       <div class="team-card-banner">
         <img src="${typeof getTeamAssetPath === 'function' ? getTeamAssetPath(team, 'banner_primary') : '/images/teams/general/general_banner_primary.jpg'}" alt="${team}">
@@ -122,7 +119,14 @@ function createButtons() {
     if (scoutBtn) {
       scoutBtn.addEventListener("click", () => {
         playSound("click-beep.wav");
-        window.location.href = '/team-roster-view.html?team_name=' + encodeURIComponent(team) + '&return_url=' + encodeURIComponent(buildReturnUrl());
+        const scoutParams = new URLSearchParams();
+        scoutParams.set('team_name', team);
+        scoutParams.set('return_url', buildReturnUrl());
+        // FTE v2 tutorial: carry mode=tutorial so authBarInit's routeToTutorial
+        // treats team-roster-view as a shoulder page and doesn't bounce the
+        // user back to the team-select step.
+        if (TUTORIAL_MODE) scoutParams.set('mode', 'tutorial');
+        window.location.href = '/team-roster-view.html?' + scoutParams.toString();
       });
     }
     if (selectBtn) {

--- a/FrontEnd/static/js/shared/authBarInit.js
+++ b/FrontEnd/static/js/shared/authBarInit.js
@@ -146,6 +146,14 @@
     var SITUATION_URL = '/tutorial-situation.html';
     var currentPath = window.location.pathname;
 
+    // FTE v2 tutorial "shoulder pages" — entered from the tutorial funnel but
+    // not themselves a step. Treat as in-scope when ?mode=tutorial is set so
+    // the user isn't bounced back to their current step (e.g. Scout opens
+    // team-roster-view from team-select; we must let them stay there).
+    var TUTORIAL_SHOULDER_PAGES = ['/team-roster-view.html'];
+    var urlMode = new URLSearchParams(window.location.search).get('mode');
+    if (urlMode === 'tutorial' && TUTORIAL_SHOULDER_PAGES.indexOf(currentPath) !== -1) return;
+
     var targetPath;
     var targetUrl;
     if (step === 'team_select' || step === 'username') {

--- a/FrontEnd/static/team-roster-view.html
+++ b/FrontEnd/static/team-roster-view.html
@@ -442,6 +442,7 @@
 
   <script src="/js/config/api-config.js"></script>
   <script src="/common.js"></script>
+  <script src="/js/shared/attributeTooltips.js"></script>
   <script src="/team-roster-view.js"></script>
   <script type="module">
     import { resumeFranchiseTrack } from '/js/musicController.js';

--- a/FrontEnd/static/team-roster-view.js
+++ b/FrontEnd/static/team-roster-view.js
@@ -210,9 +210,11 @@ async function loadRoster() {
 
 async function loadStats() {
   try {
-    // Skip stats loading if in base mode (no franchise/tournament)
-    if (!mode) {
-      // Hide stats section for base roster view
+    // Skip stats loading if in base mode (no franchise/tournament) or
+    // FTE v2 tutorial mode — tutorial users haven't played any games yet,
+    // so the table would be empty + the franchise/tournament branches
+    // below would bail with "Invalid mode".
+    if (!mode || mode === 'tutorial') {
       const statsSection = document.getElementById('stats-section');
       if (statsSection) {
         statsSection.style.display = 'none';
@@ -420,11 +422,14 @@ function renderRoster() {
     tbody.appendChild(tr);
   });
   
-  // Initialize tooltips if available
+  // Initialize tooltips if available. Scope to the whole roster table so the
+  // column headers (SC, SH, ID, OD, …) also get tooltips, not just the data
+  // cells under them.
   if (typeof initAttributeTooltips !== 'undefined') {
-    initAttributeTooltips(tbody, ['td']);
+    const rosterTable = document.getElementById('roster-table') || tbody;
+    initAttributeTooltips(rosterTable, ['td', 'th']);
   }
-  
+
   // If player view is active, re-render it when roster changes
   if (currentView === 'player') {
     renderPlayerView();


### PR DESCRIPTION
Bundled per your direction — Q1 + Q2 from the last alignment.

## Q1 — Scout button in tutorial team-select
Tutorial users can now Scout teams before picking. Three small touchpoints:

- [\`franchise-select-team.js\`](FrontEnd/static/franchise-select-team.js): render both Scout + Select in tutorial; propagate \`mode=tutorial\` on the scout URL so the destination knows it's tutorial-scoped.
- [\`authBarInit.js\`](FrontEnd/static/js/shared/authBarInit.js): \`routeToTutorial()\` now treats \`team-roster-view.html\` as a tutorial **shoulder page** when \`?mode=tutorial\` is set — without this, the redirect would bounce the user straight back to their current tutorial step.
- [\`team-roster-view.js\`](FrontEnd/static/team-roster-view.js): hide the Season Statistics section in tutorial mode (no games played; the existing franchise/tournament branches would otherwise bail with \"Invalid mode\").

Backend already supports it — \`/roster/{team_name}\` is mode-agnostic, so the attribute table loads naturally.

## Q2 — Attribute-header tooltips on team pages

- [\`team-roster-view.html\`](FrontEnd/static/team-roster-view.html): adds \`<script src=\"/js/shared/attributeTooltips.js\">\`. **Latent bug fixed** — the existing \`initAttributeTooltips()\` calls in \`team-roster-view.js\` were silently no-oping because the script was never loaded on this page.
- [\`team-roster-view.js\`](FrontEnd/static/team-roster-view.js) + [\`franchise-command-center.js\`](FrontEnd/static/franchise-command-center.js): three call sites updated to also bind on \`th\` headers by scoping to the parent table. The helper only fires when the cell text matches a known abbreviation, so non-attribute headers (Name, POS, PTS, …) are safely ignored.
- \`player-detail.js\` unchanged — its only \`<th>\` cells are stat columns (PTS, FGM, …) which aren't in \`ATTRIBUTE_NAMES\`. Attribute abbrevs there live in \`.attribute-label\` spans already wired.

## Test plan
- [ ] Tutorial flow: from team-select, click **Scout** on any team → lands on team-roster-view with attributes visible, no stats section, no auth bar.
- [ ] On the scouted team-roster-view page, hover SC/SH/ID/… column headers → tooltip with full attribute name.
- [ ] Click Back → returns to \`franchise-select-team?mode=tutorial\` (tutorial state preserved).
- [ ] Click **Select** on a team → existing tutorial-pick flow still works.
- [ ] Non-tutorial Scout (franchise / tournament) still shows the stats section and works as before.
- [ ] FCC roster tab: hover SC/SH/ID/… column headers → tooltip fires.