### PR TITLE
FTE v2: onboarding redesign (Persona Intro + modal taxonomy + green scarcity + RT colors)

### DIFF
--- a/BackEnd/api/auth_routes.py
+++ b/BackEnd/api/auth_routes.py
@@ -88,6 +88,7 @@ class AuthResponse(BaseModel):
 
 
 TutorialStep = Literal[
+    "persona_intro",
     "team_select",
     "username",
     "situation",
@@ -106,13 +107,17 @@ class TutorialState(BaseModel):
 
 
 # Index map for forward-only step validation. Higher = later in the funnel.
+# persona_intro was prepended in the FTE v2 onboarding redesign (Sammy persona
+# intro screen). Grandfathered users already past team_select don't need
+# migration — the routing logic treats their existing step as still valid.
 _TUTORIAL_STEP_ORDER = {
-    "team_select": 0,
-    "username": 1,
-    "situation": 2,
-    "set_lineup": 3,
-    "in_game": 4,
-    "complete": 5,
+    "persona_intro": 0,
+    "team_select": 1,
+    "username": 2,
+    "situation": 3,
+    "set_lineup": 4,
+    "in_game": 5,
+    "complete": 6,
 }
 
 
@@ -330,7 +335,7 @@ async def signup(request: Request, body: SignupRequest):
         "fte": True,
         "fte_v2_complete": False,
         "tutorial_state": {
-            "step": "team_select",
+            "step": "persona_intro",
             "team_pick": None,
             "started_at": now,
             "completed_at": None,
@@ -369,7 +374,7 @@ async def signup(request: Request, body: SignupRequest):
             "fte": True,
             "fte_v2_complete": False,
             "tutorial_state": {
-                "step": "team_select",
+                "step": "persona_intro",
                 "team_pick": None,
                 "started_at": now.isoformat(),
                 "completed_at": None,

--- a/FrontEnd/static/css/coach-mark.css
+++ b/FrontEnd/static/css/coach-mark.css
@@ -1,0 +1,116 @@
+/*
+ * Coach-mark — spotlight guidance pattern, NOT a modal.
+ *
+ * Per styleguide: coach-marks are a distinct pattern from the three modal
+ * types (Functional, Moment, Strategic). They sit on the page, do not block
+ * interaction, and point at a specific element so the user can see the very
+ * thing the copy is describing.
+ */
+
+.gob-coachmark {
+  position: absolute;
+  z-index: 1500;
+  width: min(360px, calc(100vw - 32px));
+  padding: 16px 18px 14px;
+  background: rgba(22, 26, 36, 0.98);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 12px;
+  box-shadow:
+    0 18px 36px rgba(0, 0, 0, 0.45),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  opacity: 0;
+  transform: translateY(6px);
+  transition: opacity 0.22s ease, transform 0.22s ease;
+  pointer-events: auto;
+}
+
+.gob-coachmark.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Pointer arrow — directional triangle that anchors the bubble to its target.
+ * Side modifiers control which edge the arrow protrudes from. */
+.gob-coachmark::before {
+  content: '';
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  background: rgba(22, 26, 36, 0.98);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  transform: rotate(45deg);
+}
+
+.gob-coachmark--left::before {
+  left: -8px;
+  top: 36px;
+  border-right: 0;
+  border-top: 0;
+}
+
+.gob-coachmark--right::before {
+  right: -8px;
+  top: 36px;
+  border-left: 0;
+  border-bottom: 0;
+}
+
+.gob-coachmark--top::before {
+  top: -8px;
+  left: 36px;
+  border-right: 0;
+  border-bottom: 0;
+}
+
+.gob-coachmark--bottom::before {
+  bottom: -8px;
+  left: 36px;
+  border-left: 0;
+  border-top: 0;
+}
+
+.gob-coachmark__portrait {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  object-fit: cover;
+  object-position: center top;
+  border: 2px solid rgba(247, 148, 32, 0.65);
+  background: rgba(0, 0, 0, 0.4);
+  float: left;
+  margin: 0 12px 6px 0;
+  flex-shrink: 0;
+}
+
+.gob-coachmark__eyebrow {
+  font-family: 'Bebas Neue Pro', 'Bebas Neue', sans-serif;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  color: #F79420;
+  text-transform: uppercase;
+  margin-bottom: 4px;
+  line-height: 1;
+}
+
+.gob-coachmark__body {
+  font-family: 'Inter', sans-serif;
+  font-size: 14px;
+  line-height: 1.45;
+  color: rgba(255, 255, 255, 0.88);
+  margin: 0 0 12px;
+}
+
+.gob-coachmark__foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  clear: both;
+}
+
+.gob-coachmark__count {
+  font-family: 'Inter', sans-serif;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.38);
+  letter-spacing: 0.04em;
+}

--- a/FrontEnd/static/css/gob-buttons.css
+++ b/FrontEnd/static/css/gob-buttons.css
@@ -1,0 +1,109 @@
+/*
+ * Canonical GOB button component — implements the Universal Button Shape
+ * defined in Styleguide_updated.md (Buttons §).
+ *
+ *   min-width: 138px   height: 42px   padding: 0 18px   radius: 10px
+ *   border: 1px solid rgba(255,255,255,0.28)
+ *   inset top highlight: rgba(255,255,255,0.18)
+ *   font: Bebas Neue Pro, +tracking
+ *   hover-lift -1px, press-compress translateY(0)
+ *
+ * Variants are role-based, NOT decorative:
+ *   .gob-btn--action  orange #F79420 — non-gating primary (saves, configures, advances UI)
+ *   .gob-btn--gate    green #34EC27 — gating primary (advances game state). Scarce by design.
+ *   .gob-btn--ghost   subdued — acknowledgements, secondary actions, dismissals
+ *
+ * Use sparingly across the product. Inside Functional modals, the existing
+ * .gob-modal-btn-* classes are already canonical and should be preferred.
+ */
+
+.gob-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 138px;
+  height: 42px;
+  padding: 0 18px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18);
+  font-family: 'Bebas Neue Pro', 'Bebas Neue', sans-serif;
+  font-size: 16px;
+  font-weight: 400;
+  letter-spacing: 0.06em;
+  line-height: 1;
+  text-decoration: none;
+  cursor: pointer;
+  appearance: none;
+  background: transparent;
+  color: #ffffff;
+  transition: filter 0.14s ease, transform 0.14s ease, background 0.14s ease, border-color 0.14s ease;
+}
+
+.gob-btn:hover:not(:disabled):not(.is-disabled) {
+  transform: translateY(-1px);
+  filter: brightness(1.06);
+}
+
+.gob-btn:active:not(:disabled):not(.is-disabled) {
+  transform: translateY(0);
+  filter: brightness(0.98);
+}
+
+.gob-btn:disabled,
+.gob-btn.is-disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+  filter: none;
+}
+
+/* Larger CTA variant — used on Persona Intro / Tip-off where the button is the
+ * primary focal point on a near-empty stage. Still on-system, just scaled up. */
+.gob-btn--lg {
+  height: 50px;
+  min-width: 180px;
+  padding: 0 28px;
+  font-size: 19px;
+  letter-spacing: 0.08em;
+}
+
+/* --- Role variants ----------------------------------------------------- */
+
+/* Non-gating primary — orange. Default for almost every primary CTA. */
+.gob-btn--action {
+  background: #F79420;
+  border-color: rgba(247, 148, 32, 0.55);
+  color: #15181f;
+}
+
+.gob-btn--action:hover:not(:disabled):not(.is-disabled) {
+  background: #ffa84a;
+}
+
+/* Gating primary — green. Reserved for actions that advance game state.
+ * Per styleguide: must remain scarce. In the FTE flow, this appears on
+ * exactly one button (Tip-off → SET LINEUP). */
+.gob-btn--gate {
+  background: #34EC27;
+  border-color: rgba(52, 236, 39, 0.55);
+  color: #15181f;
+}
+
+.gob-btn--gate:hover:not(:disabled):not(.is-disabled) {
+  background: #4dff3f;
+}
+
+/* Ghost — acknowledgements and quiet secondaries. */
+.gob-btn--ghost {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.18);
+  color: rgba(255, 255, 255, 0.85);
+  box-shadow: none;
+}
+
+.gob-btn--ghost:hover:not(:disabled):not(.is-disabled) {
+  background: rgba(255, 255, 255, 0.11);
+  border-color: rgba(255, 255, 255, 0.30);
+  color: #ffffff;
+}

--- a/FrontEnd/static/css/tutorial-persona-intro.css
+++ b/FrontEnd/static/css/tutorial-persona-intro.css
@@ -1,0 +1,71 @@
+/*
+ * FTE v2 — Persona Intro (Screen 0)
+ * Generic Sammy + name + welcome line + supporting body + LET'S GO CTA.
+ * On-system shell background per styleguide §Page Background System (Type 1).
+ */
+
+body.tutorial-persona-page {
+  background: #0b0d14;
+  margin: 0;
+  min-height: 100vh;
+  font-family: 'Inter', sans-serif;
+  color: #ffffff;
+}
+
+.persona-intro {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 24px 96px;
+  text-align: center;
+}
+
+.persona-intro__portrait {
+  width: 220px;
+  height: 220px;
+  border-radius: 50%;
+  object-fit: cover;
+  object-position: center top;
+  background: rgba(0, 0, 0, 0.4);
+  border: 3px solid rgba(255, 255, 255, 0.20);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.45);
+  margin-bottom: 28px;
+}
+
+.persona-intro__name {
+  font-family: 'Bebas Neue Pro', 'Bebas Neue', sans-serif;
+  font-size: 13px;
+  letter-spacing: 0.20em;
+  color: rgba(255, 255, 255, 0.55);
+  text-transform: uppercase;
+  margin-bottom: 18px;
+}
+
+.persona-intro__headline {
+  font-family: 'Bebas Neue Pro', 'Bebas Neue', sans-serif;
+  font-size: clamp(40px, 6vw, 64px);
+  line-height: 1.0;
+  letter-spacing: 0.02em;
+  color: #ffffff;
+  margin: 0 0 22px;
+  max-width: 720px;
+}
+
+.persona-intro__body {
+  font-family: 'Inter', sans-serif;
+  font-size: 16px;
+  line-height: 1.55;
+  color: rgba(255, 255, 255, 0.72);
+  max-width: 480px;
+  margin: 0 0 36px;
+}
+
+.persona-intro__error {
+  font-family: 'Inter', sans-serif;
+  font-size: 14px;
+  color: #ff6d6d;
+  margin: 12px 0 0;
+  min-height: 1em;
+}

