### PR TITLE
FTE v2: lobby music on Persona Intro + "Gameplay" dot on progress thread

### DIFF
--- a/FrontEnd/static/js/shared/tutorialProgressThread.js
+++ b/FrontEnd/static/js/shared/tutorialProgressThread.js
@@ -1,5 +1,5 @@
 /**
- * Tutorial Progress Thread — quiet 5-step indicator for the FTE v2 funnel.
+ * Tutorial Progress Thread — quiet 6-step indicator for the FTE v2 funnel.
  *
  * Per spec: "a subtle progress indicator across the onboarding steps (quiet
  * step thread; should not compete with content)."
@@ -8,7 +8,12 @@
  *   mountTutorialProgress('username');   // step IDs below
  *
  * Steps mirror the user-visible flow, not the backend's TutorialStep enum:
- *   persona | program | username | tipoff | lineup
+ *   persona | program | username | tipoff | lineup | gameplay
+ *
+ * The "gameplay" step is a visual hint of what's coming next — the bar is
+ * never mounted on court.html (per fte_system.md §6), so gameplay is never
+ * the active step. It always renders as a faint pending dot when the bar
+ * is visible, signaling the final stop of the funnel.
  */
 
 const STEPS = [
@@ -17,6 +22,7 @@ const STEPS = [
   { id: 'username', label: 'Username' },
   { id: 'tipoff', label: 'Tip-off' },
   { id: 'lineup', label: 'Lineup' },
+  { id: 'gameplay', label: 'Gameplay' },
 ];
 
 const STYLESHEET_HREF = '/css/tutorial-progress.css';

--- a/FrontEnd/static/tutorial-persona-intro.js
+++ b/FrontEnd/static/tutorial-persona-intro.js
@@ -16,6 +16,17 @@ const errorEl = document.getElementById('persona-intro-error');
 
 mountTutorialProgress('persona');
 
+// Lobby music — same track + volume as mode-select / franchise-select-team
+// so the audio feels continuous across the onboarding funnel. Each page
+// owns its own Audio instance (the prior page's instance is GC'd on
+// unload); matches the existing precedent on those two pages.
+try {
+  const lobbyMusic = new Audio('/sounds/crossover-21738.mp3');
+  lobbyMusic.loop = true;
+  lobbyMusic.volume = 0.4;
+  lobbyMusic.play().catch(function () {});
+} catch (e) { /* autoplay or codec fail — silent */ }
+
 function showError(msg) {
   if (errorEl) errorEl.textContent = msg || '';
 }

--- a/_documentation_master/00_General_Systems/fte_system.md
+++ b/_documentation_master/00_General_Systems/fte_system.md
@@ -61,7 +61,7 @@ Universal button class system: `FrontEnd/static/css/gob-buttons.css` (`.gob-btn-
 
 ### Progress thread
 
-Quiet 5-dot indicator at the bottom of every funnel screen. Module: `FrontEnd/static/js/shared/tutorialProgressThread.js`; CSS: `FrontEnd/static/css/tutorial-progress.css`. Step IDs: `persona | program | username | tipoff | lineup`. Hidden on `court.html`.
+Quiet 6-dot indicator at the bottom of every funnel screen. Module: `FrontEnd/static/js/shared/tutorialProgressThread.js`; CSS: `FrontEnd/static/css/tutorial-progress.css`. Step IDs: `persona | program | username | tipoff | lineup | gameplay`. Hidden on `court.html` — `gameplay` is therefore never the active step; it always renders as a faint pending dot, signaling the final stop.
 
 ---
 
@@ -323,3 +323,7 @@ For commit-level history, `git log --grep "FTE v2"`. High-level milestones:
 | Canonical button / modal / coach-mark CSS | `css/gob-buttons.css`, `resource-pages.css` (`gob-modal-*`), `css/coach-mark.css`, `css/tutorial-tipoff.css`, `css/username-modal.css` |
 | Action color rules / Attribute Bar Scale | `_documentation_master/00_General_Systems/Styleguide_updated.md` |
 | Visual reference / design notes | `_documentation_master/07_Design_Systems/FTE Onboarding Redesign.html` |
+
+
+**Set Lineup Alogrithm**
+


### PR DESCRIPTION
Two small tweaks per request.

## 1. Lobby music on Persona Intro
Persona Intro now plays the same \`/sounds/crossover-21738.mp3\` loop at volume 0.4 that mode-select and franchise-select-team already use. Each page owns its own \`Audio\` instance — prior page's instance is GC'd on unload, matching existing precedent.

## 2. "Gameplay" added to the progress thread
The thread is now 6 dots: \`persona | program | username | tipoff | lineup | gameplay\`.

Because the bar is never mounted on court.html (per fte_system.md §6), the \`gameplay\` step is never the active step — it always renders as a faint pending dot, signaling the final stop. No CSS or render-logic changes needed; the existing loop handles 6 the same way as 5.

\`fte_system.md\` updated (5-dot → 6-dot, step list now includes \`gameplay\`).

## Test plan
- [ ] Land on persona-intro → lobby music starts (same track as mode-select). Continues looping. Volume matches mode-select.
- [ ] Navigate through funnel → music restarts on each page (existing behavior, not new).
- [ ] Every funnel screen now shows 6 dots, ending with "Gameplay" on the right.
- [ ] On set-lineup, \`Lineup\` is active and \`Gameplay\` is the faint pending dot to its right.
- [ ] On court.html, the thread is hidden (unchanged).