### PR TITLE
FTE: Pick Your Program subhead — "proving ground" → "onboarding"

### DIFF
--- a/FrontEnd/static/franchise-select-team.js
+++ b/FrontEnd/static/franchise-select-team.js
@@ -256,7 +256,7 @@ document.addEventListener("DOMContentLoaded", function () {
     const subtitle = document.getElementById('page-subtitle');
     if (title) title.textContent = 'Pick Your Program';
     if (subtitle) {
-      subtitle.textContent = "This one's your proving ground — a single game to feel out the controls. Your real franchise comes next. Pick whoever speaks to you.";
+      subtitle.textContent = "This one's your onboarding — a single game to feel out the controls. Your real franchise comes next. Pick whoever speaks to you.";
     }
     // Mount the quiet 5-step progress thread (Pick Program = step 2 of 5).
     import('/js/shared/tutorialProgressThread.js')


### PR DESCRIPTION
One-word copy tweak per Coach.

Before: "This one's your **proving ground** — a single game to feel out the controls..."
After:  "This one's your **onboarding** — a single game to feel out the controls..."

[franchise-select-team.js:259](FrontEnd/static/franchise-select-team.js#L259). Visible only in tutorial mode.