### PR TITLE
FTE v2: pass game_id on tutorial /api/playbooks fetch from court Playcall Center

### DIFF
--- a/FrontEnd/static/court.html
+++ b/FrontEnd/static/court.html
@@ -5164,7 +5164,12 @@
         const params = new URLSearchParams();
         params.set('mode', mode);
         params.set('team_id', teamId);
-        if (mode === 'single' && gameId) {
+        // FTE v2 tutorial games live in the games_collection like single mode,
+        // so they need game_id on the request for the backend to find the game
+        // doc and return the preloaded playbook_settings. Without this,
+        // get_playbooks falls back to default-init and returns empty offense
+        // plays — Playcall Center renders blank.
+        if ((mode === 'single' || mode === 'tutorial') && gameId) {
           params.set('game_id', gameId);
         } else if (mode === 'tournament' && tournamentId) {
           params.set('tournament_id', tournamentId);


### PR DESCRIPTION
One-line surgical fix for the empty Playcall Center in tutorial mode.

## Root cause
Court.html's inline Playcall Center loader had a mode dispatcher with branches for \`single\`, \`franchise\`, and \`tournament\` — but no \`tutorial\` branch. For \`mode=tutorial\` the request went out as:

\`\`\`
/api/playbooks?mode=tutorial&team_id=Ocean+City
\`\`\`

…with **no \`game_id\`**. Backend aliases \`mode=tutorial → single\`, can't locate the game doc without \`game_id\`, falls through to the \"team has no playbook_settings\" elif at [\`gameplan_routes.py:2395\`](BackEnd/api/gameplan_routes.py#L2395), returns \`initialize_playbook_settings()\` (empty \`pc_order.offense\`). Frontend renders an empty Playcall Center.

\`bootGame.js\`'s \`loadPlaybookSettings\` already attached \`game_id\` unconditionally; the gap was specific to this court.html inline fetcher.

## Patch
[\`court.html:5167\`](FrontEnd/static/court.html#L5167):

\`\`\`diff
- if (mode === 'single' && gameId) {
+ if ((mode === 'single' || mode === 'tutorial') && gameId) {
     params.set('game_id', gameId);
\`\`\`

Same single/tutorial aliasing we apply on the backend and other endpoints.

## Verified
- Staging game \`6a1abf2445be4838a00468f3\` (the user's broken game): doc shows 8 plays on \`OCEAN_CITY.playbook_settings.pc_order.offense\` intact.
- \`normalize_team_id_to_canonical('Ocean City', 'single', doc)\` returns \`'OCEAN_CITY'\` correctly.
- \`ensure_team_objects_exist\` returns the team with playbook_settings populated.
- The DB / resolution paths are fine when \`game_id\` reaches the backend — and they will, once this dispatcher branch matches.

## Test plan
- [ ] Fresh tutorial walkthrough → court Playcall Center shows the 8 preloaded plays (3-2 Motion, 4-1 Motion, 5-0 Motion, PF Post Motion, Base Post Play, Pick & Roll - Entry Pass, Iso, Double Screen Three - Wing).
- [ ] Non-tutorial single / franchise / tournament Playcall Centers unaffected.