### PR TITLE
FTE v2: onboarding polish — flash fixes, RT colors, coach-mark, opponent nerf

### DIFF
--- a/BackEnd/utils/tutorial_game.py
+++ b/BackEnd/utils/tutorial_game.py
@@ -36,8 +36,10 @@ logger = logging.getLogger(__name__)
 
 
 # fte_inject_state.md §3 — opponent nerf via forced make/miss shot_threshold.
+# COMPUTER value tuned down from 210 → 110 (per Coach) so the tutorial game
+# stays winnable but the AI puts up some shots; 210 was too extreme.
 USER_SHOT_THRESHOLD = 10
-COMPUTER_SHOT_THRESHOLD = 210
+COMPUTER_SHOT_THRESHOLD = 110
 
 
 # fte_inject_state.md §2 — strategy_settings: all keys = 2 except fc_press / hc_trap = 1.

--- a/FrontEnd/static/css/coach-mark.css
+++ b/FrontEnd/static/css/coach-mark.css
@@ -69,6 +69,15 @@
   border-top: 0;
 }
 
+/* Flex row keeps the portrait and the text block as siblings — all body
+ * copy stays left-aligned with a consistent indent, no float wrap. */
+.gob-coachmark__row {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
 .gob-coachmark__portrait {
   width: 44px;
   height: 44px;
@@ -77,9 +86,12 @@
   object-position: center top;
   border: 2px solid rgba(247, 148, 32, 0.65);
   background: rgba(0, 0, 0, 0.4);
-  float: left;
-  margin: 0 12px 6px 0;
   flex-shrink: 0;
+}
+
+.gob-coachmark__text {
+  flex: 1;
+  min-width: 0;
 }
 
 .gob-coachmark__eyebrow {
@@ -97,7 +109,8 @@
   font-size: 14px;
   line-height: 1.45;
   color: rgba(255, 255, 255, 0.88);
-  margin: 0 0 12px;
+  margin: 0;
+  text-align: left;
 }
 
 .gob-coachmark__foot {
@@ -105,7 +118,6 @@
   align-items: center;
   justify-content: space-between;
   gap: 10px;
-  clear: both;
 }
 
 .gob-coachmark__count {

--- a/FrontEnd/static/css/rt-buckets.css
+++ b/FrontEnd/static/css/rt-buckets.css
@@ -1,0 +1,16 @@
+/*
+ * Canonical RT (player rating) color scale per Styleguide §Attribute Bar Scale.
+ * Applied to any element bearing one of these class names — works on <td>,
+ * <span>, <div>, etc. Pair with /js/shared/rtBucket.js.
+ *
+ *   0–40  red       → .rt-low
+ *   41–60 yellow    → .rt-mid
+ *   61–80 green     → .rt-high
+ *   81+   light blue→ .rt-elite
+ */
+
+.rt-low      { color: #ff6d6d; }
+.rt-mid      { color: #FFD700; }
+.rt-high     { color: #34EC27; }
+.rt-elite    { color: #4A90D9; }
+.rt-unknown  { color: rgba(255, 255, 255, 0.4); }

--- a/FrontEnd/static/franchise-command-center.html
+++ b/FrontEnd/static/franchise-command-center.html
@@ -17,7 +17,9 @@
   <link rel="stylesheet" href="/command-center-team-styles.css">
   <link rel="stylesheet" href="/scouting-report.css">
   <link rel="stylesheet" href="/css/auth-bar.css">
+  <link rel="stylesheet" href="/css/rt-buckets.css">
   <script src="/js/shared/pageLoadOverlay.js"></script>
+  <script src="/js/shared/rtBucket.js"></script>
 </head>
 <body>
   <!-- Page load overlay: hides stale/incomplete FCC until data and UI are ready (not shown on tab switch) -->

--- a/FrontEnd/static/franchise-command-center.js
+++ b/FrontEnd/static/franchise-command-center.js
@@ -2142,30 +2142,35 @@ function renderTeam(data) {
       nameTd.appendChild(gr);
     }
     tr.appendChild(nameTd);
-    
+
     // Add other columns directly as DOM elements
-    const addCell = (content) => {
+    const addCell = (content, extraClass) => {
       const td = document.createElement('td');
       td.textContent = content;
+      if (extraClass) td.className = extraClass;
       tr.appendChild(td);
     };
-    
+
     addCell(p.pos);
     addCell(p.year);
     addCell(p.height);
     addCell(p.weight);
-    
+
     ATTR_HEADERS.forEach(h => {
       const attrs = p.attributes || {};
       // Use anchor attribute (base value) as fallback, same as lineup screen
       const rawVal = attrs[`anchor_${h}`] ?? attrs[h];
       // Convert to 0-12 scale, except NG which stays as decimal
-      const displayVal = h === 'NG' 
+      const displayVal = h === 'NG'
         ? (rawVal != null ? rawVal.toFixed(2) : '--')
         : (rawVal != null ? Math.floor(rawVal / 10) : '--');
       addCell(displayVal);
     });
-    addCell(p.rt ?? '-');
+    // RT colored per canonical Attribute Bar Scale (see /css/rt-buckets.css).
+    addCell(
+      p.rt ?? '-',
+      typeof window.getRtBucketClass === 'function' ? window.getRtBucketClass(p.rt) : ''
+    );
 
     tbody.appendChild(tr);
   });
@@ -2419,27 +2424,32 @@ function sortRosterTable(columnName, direction) {
       nameTd.appendChild(gr);
     }
     tr.appendChild(nameTd);
-    
-    const addCell = (content) => {
+
+    const addCell = (content, extraClass) => {
       const td = document.createElement('td');
       td.textContent = content;
+      if (extraClass) td.className = extraClass;
       tr.appendChild(td);
     };
-    
+
     addCell(p.pos);
     addCell(p.year);
     addCell(p.height);
     addCell(p.weight);
-    
+
     ATTR_HEADERS.forEach(h => {
       const attrs = p.attributes || {};
       const rawVal = attrs[`anchor_${h}`] ?? attrs[h];
-      const displayVal = h === 'NG' 
+      const displayVal = h === 'NG'
         ? (rawVal != null ? rawVal.toFixed(2) : '--')
         : (rawVal != null ? Math.floor(rawVal / 10) : '--');
       addCell(displayVal);
     });
-    addCell(p.rt ?? '-');
+    // RT colored per canonical Attribute Bar Scale (see /css/rt-buckets.css).
+    addCell(
+      p.rt ?? '-',
+      typeof window.getRtBucketClass === 'function' ? window.getRtBucketClass(p.rt) : ''
+    );
 
     tbody.appendChild(tr);
   });

--- a/FrontEnd/static/franchise-select-team.html
+++ b/FrontEnd/static/franchise-select-team.html
@@ -15,6 +15,7 @@
   <link rel="stylesheet" href="/css/gob-buttons.css">
   <link rel="stylesheet" href="/css/username-modal.css">
   <link rel="stylesheet" href="/franchise-select-team.css">
+  <script src="/js/shared/pageLoadOverlay.js"></script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/FrontEnd/static/franchise-select-team.js
+++ b/FrontEnd/static/franchise-select-team.js
@@ -185,6 +185,14 @@ async function selectTutorialTeam(team) {
     teamName: team,
     mascot,
     onSuccess: async () => {
+      // Mask the team-select page during the in-flight nav to tutorial-situation
+      // so the user doesn't see the (now-stale) team grid flash between modal
+      // close and tutorial-situation's first paint. The destination page paints
+      // its own dark backdrop + Moment modal as soon as its script runs, so no
+      // further coordination is needed.
+      if (window.PageLoadOverlay && window.PageLoadOverlay.show) {
+        window.PageLoadOverlay.show();
+      }
       // Step 3: advance to "situation" and navigate to the situation card.
       try {
         await fetch(API_CONFIG.buildUrl('/api/auth/tutorial-advance'), {

--- a/FrontEnd/static/js/shared/coachMark.js
+++ b/FrontEnd/static/js/shared/coachMark.js
@@ -93,23 +93,35 @@ export function showCoachMark(opts = {}) {
   bubble.setAttribute('role', 'dialog');
   bubble.setAttribute('aria-live', 'polite');
 
+  // Two-column row keeps the portrait fixed-width and the text block flowing
+  // to its right. All body copy stays left-aligned, including lines that
+  // would wrap below the portrait under the older float-based layout.
+  const row = document.createElement('div');
+  row.className = 'gob-coachmark__row';
+
   const portraitImg = document.createElement('img');
   portraitImg.className = 'gob-coachmark__portrait';
   portraitImg.src = portrait;
   portraitImg.alt = '';
-  bubble.appendChild(portraitImg);
+  row.appendChild(portraitImg);
+
+  const textBlock = document.createElement('div');
+  textBlock.className = 'gob-coachmark__text';
 
   if (opts.eyebrow) {
     const eyebrow = document.createElement('div');
     eyebrow.className = 'gob-coachmark__eyebrow';
     eyebrow.textContent = opts.eyebrow;
-    bubble.appendChild(eyebrow);
+    textBlock.appendChild(eyebrow);
   }
 
   const body = document.createElement('p');
   body.className = 'gob-coachmark__body';
   body.textContent = opts.body;
-  bubble.appendChild(body);
+  textBlock.appendChild(body);
+
+  row.appendChild(textBlock);
+  bubble.appendChild(row);
 
   const foot = document.createElement('div');
   foot.className = 'gob-coachmark__foot';

--- a/FrontEnd/static/js/shared/rtBucket.js
+++ b/FrontEnd/static/js/shared/rtBucket.js
@@ -1,0 +1,25 @@
+/**
+ * Canonical RT (player rating) color bucket per Styleguide §Attribute Bar Scale.
+ * Apply consistently wherever a player rating is displayed as text.
+ *
+ *   0–40  red (#ff6d6d)       → .rt-low
+ *   41–60 yellow (#FFD700)    → .rt-mid
+ *   61–80 green (#34EC27)     → .rt-high
+ *   81+   light blue (#4A90D9)→ .rt-elite
+ *   non-numeric / null        → .rt-unknown
+ *
+ * Pair with /css/rt-buckets.css for the color rules. Loaded as a classic
+ * script (no module export) so it works from both ES modules and IIFE
+ * pages — exposes window.getRtBucketClass.
+ */
+(function (global) {
+  function getRtBucketClass(rt) {
+    var v = Number(rt);
+    if (!isFinite(v)) return 'rt-unknown';
+    if (v <= 40) return 'rt-low';
+    if (v <= 60) return 'rt-mid';
+    if (v <= 80) return 'rt-high';
+    return 'rt-elite';
+  }
+  global.getRtBucketClass = getRtBucketClass;
+})(typeof window !== 'undefined' ? window : this);

--- a/FrontEnd/static/recruiting-orders.html
+++ b/FrontEnd/static/recruiting-orders.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="/franchise-command-center.css">
   <link rel="stylesheet" href="/resource-pages.css">
   <link rel="stylesheet" href="/recruiting.css">
+  <link rel="stylesheet" href="/css/rt-buckets.css">
 </head>
 <body>
   <div id="toast" class="toast" hidden role="status" aria-live="polite"></div>
@@ -141,6 +142,7 @@
   <script src="/js/config/api-config.js"></script>
   <script src="/common.js"></script>
   <script src="/js/shared/attributeTooltips.js"></script>
+  <script src="/js/shared/rtBucket.js"></script>
   <script src="/recruiting-common.js"></script>
   <script src="/recruiting-orders.js"></script>
 </body>

--- a/FrontEnd/static/recruiting-orders.js
+++ b/FrontEnd/static/recruiting-orders.js
@@ -375,7 +375,7 @@
         '<td>' + escapeHtml(recruit.attrs.ND) + '</td>',
         '<td>' + escapeHtml(recruit.attrs.IQ) + '</td>',
         '<td>' + escapeHtml(recruit.attrs.FT) + '</td>',
-        '<td>' + (recruit.rt != null ? escapeHtml(recruit.rt) : '--') + '</td>',
+        '<td class="' + (typeof window.getRtBucketClass === 'function' ? window.getRtBucketClass(recruit.rt) : '') + '">' + (recruit.rt != null ? escapeHtml(recruit.rt) : '--') + '</td>',
         '<td>' + getLeanCellHtml(recruit) + '</td>',
         '<td>' + (rank
           ? '<button class="picked-rank-badge" type="button" data-action="scroll-to-pick" data-recruit-id="' + escapeHtml(recruit.recruitId) + '">' + rank + '</button>'
@@ -470,7 +470,7 @@
       '<td>' + (recruit ? recruit.height : '--') + '</td>',
       '<td>' + (recruit && recruit.weight != null ? recruit.weight : '--') + '</td>',
       '<td>' + (recruit ? recruit.pos : '--') + '</td>',
-      '<td>' + (recruit && recruit.rt != null ? recruit.rt : '--') + '</td>',
+      '<td class="' + (recruit && typeof window.getRtBucketClass === 'function' ? window.getRtBucketClass(recruit.rt) : '') + '">' + (recruit && recruit.rt != null ? recruit.rt : '--') + '</td>',
       '<td>' + (recruit ? getLeanCellHtml(recruit) : '--') + '</td>',
       '<td><input class="recruiting-points-input" inputmode="numeric" type="text" data-action="points" data-index="' + index + '" value="' + pointsValue + '"' + (recruit ? '' : ' disabled') + '></td>',
       '<td><input class="recruiting-checkbox" type="checkbox" data-action="playing_time" data-index="' + index + '"' + (recruit && !!entry.playing_time ? ' checked' : '') + (recruit ? '' : ' disabled') + '></td>',
@@ -486,7 +486,7 @@
       '<td>' + (recruit ? recruit.homeRegion : '--') + '</td>',
       '<td>' + (recruit ? recruit.archetype : '--') + '</td>',
       '<td>' + (recruit ? recruit.pos : '--') + '</td>',
-      '<td>' + (recruit && recruit.rt != null ? recruit.rt : '--') + '</td>',
+      '<td class="' + (recruit && typeof window.getRtBucketClass === 'function' ? window.getRtBucketClass(recruit.rt) : '') + '">' + (recruit && recruit.rt != null ? recruit.rt : '--') + '</td>',
       '<td>' + (recruit ? getLeanCellHtml(recruit) : '--') + '</td>',
       '<td>' + buildAdjustButtons(index, !!recruit) + '</td>',
       '<td><button class="recruiting-remove-btn" type="button" data-action="remove" data-index="' + index + '"' + (recruit ? '' : ' disabled') + '>x</button></td>'

--- a/FrontEnd/static/recruiting.html
+++ b/FrontEnd/static/recruiting.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/franchise-command-center.css">
   <link rel="stylesheet" href="/resource-pages.css">
+  <link rel="stylesheet" href="/css/rt-buckets.css">
   <style>
     .recruiting-page-header {
       display: grid;
@@ -263,6 +264,7 @@
   <script src="/js/config/api-config.js"></script>
   <script src="/common.js"></script>
   <script src="/js/shared/attributeTooltips.js"></script>
+  <script src="/js/shared/rtBucket.js"></script>
   <script src="/recruiting-common.js"></script>
   <script src="/recruiting.js"></script>
   <script type="module">

--- a/FrontEnd/static/recruiting.js
+++ b/FrontEnd/static/recruiting.js
@@ -149,6 +149,9 @@
   }
 
   function appendStandardRow(tbody, row, isWeek36) {
+    // RT colored per canonical Attribute Bar Scale (see /css/rt-buckets.css).
+    var rtClass = typeof window.getRtBucketClass === 'function' ? window.getRtBucketClass(row.rt) : '';
+    var rtCell = '<td class="' + rtClass + '">' + (row.rt != null ? row.rt : '--') + '</td>';
     var tr = document.createElement('tr');
     tr.innerHTML = isWeek36 ? [
       '<td>' + row.name + '</td>',
@@ -168,7 +171,7 @@
       '<td>' + row.attrs.ND + '</td>',
       '<td>' + row.attrs.IQ + '</td>',
       '<td>' + row.attrs.FT + '</td>',
-      '<td>' + (row.rt != null ? row.rt : '--') + '</td>',
+      rtCell,
       '<td>' + row.signedDisplay + '</td>'
     ].join('') : [
       '<td>' + row.name + '</td>',
@@ -188,7 +191,7 @@
       '<td>' + row.attrs.ND + '</td>',
       '<td>' + row.attrs.IQ + '</td>',
       '<td>' + row.attrs.FT + '</td>',
-      '<td>' + (row.rt != null ? row.rt : '--') + '</td>',
+      rtCell,
       '<td>' + (row.leanDisplay || '--') + '</td>'
     ].join('');
     tbody.appendChild(tr);

--- a/FrontEnd/static/set-lineup.css
+++ b/FrontEnd/static/set-lineup.css
@@ -759,22 +759,11 @@ body.set-lineup-page .resource-page-container.fcc-brand-page-shell.set-lineup-sh
 }
 
 /*
- * Per Styleguide §Color System → Attribute Bar Scale, color the player
- * rating display by tier so users can scan strength at a glance. Same
- * thresholds as the attribute pills throughout the product.
- *   0–40  red       41–60 yellow    61–80 green    81+   light blue
- * Both .inline-rt (roster row) and .player-rating (slot) share buckets.
+ * RT color buckets — canonical scale lives in /css/rt-buckets.css.
+ * That stylesheet is loaded on this page in set-lineup.html, so both
+ * .inline-rt and .player-rating inherit the bucket colors via the
+ * `rt-low / rt-mid / rt-high / rt-elite` class the JS applies.
  */
-.inline-rt.rt-low,
-.player-rating.rt-low      { color: #ff6d6d; }
-.inline-rt.rt-mid,
-.player-rating.rt-mid      { color: #FFD700; }
-.inline-rt.rt-high,
-.player-rating.rt-high     { color: #34EC27; }
-.inline-rt.rt-elite,
-.player-rating.rt-elite    { color: #4A90D9; }
-.inline-rt.rt-unknown,
-.player-rating.rt-unknown  { color: rgba(255, 255, 255, 0.4); }
 
 .roster-table tr.selected td,
 .roster-stats-table tr.selected td {

--- a/FrontEnd/static/set-lineup.html
+++ b/FrontEnd/static/set-lineup.html
@@ -13,7 +13,9 @@
   <link rel="stylesheet" href="/resource-pages.css" />
   <link rel="stylesheet" href="/tournament.css" />
   <link rel="stylesheet" href="/set-lineup.css" />
+  <link rel="stylesheet" href="/css/rt-buckets.css" />
   <script src="/js/shared/pageLoadOverlay.js"></script>
+  <script src="/js/shared/rtBucket.js"></script>
 </head>
 <body class="set-lineup-page">
   <!-- Page load overlay: hides stale/incomplete lineup until data and UI are ready -->

--- a/FrontEnd/static/set-lineup.js
+++ b/FrontEnd/static/set-lineup.js
@@ -322,10 +322,13 @@ function getRT(player) {
   return ratings.length ? Math.max(...ratings) : -Infinity;
 }
 
-// Canonical Attribute Bar Scale (Styleguide §Color System):
-//   0–40 red · 41–60 yellow · 61–80 green · 81+ light blue (incl. 100+)
-// Returns a CSS class suffix; caller applies as `rt-${bucket}`.
+// RT color bucket helper — canonical implementation at
+// /js/shared/rtBucket.js (loaded as a classic script on this page).
+// Falls back to a local definition if the global isn't present.
 function getRtBucketClass(rt) {
+  if (typeof window !== 'undefined' && typeof window.getRtBucketClass === 'function') {
+    return window.getRtBucketClass(rt);
+  }
   const v = Number(rt);
   if (!Number.isFinite(v)) return 'rt-unknown';
   if (v <= 40) return 'rt-low';

--- a/FrontEnd/static/signup.html
+++ b/FrontEnd/static/signup.html
@@ -154,11 +154,34 @@
         // Store token and user info
         localStorage.setItem('auth_token', data.token);
         localStorage.setItem('auth_user', JSON.stringify(data.user));
-        
+
         if (window.GOB_Analytics) window.GOB_Analytics.signup();
-        
-        // Redirect to mode select
-        window.location.href = '/mode-select.html';
+
+        // Route directly to the user's current tutorial step. Avoids a
+        // mode-select flash for new users whose first stop is the FTE
+        // persona-intro screen.
+        var nextHref = '/mode-select.html';
+        try {
+          var u = data.user || {};
+          if (u.fte_v2_complete === false) {
+            var step = (u.tutorial_state && u.tutorial_state.step) || 'persona_intro';
+            switch (step) {
+              case 'persona_intro':
+                nextHref = '/tutorial-persona-intro.html';
+                break;
+              case 'team_select':
+              case 'username':
+                nextHref = '/franchise-select-team.html?mode=tutorial';
+                break;
+              case 'situation':
+                nextHref = '/tutorial-situation.html';
+                break;
+              // set_lineup / in_game / complete fall through to mode-select;
+              // mode-select's auth handler will route from there.
+            }
+          }
+        } catch (_) { /* defensive: any failure falls back to mode-select */ }
+        window.location.href = nextHref;
         
       } catch (error) {
         errorEl.textContent = error.message;

--- a/FrontEnd/static/team-roster-view.html
+++ b/FrontEnd/static/team-roster-view.html
@@ -15,6 +15,7 @@
   <link rel="stylesheet" href="/resource-pages.css">
   <link rel="stylesheet" href="/command-center-team-styles.css">
   <link rel="stylesheet" href="/set-lineup.css">
+  <link rel="stylesheet" href="/css/rt-buckets.css">
   <style>
     :root {
       --roster-text: #f4f6ff;
@@ -389,6 +390,7 @@
   <script src="/js/config/api-config.js"></script>
   <script src="/common.js"></script>
   <script src="/js/shared/attributeTooltips.js"></script>
+  <script src="/js/shared/rtBucket.js"></script>
   <script src="/team-roster-view.js"></script>
   <script type="module">
     import { resumeFranchiseTrack } from '/js/musicController.js';

--- a/FrontEnd/static/team-roster-view.js
+++ b/FrontEnd/static/team-roster-view.js
@@ -387,12 +387,13 @@ function renderRoster() {
     }
     tr.appendChild(nameTd);
     
-    const addCell = (content) => {
+    const addCell = (content, extraClass) => {
       const td = document.createElement('td');
       td.textContent = content;
+      if (extraClass) td.className = extraClass;
       tr.appendChild(td);
     };
-    
+
     addCell(p.pos);
     addCell(p.year);
     addCell(p.height);
@@ -409,7 +410,11 @@ function renderRoster() {
     addCell(formatAttr('ND'));
     addCell(formatAttr('IQ'));
     addCell(formatAttr('FT'));
-    addCell(p.highestRT !== null ? p.highestRT : '-');
+    // RT colored per canonical Attribute Bar Scale (see /css/rt-buckets.css).
+    addCell(
+      p.highestRT !== null ? p.highestRT : '-',
+      typeof window.getRtBucketClass === 'function' ? window.getRtBucketClass(p.highestRT) : ''
+    );
     
     tbody.appendChild(tr);
   });


### PR DESCRIPTION
Five small polish fixes bundled per direction.

## Summary

| # | Fix | Files |
|---|---|---|
| 1 | Post-signup flash to mode-select removed. [signup.html](FrontEnd/static/signup.html) now reads \`data.user.tutorial_state.step\` from the auth response and routes directly to the right tutorial page. Grandfathered users still go to mode-select. | \`signup.html\` |
| 2 | Post-username flash to team-select removed. [franchise-select-team.js](FrontEnd/static/franchise-select-team.js) calls \`PageLoadOverlay.show()\` before the tutorial-advance + nav. Destination paints its own dark backdrop immediately so no further handshake is needed. | \`franchise-select-team.html/js\` |
| 3 | RT color-coding extended to all four roster surfaces. Extracted the bucket helper to [\`/js/shared/rtBucket.js\`](FrontEnd/static/js/shared/rtBucket.js) (exposes \`window.getRtBucketClass\`) + [\`/css/rt-buckets.css\`](FrontEnd/static/css/rt-buckets.css). | team-roster-view, FCC Roster (renderTeam + sortRosterTable), Recruiting, Recruiting Orders, set-lineup (refactored to use shared helper) |
| 4 | Coach-mark wrap fix. Portrait was \`float:left\` causing the third line to wrap to the left edge below the float. Now uses flexbox (portrait \| text block) so all body copy stays left-aligned. | [\`css/coach-mark.css\`](FrontEnd/static/css/coach-mark.css), [\`js/shared/coachMark.js\`](FrontEnd/static/js/shared/coachMark.js) |
| 5 | Tutorial opponent: \`COMPUTER_SHOT_THRESHOLD\` 210 → 110 per Coach. | [\`BackEnd/utils/tutorial_game.py\`](BackEnd/utils/tutorial_game.py) |

## Universal-fix note
Per your direction, I did **not** ship a \`navigateWithOverlay\` helper. The two flashes are now solved with bespoke fixes (#1 = route around the stale page; #2 = overlay only in this specific transition). If a third instance shows up we can revisit factoring the pattern.

## Test plan
- [ ] Brand-new signup → lands directly on \`/tutorial-persona-intro.html\`; no mode-select flash in between.
- [ ] Username modal submit → smooth fade to tutorial-situation tip-off; no team-select flash.
- [ ] RT values colored across team-roster-view Grid, FCC Roster tab (both initial render and after sort), Recruiting standard rows, Recruiting Orders standard/visit/picks rows. Scale: ≤40 red, 41–60 yellow, 61–80 green, 81+ light blue.
- [ ] Lineup coach-mark: portrait left, all 3+ body lines left-aligned with the same indent.
- [ ] Tutorial game: computer team makes some shots but stays winnable.