--- a/FrontEnd/static/css/tutorial-progress.css
+++ b/FrontEnd/static/css/tutorial-progress.css
@@ -1,0 +1,82 @@
+/*
+ * FTE v2 tutorial progress indicator — quiet step thread shown at the bottom
+ * of each onboarding screen. Per spec, should not compete with content.
+ */
+
+.tutorial-progress-thread {
+  position: fixed;
+  left: 50%;
+  bottom: 20px;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: rgba(13, 17, 36, 0.78);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(6px);
+  z-index: 50;
+  pointer-events: none;
+}
+
+.tutorial-progress-step {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.tutorial-progress-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.18);
+  transition: background 0.18s ease, transform 0.18s ease;
+}
+
+.tutorial-progress-step.is-complete .tutorial-progress-dot {
+  background: rgba(247, 148, 32, 0.55);
+}
+
+.tutorial-progress-step.is-active .tutorial-progress-dot {
+  background: #F79420;
+  box-shadow: 0 0 0 3px rgba(247, 148, 32, 0.18);
+  transform: scale(1.1);
+}
+
+.tutorial-progress-label {
+  font-family: 'Inter', sans-serif;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.10em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.35);
+  white-space: nowrap;
+}
+
+.tutorial-progress-step.is-active .tutorial-progress-label {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.tutorial-progress-step.is-complete .tutorial-progress-label {
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.tutorial-progress-sep {
+  width: 18px;
+  height: 1px;
+  background: rgba(255, 255, 255, 0.10);
+}
+
+@media (max-width: 640px) {
+  .tutorial-progress-label {
+    display: none;
+  }
+  .tutorial-progress-thread {
+    gap: 6px;
+    padding: 7px 11px;
+  }
+  .tutorial-progress-sep {
+    width: 10px;
+  }
+}

--- a/FrontEnd/static/css/tutorial-tipoff.css
+++ b/FrontEnd/static/css/tutorial-tipoff.css
@@ -1,0 +1,147 @@
+/*
+ * FTE v2 — Pre-Game Tip-off (Screen 3)
+ * Implemented as a canonical Moment modal per Styleguide_updated.md §Modal
+ * System / Moment Modals: full-bleed team banner background, darkening
+ * gradient, outcome (matchup/score) as the visual hero, portrait spotlight,
+ * subtle scale-in. The only green CTA in the entire FTE flow lives here.
+ */
+
+body.tutorial-tipoff-page {
+  background: #0b0d14;
+  margin: 0;
+  min-height: 100vh;
+  font-family: 'Inter', sans-serif;
+  color: #ffffff;
+  overflow: hidden;
+}
+
+.tipoff-stage {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 1;
+}
+
+.tipoff-stage__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.72);
+  z-index: 0;
+}
+
+/* Moment modal box — full-bleed team banner background w/ darkening gradient.
+ * Surface, border, radius, max-width all per Moment Modal canonical spec. */
+.tipoff-moment {
+  position: relative;
+  z-index: 1;
+  width: min(560px, calc(100vw - 32px));
+  background-color: rgba(13, 17, 36, 0.97);
+  background-size: cover;
+  background-position: center center;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 16px;
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+  animation: tipoff-modal-in 200ms ease both;
+}
+
+.tipoff-moment__inner {
+  padding: 28px 28px 24px;
+  text-align: center;
+}
+
+.tipoff-moment__portrait {
+  width: 110px;
+  height: 110px;
+  border-radius: 50%;
+  object-fit: cover;
+  object-position: center top;
+  background: rgba(0, 0, 0, 0.5);
+  border: 3px solid #F79420;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.55);
+  margin: 0 auto 14px;
+  display: block;
+}
+
+.tipoff-moment__eyebrow {
+  font-family: 'Bebas Neue Pro', 'Bebas Neue', sans-serif;
+  font-size: 14px;
+  letter-spacing: 0.18em;
+  color: #F79420;
+  text-transform: uppercase;
+  margin-bottom: 12px;
+  line-height: 1;
+}
+
+.tipoff-moment__score {
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+
+.tipoff-moment__team {
+  font-family: 'Bebas Neue Pro', 'Bebas Neue', sans-serif;
+  font-size: 18px;
+  letter-spacing: 0.04em;
+  color: rgba(255, 255, 255, 0.78);
+  line-height: 1;
+}
+
+.tipoff-moment__num {
+  font-family: 'Bebas Neue Pro', 'Bebas Neue', sans-serif;
+  font-size: 56px;
+  line-height: 0.95;
+  color: #ffffff;
+  text-shadow: 0 2px 12px rgba(0, 0, 0, 0.6);
+}
+
+.tipoff-moment__dash {
+  font-family: 'Inter', sans-serif;
+  font-size: 22px;
+  color: rgba(255, 255, 255, 0.35);
+  margin: 0 4px;
+}
+
+.tipoff-moment__context {
+  margin: 0 0 18px;
+  font-family: 'Inter', sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.tipoff-moment__rally {
+  margin-bottom: 22px;
+  font-family: 'Bebas Neue Pro', 'Bebas Neue', sans-serif;
+  font-size: 30px;
+  letter-spacing: 0.04em;
+  color: #ffffff;
+  line-height: 1.05;
+}
+
+.tipoff-moment__actions {
+  display: flex;
+  justify-content: center;
+}
+
+.tipoff-moment__cta {
+  width: 100%;
+  max-width: 320px;
+}
+
+@keyframes tipoff-modal-in {
+  from { opacity: 0; transform: scale(0.96); }
+  to   { opacity: 1; transform: scale(1.0); }
+}
+
+@media (max-width: 560px) {
+  .tipoff-moment__num { font-size: 44px; }
+  .tipoff-moment__rally { font-size: 24px; }
+  .tipoff-moment__team { font-size: 16px; }
+}

--- a/FrontEnd/static/css/username-modal.css
+++ b/FrontEnd/static/css/username-modal.css
@@ -1,0 +1,96 @@
+/*
+ * Username Functional modal — sits on top of the canonical `gob-modal-*`
+ * chrome (defined in resource-pages.css). Adds the team-linked Sammy
+ * portrait that overlaps the top edge of the modal so the persona stays
+ * warm without breaking the system box.
+ */
+
+/* Allow the portrait to extend above the modal box. */
+.username-modal-box {
+  overflow: visible;
+}
+
+.username-modal-portrait-wrap {
+  position: absolute;
+  top: -56px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 2;
+  pointer-events: none;
+}
+
+.username-modal-portrait {
+  display: block;
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  object-fit: cover;
+  object-position: center top;
+  background: rgba(0, 0, 0, 0.5);
+  border: 3px solid #F79420;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.55);
+}
+
+/* Extra top padding so the title clears the portrait overlap. */
+.username-modal-body {
+  padding-top: 56px;
+  text-align: center;
+}
+
+.username-modal-body .gob-modal-subtitle {
+  margin-top: 6px;
+}
+
+.username-modal-field-wrap {
+  margin-top: 18px;
+  text-align: left;
+}
+
+.username-modal-input {
+  width: 100%;
+  height: 44px;
+  padding: 0 14px;
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  color: #ffffff;
+  font-family: 'Inter', sans-serif;
+  font-size: 15px;
+  letter-spacing: 0.01em;
+  outline: none;
+  transition: border-color 0.14s ease, background 0.14s ease;
+}
+
+.username-modal-input:focus {
+  border-color: rgba(247, 148, 32, 0.7);
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.username-modal-input::placeholder {
+  color: rgba(255, 255, 255, 0.32);
+}
+
+.username-modal-hint {
+  margin: 8px 2px 0;
+  font-family: 'Inter', sans-serif;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.45);
+  letter-spacing: 0.02em;
+}
+
+.username-modal-error {
+  margin: 8px 2px 0;
+  min-height: 1.2em;
+  font-family: 'Inter', sans-serif;
+  font-size: 12px;
+  color: #ff6d6d;
+  letter-spacing: 0.02em;
+}
+
+.username-modal-actions {
+  padding-bottom: 24px;
+}
+
+.username-modal-cta {
+  width: 100%;
+}

--- a/FrontEnd/static/franchise-select-team.css
+++ b/FrontEnd/static/franchise-select-team.css
@@ -95,6 +95,41 @@ input[type="reset"] {
   box-shadow: 0 20px 32px rgba(0, 0, 0, 0.3);
 }
 
+/* FTE v2 — committed selection state. Shown after user taps a card,
+ * before the username modal opens. Orange ring + check badge make the
+ * choice feel registered. */
+.team-card.is-selected {
+  border-color: #F79420;
+  box-shadow: 0 0 0 2px rgba(247, 148, 32, 0.55), 0 20px 32px rgba(0, 0, 0, 0.32);
+}
+
+.team-card-check {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: #F79420;
+  color: #15181f;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'Bebas Neue Pro', 'Bebas Neue', sans-serif;
+  font-size: 18px;
+  line-height: 1;
+  z-index: 3;
+  opacity: 0;
+  transform: scale(0.6);
+  transition: opacity 0.18s ease, transform 0.18s ease;
+  pointer-events: none;
+}
+
+.team-card.is-selected .team-card-check {
+  opacity: 1;
+  transform: scale(1);
+}
+
 .team-card-banner {
   position: relative;
   aspect-ratio: 16 / 9;

--- a/FrontEnd/static/franchise-select-team.html
+++ b/FrontEnd/static/franchise-select-team.html
@@ -11,6 +11,9 @@
   <link rel="icon" type="image/x-icon" href="/images/favicon.ico">
   <title>Choose Your Program</title>
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/resource-pages.css">
+  <link rel="stylesheet" href="/css/gob-buttons.css">
+  <link rel="stylesheet" href="/css/username-modal.css">
   <link rel="stylesheet" href="/franchise-select-team.css">
 </head>
 <body>

--- a/FrontEnd/static/franchise-select-team.js
+++ b/FrontEnd/static/franchise-select-team.js
@@ -102,10 +102,12 @@ function createButtons() {
   teams.forEach(team => {
     const card = document.createElement("div");
     card.className = "team-card";
+    card.dataset.team = team;
     const overlayHtml = `<button class="team-card-action team-card-action-scout" type="button">Scout</button>
        <button class="team-card-action team-card-action-select" type="button">Select</button>`;
     const overlayClass = 'team-card-overlay';
     card.innerHTML = `
+      <div class="team-card-check" aria-hidden="true">✓</div>
       <div class="team-card-banner">
         <img src="${typeof getTeamAssetPath === 'function' ? getTeamAssetPath(team, 'banner_primary') : '/images/teams/general/general_banner_primary.jpg'}" alt="${team}">
         <div class="team-card-tagline">${taglines[team] || team}</div>
@@ -133,6 +135,14 @@ function createButtons() {
       selectBtn.addEventListener("click", () => {
         playSound("click-beep.wav");
         if (TUTORIAL_MODE) {
+          // Visually commit the selection so the choice feels registered
+          // before the username modal opens. Clear prior selections so we
+          // never end up with two highlighted cards if the user changes
+          // their mind in the few hundred ms before the modal appears.
+          if (teamContainer) {
+            teamContainer.querySelectorAll('.team-card.is-selected').forEach(el => el.classList.remove('is-selected'));
+          }
+          card.classList.add('is-selected');
           selectTutorialTeam(team);
         } else {
           selectTeam(team);
@@ -165,17 +175,15 @@ async function selectTutorialTeam(team) {
     return;
   }
 
-  // Step 2: open the username modal with team-aware copy. Use the mascot
-  // (collective noun) so the sentence reads naturally — "the Sterling
-  // Knights", "the Pirates" — instead of grammatically broken "the Lancaster".
-  // Mascot string sourced from team_doc.mascot in the teams collection
-  // (single source of truth), fetched at module load.
+  // Step 2: open the username Functional modal with team-aware chrome.
+  // Mascot drives the title ("YOU'RE COACHING THE STERLING KNIGHTS").
+  // Team name drives the Sammy portrait variant (team-linked kit).
   const mascotMap = await fetchMascotMap();
   const mascot = mascotMap[team] || team;
-  const prompt = `You're now coaching the ${mascot}. What's your username, Coach?`;
   const { openUsernameModal } = await import('/js/shared/usernameModal.js');
   openUsernameModal({
-    prompt,
+    teamName: team,
+    mascot,
     onSuccess: async () => {
       // Step 3: advance to "situation" and navigate to the situation card.
       try {
@@ -233,17 +241,19 @@ document.addEventListener("DOMContentLoaded", function () {
   } catch (e) {}
 
   if (TUTORIAL_MODE) {
-    // Tutorial flow: strict header + a single supporting subhead. No intro
-    // modal (Coach feedback: don't block team selection with a modal).
+    // Tutorial flow: strict header + a single confident, low-stakes subhead.
+    // No intro modal (Coach feedback: don't block team selection with a modal).
     if (backLink) backLink.style.display = 'none';
     const title = document.getElementById('page-title');
     const subtitle = document.getElementById('page-subtitle');
     if (title) title.textContent = 'Pick Your Program';
-    // Existing #page-subtitle styling (Inter 15px, 66% white) already reads
-    // as supporting text. No extra class needed.
     if (subtitle) {
-      subtitle.textContent = "Don't sweat it too much. This is your 'learn the ropes' game — you pick your franchise program after this game.";
+      subtitle.textContent = "This one's your proving ground — a single game to feel out the controls. Your real franchise comes next. Pick whoever speaks to you.";
     }
+    // Mount the quiet 5-step progress thread (Pick Program = step 2 of 5).
+    import('/js/shared/tutorialProgressThread.js')
+      .then(({ mountTutorialProgress }) => mountTutorialProgress('program'))
+      .catch((e) => console.warn('[tutorial] could not mount progress thread:', e));
   } else if (backLink) {
     backLink.addEventListener("click", function (event) {
       event.preventDefault();

--- a/FrontEnd/static/js/shared/authBarInit.js
+++ b/FrontEnd/static/js/shared/authBarInit.js
@@ -31,6 +31,7 @@
     'play-builder-v2.html',
     'play-details.html',
     // FTE v2 tutorial funnel — immersive screens, no auth bar
+    'tutorial-persona-intro.html',
     'tutorial-situation.html',
     // Optional non-.html route variants
     '/box-score',
@@ -138,10 +139,11 @@
   // resume; if the engine ever started, the game restarts from tip.
   function routeToTutorial(meData) {
     if (!meData || meData.fte_v2_complete !== false) return;
-    var state = (meData && meData.tutorial_state) || { step: 'team_select', team_pick: null };
-    var step = state.step || 'team_select';
+    var state = (meData && meData.tutorial_state) || { step: 'persona_intro', team_pick: null };
+    var step = state.step || 'persona_intro';
     var teamPick = state.team_pick;
 
+    var PERSONA_INTRO_URL = '/tutorial-persona-intro.html';
     var TEAM_SELECT_URL = '/franchise-select-team.html?mode=tutorial';
     var SITUATION_URL = '/tutorial-situation.html';
     var currentPath = window.location.pathname;
@@ -156,7 +158,10 @@
 
     var targetPath;
     var targetUrl;
-    if (step === 'team_select' || step === 'username') {
+    if (step === 'persona_intro') {
+      targetPath = '/tutorial-persona-intro.html';
+      targetUrl = PERSONA_INTRO_URL;
+    } else if (step === 'team_select' || step === 'username') {
       targetPath = '/franchise-select-team.html';
       targetUrl = TEAM_SELECT_URL;
     } else if (step === 'situation') {

--- a/FrontEnd/static/js/shared/coachMark.js
+++ b/FrontEnd/static/js/shared/coachMark.js
@@ -1,0 +1,163 @@
+/**
+ * Coach-mark — spotlight tooltip anchored to a DOM element.
+ *
+ * Per spec: distinct from the three modal types. Sits on the page, leaves
+ * the underlying screen visible and interactive, points at the thing it's
+ * talking about.
+ *
+ *   import { showCoachMark } from '/js/shared/coachMark.js';
+ *
+ *   const handle = showCoachMark({
+ *     anchor: document.getElementById('roster-table-container'),
+ *     side: 'left',                    // which edge of anchor to attach to
+ *     offset: 24,                      // gap between anchor and bubble
+ *     eyebrow: 'QUICK TIP',
+ *     body: "I've set a solid lineup for you. ...",
+ *     dismissLabel: 'GOT IT',
+ *     onDismiss: () => {},             // optional
+ *     portraitSrc: '/images/...png',   // optional Sammy headshot
+ *     count: 'Tip 1 of 1',             // optional micro-text
+ *   });
+ *
+ * Returned handle: { close, element }.
+ */
+
+import { GENERIC_SAMMY_IMAGE } from '/js/shared/teamCoachAsset.js';
+
+const STYLESHEET_HREF = '/css/coach-mark.css';
+const GOB_BUTTONS_HREF = '/css/gob-buttons.css';
+
+function ensureStylesheets() {
+  [STYLESHEET_HREF, GOB_BUTTONS_HREF].forEach((href) => {
+    if (document.querySelector(`link[href="${href}"]`)) return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = href;
+    document.head.appendChild(link);
+  });
+}
+
+function positionRelativeTo(bubble, anchor, side, offset) {
+  if (!anchor) {
+    // Fall back to centered placement near the top — better than off-screen.
+    bubble.style.top = '120px';
+    bubble.style.left = '50%';
+    bubble.style.transform = 'translateX(-50%)';
+    return;
+  }
+  const r = anchor.getBoundingClientRect();
+  const scrollX = window.scrollX || 0;
+  const scrollY = window.scrollY || 0;
+  // Use a sensible anchor point on the chosen side of the target element.
+  let top;
+  let left;
+  switch (side) {
+    case 'right':
+      top = r.top + scrollY + 12;
+      left = r.right + scrollX + offset;
+      break;
+    case 'top':
+      top = r.top + scrollY - offset;
+      left = r.left + scrollX + 24;
+      break;
+    case 'bottom':
+      top = r.bottom + scrollY + offset;
+      left = r.left + scrollX + 24;
+      break;
+    case 'left':
+    default:
+      top = r.top + scrollY + 12;
+      left = r.left + scrollX - offset - 360; // 360 = bubble max width
+      break;
+  }
+  // Clamp into the viewport so the bubble never lands off-screen.
+  const maxLeft = window.innerWidth - 380;
+  if (left < 12) left = 12;
+  if (left > maxLeft) left = maxLeft;
+  bubble.style.top = `${Math.max(12, top)}px`;
+  bubble.style.left = `${left}px`;
+}
+
+export function showCoachMark(opts = {}) {
+  if (!opts.body) throw new Error('showCoachMark: body is required');
+  if (!opts.dismissLabel) throw new Error('showCoachMark: dismissLabel is required');
+
+  ensureStylesheets();
+
+  const side = ['left', 'right', 'top', 'bottom'].includes(opts.side) ? opts.side : 'left';
+  const offset = typeof opts.offset === 'number' ? opts.offset : 24;
+  const portrait = opts.portraitSrc || GENERIC_SAMMY_IMAGE;
+
+  const bubble = document.createElement('div');
+  bubble.className = `gob-coachmark gob-coachmark--${side}`;
+  bubble.setAttribute('role', 'dialog');
+  bubble.setAttribute('aria-live', 'polite');
+
+  const portraitImg = document.createElement('img');
+  portraitImg.className = 'gob-coachmark__portrait';
+  portraitImg.src = portrait;
+  portraitImg.alt = '';
+  bubble.appendChild(portraitImg);
+
+  if (opts.eyebrow) {
+    const eyebrow = document.createElement('div');
+    eyebrow.className = 'gob-coachmark__eyebrow';
+    eyebrow.textContent = opts.eyebrow;
+    bubble.appendChild(eyebrow);
+  }
+
+  const body = document.createElement('p');
+  body.className = 'gob-coachmark__body';
+  body.textContent = opts.body;
+  bubble.appendChild(body);
+
+  const foot = document.createElement('div');
+  foot.className = 'gob-coachmark__foot';
+
+  const count = document.createElement('span');
+  count.className = 'gob-coachmark__count';
+  count.textContent = opts.count || '';
+  foot.appendChild(count);
+
+  const dismissBtn = document.createElement('button');
+  dismissBtn.type = 'button';
+  dismissBtn.className = 'gob-btn gob-btn--ghost';
+  dismissBtn.style.height = '34px';
+  dismissBtn.style.minWidth = 'auto';
+  dismissBtn.style.fontSize = '14px';
+  dismissBtn.style.padding = '0 14px';
+  dismissBtn.textContent = opts.dismissLabel;
+  foot.appendChild(dismissBtn);
+
+  bubble.appendChild(foot);
+  document.body.appendChild(bubble);
+
+  positionRelativeTo(bubble, opts.anchor, side, offset);
+
+  // Reposition on resize / scroll so the bubble tracks its anchor.
+  const reposition = () => positionRelativeTo(bubble, opts.anchor, side, offset);
+  window.addEventListener('resize', reposition);
+  window.addEventListener('scroll', reposition, true);
+
+  requestAnimationFrame(() => bubble.classList.add('is-visible'));
+
+  function close() {
+    if (!bubble.parentNode) return;
+    window.removeEventListener('resize', reposition);
+    window.removeEventListener('scroll', reposition, true);
+    bubble.classList.remove('is-visible');
+    setTimeout(() => {
+      if (bubble.parentNode) bubble.parentNode.removeChild(bubble);
+    }, 220);
+  }
+
+  dismissBtn.addEventListener('click', () => {
+    try {
+      if (typeof opts.onDismiss === 'function') opts.onDismiss();
+    } finally {
+      close();
+    }
+  });
+
+  return { close, element: bubble };
+}

--- a/FrontEnd/static/js/shared/teamCoachAsset.js
+++ b/FrontEnd/static/js/shared/teamCoachAsset.js
@@ -1,0 +1,29 @@
+/**
+ * Resolves the per-team Sammy portrait path used in the FTE v2 tutorial flow.
+ *
+ * Assets live at /images/coaches/<abbr>/Sammy-<abbr>.png. The 8 tutorial teams
+ * map to abbreviation folders below. Falls back to the generic Sammy when no
+ * team is provided (Persona Intro step) or when the team isn't in the map.
+ */
+
+const TEAM_COACH_ABBR = {
+  'Bentley-Truman': 'BT',
+  'Four Corners': 'FC',
+  'Lancaster': 'Lan',
+  'Little York': 'LY',
+  'Morristown': 'Mor',
+  'Ocean City': 'OC',
+  'South Lancaster': 'SL',
+  'Xavien': 'Xav',
+};
+
+const GENERIC_SAMMY = '/images/sammy_tutorial.png';
+
+export function getTeamSammyImage(teamName) {
+  if (!teamName) return GENERIC_SAMMY;
+  const abbr = TEAM_COACH_ABBR[teamName];
+  if (!abbr) return GENERIC_SAMMY;
+  return `/images/coaches/${abbr}/Sammy-${abbr}.png`;
+}
+
+export const GENERIC_SAMMY_IMAGE = GENERIC_SAMMY;

--- a/FrontEnd/static/js/shared/tutorialProgressThread.js
+++ b/FrontEnd/static/js/shared/tutorialProgressThread.js
@@ -1,0 +1,71 @@
+/**
+ * Tutorial Progress Thread — quiet 5-step indicator for the FTE v2 funnel.
+ *
+ * Per spec: "a subtle progress indicator across the onboarding steps (quiet
+ * step thread; should not compete with content)."
+ *
+ *   import { mountTutorialProgress } from '/js/shared/tutorialProgressThread.js';
+ *   mountTutorialProgress('username');   // step IDs below
+ *
+ * Steps mirror the user-visible flow, not the backend's TutorialStep enum:
+ *   persona | program | username | tipoff | lineup
+ */
+
+const STEPS = [
+  { id: 'persona', label: 'Persona' },
+  { id: 'program', label: 'Program' },
+  { id: 'username', label: 'Username' },
+  { id: 'tipoff', label: 'Tip-off' },
+  { id: 'lineup', label: 'Lineup' },
+];
+
+const STYLESHEET_HREF = '/css/tutorial-progress.css';
+const HOST_ID = 'tutorial-progress-thread';
+
+function ensureStylesheetLoaded() {
+  if (document.querySelector(`link[href="${STYLESHEET_HREF}"]`)) return;
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = STYLESHEET_HREF;
+  document.head.appendChild(link);
+}
+
+export function mountTutorialProgress(activeStepId) {
+  ensureStylesheetLoaded();
+
+  // Remove a prior instance if any (idempotent — safe to call from any page).
+  const existing = document.getElementById(HOST_ID);
+  if (existing) existing.remove();
+
+  const activeIdx = STEPS.findIndex((s) => s.id === activeStepId);
+  const host = document.createElement('div');
+  host.id = HOST_ID;
+  host.className = 'tutorial-progress-thread';
+  host.setAttribute('role', 'progressbar');
+  host.setAttribute('aria-valuemin', '1');
+  host.setAttribute('aria-valuemax', String(STEPS.length));
+  host.setAttribute('aria-valuenow', String(activeIdx >= 0 ? activeIdx + 1 : 1));
+
+  STEPS.forEach((step, idx) => {
+    const stepEl = document.createElement('div');
+    stepEl.className = 'tutorial-progress-step';
+    if (activeIdx >= 0 && idx < activeIdx) stepEl.classList.add('is-complete');
+    if (idx === activeIdx) stepEl.classList.add('is-active');
+    stepEl.innerHTML = `
+      <span class="tutorial-progress-dot" aria-hidden="true"></span>
+      <span class="tutorial-progress-label">${step.label}</span>
+    `;
+    host.appendChild(stepEl);
+    if (idx < STEPS.length - 1) {
+      const sep = document.createElement('span');
+      sep.className = 'tutorial-progress-sep';
+      sep.setAttribute('aria-hidden', 'true');
+      host.appendChild(sep);
+    }
+  });
+
+  document.body.appendChild(host);
+  return host;
+}
+
+export const TUTORIAL_STEP_IDS = STEPS.map((s) => s.id);

--- a/FrontEnd/static/js/shared/usernameModal.js
+++ b/FrontEnd/static/js/shared/usernameModal.js
@@ -1,27 +1,41 @@
 /**
- * Username Modal — FTE v2 design.
+ * Username Modal — FTE v2 onboarding redesign.
  *
- * Wraps showSammyModal() with username-specific config:
- *   - Validation: 3-24 chars, no spaces, [a-zA-Z0-9_] only
- *   - POST /api/auth/set-username
- *   - On success: update localStorage.auth_user, refresh auth-bar display, close
- *   - On failure: show inline error
+ * Implemented as the canonical Functional modal (`gob-modal-*` chrome,
+ * 3px orange accent bar, Bebas Neue Pro title, Inter subtitle). Team-linked
+ * Sammy portrait overlaps the top edge of the modal so the persona stays
+ * warm without breaking the system box.
  *
- * Replaces the inline username modal previously defined in authBarInit.js
- * (ensureUsernameModal + openUsernameModal). In PR 2b this is invoked by the
- * legacy FTE v1 entry path; in PR 2c it'll also be the username step of the
- * new tutorial funnel.
+ * Primary CTA is the canonical `.gob-btn--action` (orange) — per the
+ * styleguide's Action Color rules, naming yourself is a non-gating action
+ * (configures a preference; doesn't advance game state). Previously this
+ * button was green, which was incorrect.
  *
  * Usage:
  *   import { openUsernameModal } from '/js/shared/usernameModal.js';
- *   openUsernameModal({ onSuccess: () => { ... } });
+ *
+ *   openUsernameModal({
+ *     teamName: 'Bentley-Truman',           // optional — drives Sammy portrait
+ *     mascot: 'Sterling Knights',           // optional — drives title
+ *     onSuccess: () => navigate(...),
+ *   });
+ *
+ * Legacy `prompt` field is no longer used (the new design swaps the
+ * sentence-prompt for a structured Title + Subtitle). Callers that still
+ * pass `prompt` are silently ignored — they'll get the default subtitle.
  */
 
-import { showSammyModal } from '/js/shared/sammyModal.js';
+import { getTeamSammyImage } from '/js/shared/teamCoachAsset.js';
+import { mountTutorialProgress } from '/js/shared/tutorialProgressThread.js';
 
-
-const USERNAME_HINT = '3-24 characters. Letters, numbers, and underscores only — no spaces.';
-const DEFAULT_USERNAME_PROMPT = 'Choose a username, Coach.';
+const USERNAME_HINT = '3–24 characters · letters, numbers, underscores';
+const DEFAULT_SUBTITLE = "Every coach in GOB needs a username. What should the league call you?";
+const STYLESHEET_HREFS = [
+  // Canonical `.gob-modal-*` classes used by every Functional modal.
+  '/resource-pages.css',
+  '/css/gob-buttons.css',
+  '/css/username-modal.css',
+];
 
 
 function validateUsername(value) {
@@ -42,73 +56,161 @@ function persistUsernameLocally(username) {
       user.username = username;
       localStorage.setItem('auth_user', JSON.stringify(user));
     }
-  } catch (_) {
-    // Best-effort; ignore parse/storage failures.
-  }
+  } catch (_) { /* best-effort */ }
   const emailDisplay = document.getElementById('auth-user-email');
   if (emailDisplay) emailDisplay.textContent = username;
 }
 
 
+function ensureStylesheets() {
+  STYLESHEET_HREFS.forEach((href) => {
+    if (document.querySelector(`link[href="${href}"]`)) return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = href;
+    document.head.appendChild(link);
+  });
+}
+
+
 /**
- * Open the username modal.
  * @param {Object} opts
- * @param {Function} [opts.onSuccess]  - called after the username is persisted server-side
- * @param {string}   [opts.prompt]     - override the default body copy (e.g., tutorial flow)
- * @returns {{ close: Function }}      - handle to dismiss the modal early if needed
+ * @param {string}   [opts.teamName]   — drives Sammy portrait variant
+ * @param {string}   [opts.mascot]     — drives title ("YOU'RE COACHING THE …")
+ * @param {Function} [opts.onSuccess]  — called after username is persisted server-side
+ * @returns {{ close: Function }}
  */
 export function openUsernameModal(opts = {}) {
   const onSuccess = typeof opts.onSuccess === 'function' ? opts.onSuccess : null;
-  const prompt = typeof opts.prompt === 'string' && opts.prompt.trim()
-    ? opts.prompt
-    : DEFAULT_USERNAME_PROMPT;
+  const mascotText = (opts.mascot || '').trim();
+  const titleText = mascotText
+    ? `YOU'RE COACHING THE ${mascotText.toUpperCase()}`
+    : 'CHOOSE A USERNAME';
+  const sammySrc = getTeamSammyImage(opts.teamName);
 
-  const handle = showSammyModal({
-    body: prompt,
-    ctaLabel: 'Continue',
-    dismissOnCta: false,  // we control dismissal — wait for API success
-    input: {
-      placeholder: 'Username',
-      hint: USERNAME_HINT,
-      validate: validateUsername,
-    },
-    onCta: async (username) => {
-      const trimmed = (username || '').trim();
+  ensureStylesheets();
+  // Username step of the funnel — quiet progress thread updates.
+  try { mountTutorialProgress('username'); } catch (_) { /* non-fatal */ }
 
-      // Fallback when API_CONFIG isn't loaded (e.g., on a public-only page) —
-      // dismiss without making the request so the caller isn't stranded.
-      if (typeof API_CONFIG === 'undefined' ||
-          typeof API_CONFIG.buildUrl !== 'function' ||
-          typeof API_CONFIG.getAuthHeaders !== 'function') {
-        handle.close();
-        if (onSuccess) onSuccess();
-        return;
-      }
+  const overlay = document.createElement('div');
+  overlay.className = 'gob-modal-overlay';
+  overlay.setAttribute('role', 'dialog');
+  overlay.setAttribute('aria-modal', 'true');
 
-      let res;
-      let data;
-      try {
-        res = await fetch(API_CONFIG.buildUrl('/api/auth/set-username'), {
-          method: 'POST',
-          headers: Object.assign({ 'Content-Type': 'application/json' }, API_CONFIG.getAuthHeaders()),
-          body: JSON.stringify({ username: trimmed }),
-        });
-        data = await res.json();
-      } catch (_) {
-        handle.setError('Something went wrong. Try again.');
-        return;
-      }
+  overlay.innerHTML = `
+    <div class="gob-modal-backdrop"></div>
+    <div class="gob-modal-box username-modal-box">
+      <div class="username-modal-portrait-wrap" aria-hidden="true">
+        <img class="username-modal-portrait" src="${sammySrc}" alt="">
+      </div>
+      <div class="gob-modal-accent"></div>
+      <div class="gob-modal-body username-modal-body">
+        <div class="gob-modal-title">${titleText}</div>
+        <p class="gob-modal-subtitle">${DEFAULT_SUBTITLE}</p>
+        <div class="username-modal-field-wrap">
+          <input
+            type="text"
+            class="username-modal-input"
+            id="username-modal-input"
+            placeholder="Username"
+            autocomplete="off"
+            spellcheck="false"
+            maxlength="24"
+            aria-label="Username"
+          >
+          <p class="username-modal-hint">${USERNAME_HINT}</p>
+          <p class="username-modal-error" id="username-modal-error" aria-live="polite"></p>
+        </div>
+      </div>
+      <div class="gob-modal-actions username-modal-actions">
+        <button type="button" class="gob-btn gob-btn--action username-modal-cta" id="username-modal-cta">CONTINUE</button>
+      </div>
+    </div>
+  `;
 
-      if (!res.ok) {
-        handle.setError((data && data.detail) || 'This username is already taken');
-        return;
-      }
+  document.body.appendChild(overlay);
+  // Force reflow so the .is-visible transition runs.
+  // eslint-disable-next-line no-unused-expressions
+  overlay.offsetHeight;
+  overlay.classList.add('is-visible');
 
-      persistUsernameLocally(data.username);
-      handle.close();
+  const inputEl = overlay.querySelector('#username-modal-input');
+  const errorEl = overlay.querySelector('#username-modal-error');
+  const ctaBtn = overlay.querySelector('#username-modal-cta');
+
+  function setError(msg) {
+    if (errorEl) errorEl.textContent = msg || '';
+  }
+
+  function setBusy(busy) {
+    if (ctaBtn) ctaBtn.disabled = !!busy;
+    if (inputEl) inputEl.disabled = !!busy;
+  }
+
+  function close() {
+    if (!overlay.parentNode) return;
+    overlay.classList.remove('is-visible');
+    setTimeout(() => {
+      if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+    }, 180);
+  }
+
+  async function submit() {
+    const value = (inputEl?.value || '').trim();
+    const err = validateUsername(value);
+    if (err) {
+      setError(err);
+      inputEl?.focus();
+      return;
+    }
+    setError('');
+
+    // Public-only fallback — if API isn't loaded, just succeed locally.
+    if (typeof API_CONFIG === 'undefined' ||
+        typeof API_CONFIG.buildUrl !== 'function' ||
+        typeof API_CONFIG.getAuthHeaders !== 'function') {
+      close();
       if (onSuccess) onSuccess();
-    },
-  });
+      return;
+    }
 
-  return handle;
+    setBusy(true);
+    let res;
+    let data;
+    try {
+      res = await fetch(API_CONFIG.buildUrl('/api/auth/set-username'), {
+        method: 'POST',
+        headers: { ...API_CONFIG.getAuthHeaders(), 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username: value }),
+      });
+      data = await res.json().catch(() => ({}));
+    } catch (_) {
+      setBusy(false);
+      setError('Something went wrong. Try again.');
+      return;
+    }
+
+    if (!res.ok) {
+      setBusy(false);
+      setError((data && data.detail) || 'This username is already taken');
+      return;
+    }
+
+    persistUsernameLocally(data.username);
+    close();
+    if (onSuccess) onSuccess();
+  }
+
+  if (ctaBtn) ctaBtn.addEventListener('click', submit);
+  if (inputEl) {
+    inputEl.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        submit();
+      }
+    });
+    setTimeout(() => inputEl.focus(), 0);
+  }
+
+  return { close };
 }

--- a/FrontEnd/static/set-lineup.css
+++ b/FrontEnd/static/set-lineup.css
@@ -758,6 +758,24 @@ body.set-lineup-page .resource-page-container.fcc-brand-page-shell.set-lineup-sh
   font-weight: 700;
 }
 
