### PR TITLE
RT buckets: !important so canonical colors win over local table styles

### DIFF
--- a/FrontEnd/static/css/rt-buckets.css
+++ b/FrontEnd/static/css/rt-buckets.css
@@ -9,8 +9,12 @@
  *   81+   light blue→ .rt-elite
  */
 
-.rt-low      { color: #ff6d6d; }
-.rt-mid      { color: #FFD700; }
-.rt-high     { color: #34EC27; }
-.rt-elite    { color: #4A90D9; }
-.rt-unknown  { color: rgba(255, 255, 255, 0.4); }
+/* !important is deliberate here — this is the canonical scale and must win
+ * over page-local table rules like `.roster-table td { color: ... }` that
+ * have higher selector specificity than a bare `.rt-low`. Applying the
+ * class anywhere should color the element per the scale. */
+.rt-low      { color: #ff6d6d !important; }
+.rt-mid      { color: #FFD700 !important; }
+.rt-high     { color: #34EC27 !important; }
+.rt-elite    { color: #4A90D9 !important; }
+.rt-unknown  { color: rgba(255, 255, 255, 0.4) !important; }

--- a/FrontEnd/static/set-lineup.js
+++ b/FrontEnd/static/set-lineup.js
@@ -322,19 +322,20 @@ function getRT(player) {
   return ratings.length ? Math.max(...ratings) : -Infinity;
 }
 
-// RT color bucket helper — canonical implementation at
-// /js/shared/rtBucket.js (loaded as a classic script on this page).
-// Falls back to a local definition if the global isn't present.
-function getRtBucketClass(rt) {
-  if (typeof window !== 'undefined' && typeof window.getRtBucketClass === 'function') {
-    return window.getRtBucketClass(rt);
-  }
-  const v = Number(rt);
-  if (!Number.isFinite(v)) return 'rt-unknown';
-  if (v <= 40) return 'rt-low';
-  if (v <= 60) return 'rt-mid';
-  if (v <= 80) return 'rt-high';
-  return 'rt-elite';
+// RT color bucket helper.
+//
+// IMPORTANT: do NOT define a local `function getRtBucketClass()` here.
+// set-lineup.js is loaded as a classic (non-module) script, and a top-level
+// function declaration of the same name as the shared global on window
+// silently clobbers it — then any wrapper that tries to delegate to
+// window.getRtBucketClass ends up calling itself recursively until the
+// stack overflows. (That bug masked the entire render in tutorial mode.)
+//
+// Canonical implementation lives at /js/shared/rtBucket.js. The two call
+// sites below pick it up via window. with an inline guard for the rare
+// case it didn't load.
+function rtBucketClassOrEmpty(rt) {
+  return typeof window.getRtBucketClass === 'function' ? window.getRtBucketClass(rt) : '';
 }
 
 function showToast(msg) {
@@ -1066,7 +1067,7 @@ function renderRosterAttributes() {
         nameText.textContent = val ?? '--';
         nameText.className = 'player-name-link';
         const rtSpan = document.createElement('span');
-        rtSpan.className = `inline-rt ${getRtBucketClass(rt)}`;
+        rtSpan.className = `inline-rt ${rtBucketClassOrEmpty(rt)}`;
         rtSpan.textContent = rt ?? '--';
         wrap.appendChild(nameText);
         wrap.appendChild(rtSpan);
@@ -1481,7 +1482,7 @@ function updateSlotDisplay(slot) {
       <div class="slot-info">
         <div class="slot-row-1">
           <div class="player-name">${slotDisplayName}</div>
-          <div class="player-rating ${getRtBucketClass(rating)}">RT: ${rating}</div>
+          <div class="player-rating ${rtBucketClassOrEmpty(rating)}">RT: ${rating}</div>
         </div>
         <div class="slot-row-2">
           <div class="slot-stat slot-stat-momentum">


### PR DESCRIPTION
## Why the colors weren't showing
team-roster-view's inline \`.roster-table td { color: rgba(255,255,255,0.9) }\` rule has specificity (0,1,1), beating my bare \`.rt-low\` (0,1,0). So the bucket classes were applied to the cells but the page-local rule won. Same situation likely on FCC.

## Fix
Add \`!important\` to all five bucket rules in [\`/css/rt-buckets.css\`](FrontEnd/static/css/rt-buckets.css). Deliberate here — these are canonical design-system colors per Styleguide §Attribute Bar Scale and should always win over local table styling. Comment in the file explains the rationale so the next person doesn't strip them.

## Test plan
- [ ] Team Roster page: RT column shows red/yellow/green/light-blue per scale.
- [ ] FCC Roster tab: same after sort and initial render.
- [ ] Recruiting + Recruiting Orders: same.
- [ ] set-lineup roster RT + slot RT: unchanged (already worked because there's no competing higher-specificity rule there).