+/*
+ * Per Styleguide §Color System → Attribute Bar Scale, color the player
+ * rating display by tier so users can scan strength at a glance. Same
+ * thresholds as the attribute pills throughout the product.
+ *   0–40  red       41–60 yellow    61–80 green    81+   light blue
+ * Both .inline-rt (roster row) and .player-rating (slot) share buckets.
+ */
+.inline-rt.rt-low,
+.player-rating.rt-low      { color: #ff6d6d; }
+.inline-rt.rt-mid,
+.player-rating.rt-mid      { color: #FFD700; }
+.inline-rt.rt-high,
+.player-rating.rt-high     { color: #34EC27; }
+.inline-rt.rt-elite,
+.player-rating.rt-elite    { color: #4A90D9; }
+.inline-rt.rt-unknown,
+.player-rating.rt-unknown  { color: rgba(255, 255, 255, 0.4); }
+
 .roster-table tr.selected td,
 .roster-stats-table tr.selected td {
   background: rgba(255,255,255,0.03) !important;

--- a/FrontEnd/static/set-lineup.js
+++ b/FrontEnd/static/set-lineup.js
@@ -322,6 +322,18 @@ function getRT(player) {
   return ratings.length ? Math.max(...ratings) : -Infinity;
 }
 
+// Canonical Attribute Bar Scale (Styleguide §Color System):
+//   0–40 red · 41–60 yellow · 61–80 green · 81+ light blue (incl. 100+)
+// Returns a CSS class suffix; caller applies as `rt-${bucket}`.
+function getRtBucketClass(rt) {
+  const v = Number(rt);
+  if (!Number.isFinite(v)) return 'rt-unknown';
+  if (v <= 40) return 'rt-low';
+  if (v <= 60) return 'rt-mid';
+  if (v <= 80) return 'rt-high';
+  return 'rt-elite';
+}
+
 function showToast(msg) {
   const toast = document.getElementById('toast');
   if (!toast) return;
@@ -1051,7 +1063,7 @@ function renderRosterAttributes() {
         nameText.textContent = val ?? '--';
         nameText.className = 'player-name-link';
         const rtSpan = document.createElement('span');
-        rtSpan.className = 'inline-rt';
+        rtSpan.className = `inline-rt ${getRtBucketClass(rt)}`;
         rtSpan.textContent = rt ?? '--';
         wrap.appendChild(nameText);
         wrap.appendChild(rtSpan);
@@ -1466,7 +1478,7 @@ function updateSlotDisplay(slot) {
       <div class="slot-info">
         <div class="slot-row-1">
           <div class="player-name">${slotDisplayName}</div>
-          <div class="player-rating">RT: ${rating}</div>
+          <div class="player-rating ${getRtBucketClass(rating)}">RT: ${rating}</div>
         </div>
         <div class="slot-row-2">
           <div class="slot-stat slot-stat-momentum">
@@ -2033,23 +2045,49 @@ async function init() {
   // lineup is in the URL (restoreLineupFromUrl populates it above). We do NOT
   // call autoset here — the engine assigned the tutorial-roster starters
   // (rank_roster + Section 5 templates) and we want to honor that exactly.
-  // Show the Sammy intro modal ONCE per tutorial run (keyed by game_id so
-  // a re-entry from game-plan or a page reload doesn't re-fire it).
+  //
+  // Onboarding redesign: replaces the previous centered "I've set your
+  // lineup" Sammy modal with a coach-mark spotlight anchored to the roster.
+  // Coach-marks are their own guidance pattern (per styleguide), distinct
+  // from the three modal types — they leave the screen visible so the
+  // copy points at the very thing it's describing.
   if (modeParam === 'tutorial') {
     const introKey = gameId
-      ? `fteV2TutorialLineupIntroShown_${gameId}`
-      : 'fteV2TutorialLineupIntroShown';
+      ? `fteV2TutorialLineupCoachMarkShown_${gameId}`
+      : 'fteV2TutorialLineupCoachMarkShown';
     const alreadyShown = (() => {
       try { return sessionStorage.getItem(introKey) === '1'; } catch (_) { return false; }
     })();
     if (!alreadyShown) {
       try { sessionStorage.setItem(introKey, '1'); } catch (_) {}
-      import('/js/shared/sammyModal.js').then(({ showSammyModal }) => {
-        showSammyModal({
-          body: "I've set your lineup — tweak it if you like, and hover any attribute to see what it means.",
-          ctaLabel: 'Got it',
+      // Resolve the team-linked Sammy portrait. `homeTeam` here is the
+      // user's team (per fte_inject_state §1-§2, user is always home).
+      Promise.all([
+        import('/js/shared/coachMark.js'),
+        import('/js/shared/teamCoachAsset.js'),
+        import('/js/shared/tutorialProgressThread.js'),
+      ]).then(([{ showCoachMark }, { getTeamSammyImage }, { mountTutorialProgress }]) => {
+        mountTutorialProgress('lineup');
+        // Wait one frame for the roster to render before anchoring.
+        requestAnimationFrame(() => {
+          showCoachMark({
+            anchor: document.getElementById('roster-table-container'),
+            side: 'right',
+            offset: 18,
+            eyebrow: 'QUICK TIP',
+            body: "I've set a solid lineup for you. Hover any attribute to learn what it does — then tweak the lineup if you want.",
+            dismissLabel: 'GOT IT',
+            portraitSrc: getTeamSammyImage(homeTeam),
+            count: 'Tip 1 of 1',
+          });
         });
-      }).catch((e) => console.warn('[tutorial] could not load sammyModal:', e));
+      }).catch((e) => console.warn('[tutorial] could not show lineup coach-mark:', e));
+    } else {
+      // Re-entry (return from game-plan, timeout-resume, etc.) — keep the
+      // progress thread present but don't re-show the tip.
+      import('/js/shared/tutorialProgressThread.js')
+        .then(({ mountTutorialProgress }) => mountTutorialProgress('lineup'))
+        .catch(() => {});
     }
   }
 

--- a/FrontEnd/static/tutorial-persona-intro.html
+++ b/FrontEnd/static/tutorial-persona-intro.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager (production only) -->
+  <script src="/js/shared/gtm-loader.js"></script>
+  <!-- End Google Tag Manager -->
+  <script src="/js/shared/authGuard.js"></script>
+  <script src="/js/shared/sentryInit.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/x-icon" href="/images/favicon.ico">
+  <title>Welcome, Coach</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/css/gob-buttons.css">
+  <link rel="stylesheet" href="/css/tutorial-persona-intro.css">
+</head>
+<body class="tutorial-persona-page">
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K69GQK3D"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+
+  <main class="persona-intro">
+    <img class="persona-intro__portrait" src="/images/sammy_tutorial.png" alt="Sammy, your assistant coach">
+    <div class="persona-intro__name">Sammy · Assistant Coach</div>
+    <h1 class="persona-intro__headline">Welcome to GOB, Coach.<br>I'll get you set up.</h1>
+    <p class="persona-intro__body">One quick game to learn the ropes — then you build your own program. I'll be right here the whole way.</p>
+    <button id="persona-intro-cta" type="button" class="gob-btn gob-btn--action gob-btn--lg">LET'S GO</button>
+    <p id="persona-intro-error" class="persona-intro__error" aria-live="polite"></p>
+  </main>
+
+  <script src="/js/config/api-config.js"></script>
+  <script type="module" src="/tutorial-persona-intro.js"></script>
+</body>
+</html>

--- a/FrontEnd/static/tutorial-persona-intro.js
+++ b/FrontEnd/static/tutorial-persona-intro.js
@@ -1,0 +1,64 @@
+/**
+ * Tutorial Persona Intro — Screen 0 of the FTE v2 funnel.
+ *
+ * First time the user meets Sammy. Only screen where Sammy appears in the
+ * generic white-kit portrait — every subsequent screen uses the team-linked
+ * variant via teamCoachAsset.js.
+ *
+ * Flow: LET'S GO → POST /api/auth/tutorial-advance { step: 'team_select' } →
+ * navigate to /franchise-select-team.html?mode=tutorial.
+ */
+
+import { mountTutorialProgress } from '/js/shared/tutorialProgressThread.js';
+
+const ctaBtn = document.getElementById('persona-intro-cta');
+const errorEl = document.getElementById('persona-intro-error');
+
+mountTutorialProgress('persona');
+
+function showError(msg) {
+  if (errorEl) errorEl.textContent = msg || '';
+}
+
+async function advanceToTeamSelect() {
+  if (typeof API_CONFIG === 'undefined' ||
+      typeof API_CONFIG.buildUrl !== 'function' ||
+      typeof API_CONFIG.getAuthHeaders !== 'function') {
+    // Public-only page guard — let the user move forward; the team-select
+    // page will handle its own auth state.
+    return true;
+  }
+  try {
+    const res = await fetch(API_CONFIG.buildUrl('/api/auth/tutorial-advance'), {
+      method: 'POST',
+      headers: { ...API_CONFIG.getAuthHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({ step: 'team_select' }),
+    });
+    if (!res.ok) {
+      console.warn('[tutorial][persona-intro] advance failed:', res.status);
+      // Don't block the user — they can still complete the flow; server state
+      // will be reconciled on the next step.
+      return true;
+    }
+    return true;
+  } catch (e) {
+    console.warn('[tutorial][persona-intro] advance threw:', e);
+    return true;
+  }
+}
+
+if (ctaBtn) {
+  ctaBtn.addEventListener('click', async () => {
+    if (ctaBtn.disabled) return;
+    ctaBtn.disabled = true;
+    showError('');
+    try {
+      await advanceToTeamSelect();
+      window.location.href = '/franchise-select-team.html?mode=tutorial';
+    } catch (e) {
+      console.error('[tutorial][persona-intro]', e);
+      showError('Something went wrong. Please try again.');
+      ctaBtn.disabled = false;
+    }
+  });
+}

--- a/FrontEnd/static/tutorial-situation.html
+++ b/FrontEnd/static/tutorial-situation.html
@@ -9,27 +9,44 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" type="image/x-icon" href="/images/favicon.ico">
-  <title>The Situation, Coach</title>
-  <link rel="stylesheet" href="/css/sammy-modal.css">
-  <style>
-    /* Dark backdrop; the situation modal renders on top via sammyModal. */
-    html, body {
-      margin: 0;
-      padding: 0;
-      min-height: 100vh;
-      background: radial-gradient(ellipse at center, #1a2042 0%, #0a0d1c 70%);
-      background-attachment: fixed;
-      font-family: 'Inter', sans-serif;
-    }
-  </style>
+  <title>Crunch Time, Coach</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/css/gob-buttons.css">
+  <link rel="stylesheet" href="/css/tutorial-tipoff.css">
 </head>
-<body>
+<body class="tutorial-tipoff-page">
   <!-- Google Tag Manager (noscript) -->
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K69GQK3D"
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
 
+  <!-- Tip-off Moment modal. Rendered/populated by tutorial-situation.js once
+       team_pick is known so we can set the correct banner background, score,
+       and team-linked Sammy portrait. -->
+  <div class="tipoff-stage" id="tipoff-stage">
+    <div class="tipoff-stage__backdrop"></div>
+    <div class="tipoff-moment" id="tipoff-moment" role="dialog" aria-modal="true" hidden>
+      <div class="tipoff-moment__inner">
+        <img class="tipoff-moment__portrait" id="tipoff-portrait" src="/images/sammy_tutorial.png" alt="">
+        <div class="tipoff-moment__eyebrow">CRUNCH TIME · Q4</div>
+        <div class="tipoff-moment__score">
+          <span class="tipoff-moment__team" id="tipoff-home-team">HOME</span>
+          <span class="tipoff-moment__num" id="tipoff-home-score">60</span>
+          <span class="tipoff-moment__dash">–</span>
+          <span class="tipoff-moment__num" id="tipoff-away-score">60</span>
+          <span class="tipoff-moment__team" id="tipoff-away-team">AWAY</span>
+        </div>
+        <p class="tipoff-moment__context">Tied with four minutes left. The game's in your hands now.</p>
+        <div class="tipoff-moment__rally">GO WIN IT, COACH.</div>
+        <div class="tipoff-moment__actions">
+          <button id="tipoff-cta" type="button" class="gob-btn gob-btn--gate gob-btn--lg tipoff-moment__cta">SET LINEUP</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <script src="/js/config/api-config.js"></script>
+  <script src="/common.js"></script>
   <script type="module" src="/tutorial-situation.js"></script>
 </body>
 </html>

--- a/FrontEnd/static/tutorial-situation.js
+++ b/FrontEnd/static/tutorial-situation.js
@@ -1,34 +1,41 @@
 /**
- * Tutorial Situation Card — step 3 of the FTE v2 funnel.
+ * Tutorial Tip-off — Screen 3 of the FTE v2 funnel.
+ *
+ * Redesigned per the FTE Onboarding Redesign: rendered as a canonical Moment
+ * modal (full-bleed team banner background + score-as-hero + portrait
+ * spotlight) instead of the previous Sammy card on a radial navy background.
+ * This is the *one* screen in the flow where the primary CTA is green —
+ * SET LINEUP genuinely advances game state.
  *
  * Flow:
- *   1. Fetch /api/auth/me to read tutorial_state.team_pick (user's picked team)
- *   2. Derive opponent: Xavien, unless user picked Xavien (then South Lancaster)
- *   3. Show Sammy modal with the situation copy
- *   4. CTA: POST /api/auth/tutorial-advance { step: "set_lineup" } and
- *      navigate to /set-lineup.html?mode=tutorial&home=<user>&away=<opp>&my_team=home
+ *   1. Fetch /api/auth/me → team_pick
+ *   2. Derive opponent (Xavien default; South Lancaster if user is Xavien)
+ *   3. Render the Moment modal with the user's banner background + team Sammy
+ *   4. SET LINEUP → POST /api/init-game (mode=tutorial) → tutorial-advance →
+ *      navigate to /set-lineup.html?mode=tutorial&...&quarter=4
  *
- * Per fte_inject_state.md §1-§2, the user is always HOME in the tutorial game.
+ * Per fte_inject_state.md §1-§2 the user is always HOME in the tutorial game.
  */
 
-import { showSammyModal } from '/js/shared/sammyModal.js';
-
+import { getTeamSammyImage } from '/js/shared/teamCoachAsset.js';
+import { mountTutorialProgress } from '/js/shared/tutorialProgressThread.js';
 
 const DEFAULT_OPPONENT = 'Xavien';
 const XAVIEN_FALLBACK_OPPONENT = 'South Lancaster';
 
+mountTutorialProgress('tipoff');
 
 function deriveOpponent(userTeam) {
   if (!userTeam) return DEFAULT_OPPONENT;
   return userTeam === DEFAULT_OPPONENT ? XAVIEN_FALLBACK_OPPONENT : DEFAULT_OPPONENT;
 }
 
-
-function situationBody(opponent) {
-  // Copy locked by Coach. En-dash (–) between scores, not a hyphen.
-  return `You're playing against ${opponent}. Tied 60–60. 4 minutes left in the 4th quarter. Go win it, Coach!`;
+function resolveTeamBanner(teamName) {
+  if (typeof getTeamAssetPath === 'function') {
+    return getTeamAssetPath(teamName, 'banner_primary');
+  }
+  return '/images/teams/general/general_banner_primary.jpg';
 }
-
 
 async function fetchMe() {
   if (typeof API_CONFIG === 'undefined' ||
@@ -44,7 +51,6 @@ async function fetchMe() {
   return res.json();
 }
 
-
 async function advanceToSetLineup() {
   try {
     await fetch(API_CONFIG.buildUrl('/api/auth/tutorial-advance'), {
@@ -54,15 +60,9 @@ async function advanceToSetLineup() {
     });
   } catch (e) {
     console.warn('[tutorial] could not advance to set_lineup step:', e);
-    // Continue anyway — server state can be recovered on the next page.
   }
 }
 
-
-// Returns { game_id, home_lineup: { PG, SG, SF, PF, C } } or null on failure.
-// home_lineup is the engine-assigned starting 5 (rank_roster output) which the
-// situation page passes forward as URL params so set-lineup pre-populates with
-// the right players. Backend returns this in the response body when mode=tutorial.
 async function initTutorialGame(userTeam, opponent) {
   try {
     const res = await fetch(API_CONFIG.buildUrl('/api/init-game'), {
@@ -93,23 +93,13 @@ async function initTutorialGame(userTeam, opponent) {
   }
 }
 
-
 function gotoSetLineup(userTeam, opponent, gameId, lineup) {
-  // quarter=4 is critical: without it, set-lineup's module-level `quarter`
-  // defaults to 1, and the /api/game fetch passes ?quarter=1 — which the
-  // backend treats as a "new game scenario" (request Q1 + saved Q4) and
-  // returns empty stats. With quarter=4 in the URL, the fetch returns the
-  // real Q4 60-60 state populated by apply_tutorial_initial_state.
   const params = new URLSearchParams({
     mode: 'tutorial',
     home: userTeam,
     away: opponent,
     my_team: 'home',
     quarter: '4',
-    // team_id is the user team name. Single-mode game-plan / playbooks
-    // endpoints resolve it via gm.home_team.name == team_id fallback
-    // (gameplan_routes.py). Without this, game-plan can't compute
-    // team_id from the URL (no home_id/team_id present in tutorial nav).
     team_id: userTeam,
   });
   if (gameId) params.set('game_id', gameId);
@@ -119,6 +109,30 @@ function gotoSetLineup(userTeam, opponent, gameId, lineup) {
   window.location.href = `/set-lineup.html?${params.toString()}`;
 }
 
+function paintMoment(userTeam, opponent) {
+  const banner = resolveTeamBanner(userTeam);
+  // Apply banner + darkening gradient to the modal box (Moment modal spec).
+  const moment = document.getElementById('tipoff-moment');
+  if (moment) {
+    moment.style.backgroundImage = `linear-gradient(
+        to bottom,
+        rgba(13,17,36,0.15) 0%,
+        rgba(13,17,36,0.55) 45%,
+        rgba(13,17,36,0.92) 78%,
+        rgba(13,17,36,0.98) 100%
+      ), url('${banner}')`;
+    moment.hidden = false;
+  }
+  const portraitEl = document.getElementById('tipoff-portrait');
+  if (portraitEl) portraitEl.src = getTeamSammyImage(userTeam);
+
+  // Score block. User team is always home (per fte_inject_state §1-§2) and
+  // the visual hero shows the matchup; we use uppercase team names per spec.
+  const homeTeamEl = document.getElementById('tipoff-home-team');
+  const awayTeamEl = document.getElementById('tipoff-away-team');
+  if (homeTeamEl) homeTeamEl.textContent = userTeam.toUpperCase();
+  if (awayTeamEl) awayTeamEl.textContent = opponent.toUpperCase();
+}
 
 async function main() {
   let me;
@@ -126,31 +140,25 @@ async function main() {
     me = await fetchMe();
   } catch (e) {
     console.error('[tutorial] failed to load /api/auth/me:', e);
-    // Show a degraded fallback so the user isn't stuck on a black screen.
-    showSammyModal({
-      eyebrow: 'Hmm',
-      body: 'We had trouble loading your tutorial. Please refresh the page.',
-      ctaLabel: 'Reload',
-      dismissOnCta: false,
-      onCta: () => window.location.reload(),
-    });
+    document.body.innerHTML = '<div style="padding:40px;text-align:center;color:#fff;font-family:Inter,sans-serif;">We had trouble loading your tutorial. Please refresh.</div>';
     return;
   }
 
   const teamPick = me?.tutorial_state?.team_pick;
   if (!teamPick) {
-    // No team picked yet — bounce back to team-select.
     window.location.replace('/franchise-select-team.html?mode=tutorial');
     return;
   }
 
   const opponent = deriveOpponent(teamPick);
+  paintMoment(teamPick, opponent);
 
-  showSammyModal({
-    body: situationBody(opponent),
-    ctaLabel: 'Set Lineup',
-    dismissOnCta: false,
-    onCta: async () => {
+  const ctaBtn = document.getElementById('tipoff-cta');
+  if (!ctaBtn) return;
+  ctaBtn.addEventListener('click', async () => {
+    if (ctaBtn.disabled) return;
+    ctaBtn.disabled = true;
+    try {
       // Order matters: init-game first (the heaviest call; without it,
       // set-lineup has nothing to display). The response includes the
       // engine-assigned lineup (rank_roster output) so we don't need a
@@ -159,13 +167,16 @@ async function main() {
       if (!init || !init.game_id) {
         console.error('[tutorial] init-game returned no game_id');
         window.alert('Could not start the tutorial game. Please refresh and try again.');
+        ctaBtn.disabled = false;
         return;
       }
       await advanceToSetLineup();
       gotoSetLineup(teamPick, opponent, init.game_id, init.home_lineup || {});
-    },
+    } catch (e) {
+      console.error('[tutorial] tip-off cta failed:', e);
+      ctaBtn.disabled = false;
+    }
   });
 }
-
 
 main();

--- a/_documentation_master/07_Design_Systems/FTE Onboarding Redesign.html
+++ b/_documentation_master/07_Design_Systems/FTE Onboarding Redesign.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>GOB — FTE Onboarding Redesign</title>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="fte/base.css">
+<link rel="stylesheet" href="fte/screens.css">
+</head>
+<body>
+
+<div id="stage" class="gob-shell">
+
+  <!-- ============================================================
+       SCREEN 0 — Persona intro  (NEW)
+       ============================================================ -->
+  <section class="screen" data-screen-label="00 Intro">
+    <div class="screen-inner">
+      <div class="intro">
+        <div class="coach-avatar coach-avatar--xl">
+          <span class="coach-avatar__ph">SAMMY<br><span style="opacity:.65">generic ·<br>white kit</span></span>
+        </div>
+        <div class="intro__name">SAMMY · ASSISTANT COACH</div>
+        <div class="intro__line">Welcome to GOB, Coach.<br>I'll get you set up.</div>
+        <p class="intro__sub">One quick game to learn the ropes — then you build your own program. I'll be right here the whole way.</p>
+        <button class="gob-btn gob-btn--action gob-btn--lg" data-go="1">LET'S GO</button>
+      </div>
+
+      <div class="note note--bl" style="top:24px; left:24px;">
+        <span class="note__t">NEW: PERSONA INTRO</span>
+        First and only time we use the <b>generic Sammy</b> (white practice kit) — she has no team yet. Introducing her once, named, makes every later appearance feel intentional instead of random.
+      </div>
+      <div class="note note--tr" style="bottom:120px; right:24px;">
+        <span class="note__t">ORANGE, NOT GREEN</span>
+        "Let's go" doesn't advance game state — it's a non-gating primary, so it's orange per your action-color rules. Green is saved for the tip-off.
+      </div>
+    </div>
+  </section>
+
+  <!-- ============================================================
+       SCREEN 1 — Pick Your Program
+       ============================================================ -->
+  <section class="screen" data-screen-label="01 Pick Program">
+    <div class="screen-inner">
+      <div class="pick" id="pick-grid-wrap">
+        <div class="pick__head">
+          <div class="pick__title">PICK YOUR PROGRAM</div>
+          <p class="pick__sub">This one's your proving ground — a single game to feel out the controls. Your real franchise comes next. Pick whoever speaks to you.</p>
+        </div>
+        <div class="pick__grid" id="team-grid"></div>
+      </div>
+
+      <div class="note note--tl" style="top:24px; left:24px;">
+        <span class="note__t">COPY: LESS HEDGING</span>
+        "Don't sweat it too much" apologizes for the screen. "Your proving ground" frames the same low-stakes idea as something with intent.
+      </div>
+      <div class="note note--tr" style="top:24px; right:24px;">
+        <span class="note__t">SELECTION STATE</span>
+        Cards now have a real selected state (orange ring + check) so the choice feels committed before the modal opens.
+      </div>
+    </div>
+  </section>
+
+  <!-- ============================================================
+       SCREEN 2 — Username  (FUNCTIONAL MODAL, on-system)
+       ============================================================ -->
+  <section class="screen" data-screen-label="02 Username">
+    <div class="screen-inner">
+      <div class="pick pick--dim">
+        <div class="pick__head">
+          <div class="pick__title">PICK YOUR PROGRAM</div>
+          <p class="pick__sub">This one's your proving ground — a single game to feel out the controls.</p>
+        </div>
+        <div class="pick__grid" id="team-grid-dim"></div>
+      </div>
+
+      <div class="gob-modal-overlay is-visible" style="position:absolute;">
+        <div class="gob-modal-backdrop"></div>
+        <div class="gob-modal-box" style="overflow:visible;">
+          <div class="uname-coach">
+            <div class="coach-avatar coach-avatar--team"><span class="coach-avatar__ph">SAMMY<br><span style="opacity:.65">Minute<br>Men kit</span></span></div>
+          </div>
+          <div class="gob-modal-accent" style="border-radius:14px 14px 0 0;"></div>
+          <div class="gob-modal-body" style="padding-top:60px;">
+            <div class="gob-modal-title">YOU'RE COACHING THE MINUTEMEN</div>
+            <p class="gob-modal-subtitle">Every coach in GOB needs a username. What should the league call you?</p>
+            <div style="margin-top:18px;">
+              <input class="gob-field" type="text" placeholder="Username" aria-label="Username">
+              <div class="gob-field-help">3–24 characters · letters, numbers, underscores</div>
+            </div>
+          </div>
+          <div class="gob-modal-actions">
+            <button class="gob-btn gob-btn--action gob-btn-primary" data-go="3" style="flex:1;">CONTINUE</button>
+          </div>
+        </div>
+      </div>
+
+      <div class="note note--tl" style="top:24px; left:24px; max-width:268px;">
+        <span class="note__t">SAMMY NOW WEARS YOUR COLORS</span>
+        From this screen on, Sammy's portrait switches to the <b>team-linked</b> version (Minute Men kit — note the purple ring) and stays that way for the rest of the tutorial. A small touch that makes the choice feel real.
+      </div>
+      <div class="note note--bl" style="bottom:60px; left:24px;">
+        <span class="note__t">CONTINUE → ORANGE</span>
+        Naming yourself configures a preference; it doesn't advance the game. Non-gating = orange. (Was green.)
+      </div>
+    </div>
+  </section>
+
+  <!-- ============================================================
+       SCREEN 3 — Tip-off  (MOMENT MODAL)
+       ============================================================ -->
+  <section class="screen" data-screen-label="03 Tip-off">
+    <div class="tipoff-bg"></div>
+    <div class="screen-inner">
+      <div class="gob-moment-overlay is-visible" style="position:absolute;">
+        <div class="gob-moment-backdrop"></div>
+        <div class="gob-moment-box">
+          <div class="moment-banner">
+            <div class="lineup__banner-fill" style="position:absolute; inset:0;"></div>
+          </div>
+          <div class="moment-body">
+            <div class="coach-avatar coach-avatar--team"><span class="coach-avatar__ph">SAMMY<br><span style="opacity:.65">Minute<br>Men kit</span></span></div>
+            <div class="moment-eyebrow">CRUNCH TIME · Q4</div>
+            <div class="moment-score">
+              <span class="moment-score__team">LITTLE YORK</span>
+              <span class="moment-score__num">60</span>
+              <span class="moment-score__dash">–</span>
+              <span class="moment-score__num">60</span>
+              <span class="moment-score__team">XAVIEN</span>
+            </div>
+            <p class="moment-meta">Tied with four minutes left. The game's in your hands now.</p>
+            <div class="moment-cheer">GO WIN IT, COACH.</div>
+            <div class="moment-actions">
+              <button class="gob-btn gob-btn--gate gob-btn--lg" data-go="4">SET LINEUP</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="note note--tl" style="top:24px; left:24px; max-width:268px;">
+        <span class="note__t">PROMOTED TO MOMENT MODAL</span>
+        This is the emotional peak of the tutorial, so it earns the Moment treatment: 560px, full-bleed team banner, the score as the visual hero — not a plain card floating on black.
+      </div>
+      <div class="note note--tr" style="bottom:90px; right:24px;">
+        <span class="note__t">SET LINEUP → GREEN (correct)</span>
+        This one genuinely advances game state, so green is right here — and because it's the only green in the whole flow, it actually lands.
+      </div>
+    </div>
+  </section>
+
+  <!-- ============================================================
+       SCREEN 4 — Set Lineup + COACH-MARK
+       ============================================================ -->
+  <section class="screen" data-screen-label="04 Set Lineup">
+    <div class="lineup">
+      <div class="lineup__banner"><div class="lineup__banner-fill"></div></div>
+      <div class="lineup__ctx">
+        <div class="sb-pill">
+          <span class="t">LITTLE YORK</span><span class="n">60</span>
+          <span style="color:var(--w35)">–</span>
+          <span class="n">60</span><span class="t">XAVIEN</span>
+          <span style="color:var(--w20)">|</span><span class="q">Q4</span><span class="t">4:00</span>
+        </div>
+        <button class="gob-btn gob-btn--gate" data-go="4">RETURN TO GAME</button>
+      </div>
+      <div class="lineup__body">
+        <div class="lineup__left">
+          <div class="lineup__section-label">ROSTER — CLICK OR DRAG TO ASSIGN</div>
+          <div id="roster-list"></div>
+        </div>
+        <div class="lineup__right">
+          <div class="lineup__section-label">STARTING FIVE</div>
+          <div id="starter-list"></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Coach-mark anchored to roster -->
+    <div class="gob-coachmark gob-coachmark--left" id="coachmark"
+         style="top:140px; left:calc(50% + 30px);">
+      <div class="coach-avatar coach-avatar--sm coach-avatar--team" style="float:left; margin:0 12px 6px 0;">
+        <span class="coach-avatar__ph" style="font-size:8px;">SAMMY</span>
+      </div>
+      <div class="gob-coachmark__eyebrow">QUICK TIP</div>
+      <div class="gob-coachmark__body">I've set a solid lineup for you. Hover any attribute to learn what it does — then tweak the lineup if you want.</div>
+      <div class="gob-coachmark__foot">
+        <span class="gob-coachmark__count">Tip 1 of 1</span>
+        <button class="gob-btn gob-btn--ghost" style="height:34px; min-width:auto; font-size:15px;" data-go="4">GOT IT</button>
+      </div>
+    </div>
+
+    <div class="note note--tl" style="top:24px; left:24px; max-width:262px;">
+      <span class="note__t">COACH-MARK, NOT A MODAL</span>
+      The old centered modal blocked the very thing it described. A spotlight coach-mark points at the roster, keeps the screen visible, and reads as guidance — its own pattern, distinct from your 3 modal types.
+    </div>
+    <div class="note note--bl" style="bottom:70px; left:24px;">
+      <span class="note__t">GOT IT → GHOST</span>
+      An acknowledgement isn't an action. Ghost button keeps green meaningful and the tone calm.
+    </div>
+  </section>
+
+  <!-- Progress thread -->
+  <div class="progress" id="progress"></div>
+</div>
+
+<!-- Prototype chrome -->
+<button class="notes-toggle" id="notesToggle"><span class="dot"></span>Design notes</button>
+<div class="proto-nav">
+  <button id="prevBtn">‹ Back</button>
+  <button id="nextBtn">Next ›</button>
+</div>
+
+<script src="fte/flow.js"></script>
+</body>
+</html>


### PR DESCRIPTION
End-to-end implementation of the FTE Onboarding Redesign spec. Strict canonical-pattern reuse from `Styleguide_updated.md` and the prototype at `_documentation_master/07_Design_Systems/FTE Onboarding Redesign.html`. No new tokens, fonts, or modal styles introduced.

## What changed (per screen)

| Screen | Change |
|---|---|
| **0 · Persona Intro (NEW)** | New page `tutorial-persona-intro.html`. Generic Sammy (white kit) — the *only* screen that uses the generic variant. Display headline + supporting body + orange `LET'S GO` CTA. Backend: prepended `persona_intro` to the tutorial step enum + order map. |
| **1 · Pick Your Program** | New subhead copy: *"This one's your proving ground — a single game to feel out the controls. Your real franchise comes next. Pick whoever speaks to you."* Committed selection state: orange ring + check badge on tap. Card design unchanged per spec. |
| **2 · Username (Functional modal)** | `usernameModal.js` rewritten from the ad-hoc Sammy card to the canonical Functional modal (`.gob-modal-*` chrome). Team-linked Sammy portrait overlaps the top edge. Title is mascot-driven: `YOU'RE COACHING THE <MASCOT>`. Primary CTA is orange (was green) — naming yourself doesn't advance game state. |
| **3 · Pre-Game Tip-off (Moment modal)** | `tutorial-situation` rewritten as a canonical Moment modal: 560px, full-bleed team banner with darkening gradient, score is the visual hero, `CRUNCH TIME · Q4` eyebrow, rallying display line `GO WIN IT, COACH.` Team-linked Sammy in the spotlight. **SET LINEUP** CTA is the only green button in the flow. |
| **4 · Set Lineup (coach-mark)** | The centered "I've set your lineup" Sammy modal is replaced by a coach-mark anchored to the roster — its own guidance pattern, distinct from the three modal types. Dismiss is a ghost `GOT IT`. RT color-coding applied via the canonical Attribute Bar Scale on both `.inline-rt` (roster) and `.player-rating` (slot). Set-lineup layout otherwise unchanged. |

## New shared infrastructure

| File | Purpose |
|---|---|
| `css/gob-buttons.css` | Canonical `.gob-btn` system per styleguide §Buttons — 138×42 min, 18px padding, 10px radius, Bebas Neue Pro +tracking, hover-lift/press-compress. Variants: `--action` (orange, non-gating), `--gate` (green, scarce — gating actions only), `--ghost`. `--lg` modifier for hero CTAs. |
| `js/shared/coachMark.js` + `css/coach-mark.css` | New primitive — spotlight tooltip anchored to a DOM element with directional arrow and team-linked portrait. Not a modal. |
| `js/shared/tutorialProgressThread.js` + `css/tutorial-progress.css` | Quiet 5-step indicator (Persona · Program · Username · Tip-off · Lineup). Mounted on every onboarding screen. |
| `js/shared/teamCoachAsset.js` | Maps team name → `/images/coaches/<abbr>/Sammy-<abbr>.png`. Falls back to generic when no team is provided (Persona Intro). |
| `css/username-modal.css` | Functional-modal-specific styling for the overlapping Sammy portrait + username input field. |
| `css/tutorial-tipoff.css` | Moment-modal-specific styling for the tip-off screen (banner bg, score hero, rally line). |
| `css/tutorial-persona-intro.css` | Persona Intro screen layout — on-system `#0b0d14` shell. |

## Backend
- `BackEnd/api/auth_routes.py`: `TutorialStep` literal gains `persona_intro`; `_TUTORIAL_STEP_ORDER` reindexed; new-user `tutorial_state.step` defaults to `persona_intro`. Grandfathered users (post-`team_select`) keep their current step — forward-only check accommodates.

## Green scarcity audit
Grep for green CTAs across all five onboarding screens — exactly **one** match:
- `tutorial-situation.html`:42 → `SET LINEUP` (gating)

The set-lineup `Play Game` button is also green; it's outside the onboarding sequence and correctly green per the styleguide's gating-action rule (advances game state).

## Sammy variant audit
- Persona Intro (Screen 0): `sammy_tutorial.png` (generic, white kit) — only screen
- Username modal · Tip-off · Lineup coach-mark: `getTeamSammyImage(teamName)` — team-linked

## Test plan
- [ ] New user signs up → routed to `/tutorial-persona-intro.html`. Generic Sammy. `LET'S GO` → `/franchise-select-team.html?mode=tutorial`.
- [ ] Pick Your Program: subhead reads *"This one's your proving ground …"* Tap card → orange ring + check appears, then Username modal opens.
- [ ] Username modal: canonical Functional chrome, 3px orange accent bar, team Sammy overlaps top, title `YOU'RE COACHING THE <MASCOT>`, orange `CONTINUE`. Validation works (3–24 chars).
- [ ] Tip-off: full-bleed team banner background, eyebrow `CRUNCH TIME · Q4`, team-linked Sammy, score block, `GO WIN IT, COACH.` display line, green `SET LINEUP` CTA.
- [ ] Set Lineup: coach-mark appears once anchored to roster (right side), team Sammy portrait, ghost `GOT IT`. Subsequent visits (return from game-plan, timeout-resume) do *not* re-show the tip.
- [ ] RT values color-coded: low red, mid yellow, high green, elite light blue.
- [ ] Progress thread present on all 5 onboarding screens, absent on `court.html`.
- [ ] Grandfathered user (already past `team_select`) is *not* sent back to Persona Intro on login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)