### PR TITLE
FTE v2: tutorial set-lineup — empty slots + intro modal + feedback algorithm

### DIFF
--- a/FrontEnd/static/css/tutorial-lineup-modal.css
+++ b/FrontEnd/static/css/tutorial-lineup-modal.css
@@ -1,0 +1,56 @@
+/*
+ * FTE v2 tutorial — set-lineup intro + post-lineup feedback modals.
+ *
+ * Reuse the canonical Functional-modal chrome (.gob-modal-* classes in
+ * resource-pages.css). This file adds only the bits specific to these
+ * two modals: the team-linked Sammy portrait that overlaps the top edge
+ * of the modal box, and the body-only layout (no input field, no title
+ * slot — the message itself is the hero).
+ */
+
+.tutorial-lineup-modal-box {
+  overflow: visible;
+}
+
+.tutorial-lineup-modal-portrait-wrap {
+  position: absolute;
+  top: -56px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 2;
+  pointer-events: none;
+}
+
+.tutorial-lineup-modal-portrait {
+  display: block;
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  object-fit: cover;
+  object-position: center top;
+  background: rgba(0, 0, 0, 0.5);
+  border: 3px solid #F79420;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.55);
+}
+
+.tutorial-lineup-modal-body {
+  padding-top: 64px;
+  padding-bottom: 8px;
+  text-align: center;
+}
+
+.tutorial-lineup-modal-message {
+  font-family: 'Inter', sans-serif;
+  font-size: 16px;
+  line-height: 1.55;
+  color: rgba(255, 255, 255, 0.92);
+  margin: 0;
+}
+
+.tutorial-lineup-modal-actions {
+  padding-bottom: 24px;
+}
+
+.tutorial-lineup-modal-cta {
+  width: 100%;
+}

--- a/FrontEnd/static/js/shared/tutorialLineupModals.js
+++ b/FrontEnd/static/js/shared/tutorialLineupModals.js
@@ -1,0 +1,294 @@
+/**
+ * FTE v2 tutorial — set-lineup intro + post-lineup feedback modals.
+ *
+ * Centered Functional-modal chrome (.gob-modal-*) + team-linked Sammy
+ * portrait overlapping the top edge. Matches the visual language of the
+ * Username modal (the canonical Functional + portrait pattern), simplified
+ * to body-only (no input field) since these modals exist to deliver a
+ * single message.
+ *
+ * Two exports:
+ *   showLineupIntroModal({ teamName, onDismiss }) — fires once on first
+ *     load of set-lineup in tutorial mode, before the user has touched
+ *     the slots.
+ *   showLineupFeedbackModal({ teamName, message, onConfirm }) — fires
+ *     when the user clicks Return To Game with a complete lineup; shows
+ *     the algorithm-chosen feedback message and a single CTA to navigate.
+ *
+ * The lineup-feedback algorithm itself (Talent + 19 qualifiers, random
+ * pick from the pool, Unconventional when none qualify) lives in
+ * pickLineupFeedbackMessage() below so the modal layer stays UI-only.
+ */
+
+import { getTeamSammyImage } from '/js/shared/teamCoachAsset.js';
+
+const STYLESHEETS = [
+  '/resource-pages.css',         // canonical .gob-modal-* classes
+  '/css/gob-buttons.css',
+  '/css/tutorial-lineup-modal.css',
+];
+
+function ensureStylesheets() {
+  STYLESHEETS.forEach((href) => {
+    if (document.querySelector(`link[href="${href}"]`)) return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = href;
+    document.head.appendChild(link);
+  });
+}
+
+function buildModal({ teamName, message, ctaLabel, ctaVariant, onConfirm }) {
+  ensureStylesheets();
+
+  const sammySrc = getTeamSammyImage(teamName);
+  // Per styleguide: --action (orange) for non-gating (intro Got It),
+  // --gate (green) for gating (feedback modal Return To Game IS the
+  // actual navigation trigger, so it advances game state).
+  const variantClass = ctaVariant === 'gate' ? 'gob-btn--gate' : 'gob-btn--action';
+
+  const overlay = document.createElement('div');
+  overlay.className = 'gob-modal-overlay';
+  overlay.setAttribute('role', 'dialog');
+  overlay.setAttribute('aria-modal', 'true');
+  overlay.innerHTML = `
+    <div class="gob-modal-backdrop"></div>
+    <div class="gob-modal-box tutorial-lineup-modal-box">
+      <div class="tutorial-lineup-modal-portrait-wrap" aria-hidden="true">
+        <img class="tutorial-lineup-modal-portrait" src="${sammySrc}" alt="">
+      </div>
+      <div class="gob-modal-accent"></div>
+      <div class="gob-modal-body tutorial-lineup-modal-body">
+        <p class="tutorial-lineup-modal-message">${message}</p>
+      </div>
+      <div class="gob-modal-actions tutorial-lineup-modal-actions">
+        <button type="button" class="gob-btn ${variantClass} tutorial-lineup-modal-cta">${ctaLabel}</button>
+      </div>
+    </div>
+  `;
+
+  document.body.appendChild(overlay);
+  // Force reflow so the .is-visible transition runs (matches Functional modal precedent).
+  // eslint-disable-next-line no-unused-expressions
+  overlay.offsetHeight;
+  overlay.classList.add('is-visible');
+
+  const ctaBtn = overlay.querySelector('.tutorial-lineup-modal-cta');
+
+  function close() {
+    if (!overlay.parentNode) return;
+    overlay.classList.remove('is-visible');
+    setTimeout(() => {
+      if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+    }, 180);
+  }
+
+  ctaBtn.addEventListener('click', () => {
+    try {
+      if (typeof onConfirm === 'function') onConfirm();
+    } finally {
+      close();
+    }
+  });
+
+  return { close, element: overlay };
+}
+
+export function showLineupIntroModal({ teamName, onDismiss }) {
+  return buildModal({
+    teamName,
+    message: "Here's your moment, Coach. Set your lineup for crunch time.",
+    ctaLabel: 'GOT IT',
+    ctaVariant: 'action', // non-gating acknowledgement
+    onConfirm: onDismiss,
+  });
+}
+
+export function showLineupFeedbackModal({ teamName, message, onConfirm }) {
+  return buildModal({
+    teamName,
+    message,
+    ctaLabel: 'RETURN TO GAME',
+    ctaVariant: 'gate', // gating — confirms the lineup and navigates to gameplay
+    onConfirm,
+  });
+}
+
+
+// =============================================================================
+// Lineup-feedback algorithm
+// =============================================================================
+//
+// Documented in fte_system.md §Set-Lineup Algorithm. Source of truth lives
+// here; doc mirrors it. If you change the messages or qualifiers, update
+// both places.
+
+const ATTRS_IN_PLAY = ['SC', 'SH', 'ID', 'OD', 'PS', 'BH', 'RB', 'ST', 'AG', 'ND', 'IQ'];
+
+const TALENT_MESSAGE = "You're putting your five best players on the court. Smart.";
+const UNCONVENTIONAL_MESSAGE = "A very unconventional lineup, Coach. You're going to keep our opponent very off-balance.";
+
+// Qualifier matchers: each takes the set of "top-2 attribute IDs" (a Set<string>)
+// and returns true if it qualifies. If qualified, the paired message is
+// added to the candidate pool.
+const QUALIFIERS = [
+  {
+    test: (t) => t.has('SC') && t.has('SH'),
+    message: "You're leading with your best scorers, good luck, Coach.",
+  },
+  {
+    test: (t) => t.has('ID') && t.has('OD'),
+    message: "You're leading with your best defenders, good luck, Coach.",
+  },
+  {
+    test: (t) => (t.has('SC') || t.has('SH')) && (t.has('ID') || t.has('OD')),
+    message: "You're balancing offense and defense, good luck, Coach.",
+  },
+  {
+    test: (t) => t.has('RB') && t.has('ST'),
+    message: "You're leading with your strong rebounders. Let's see how well they clean the boards.",
+  },
+  {
+    test: (t) => (t.has('ID') || t.has('OD')) && t.has('ST'),
+    message: "You're leading with muscle and defense. You're an intimidator, Coach.",
+  },
+  {
+    test: (t) => (t.has('SH') || t.has('SC')) && t.has('AG'),
+    message: "You're leading with your athletic scorers. I like it, Coach.",
+  },
+  {
+    test: (t) => t.has('PS') && t.has('BH'),
+    message: "You're leading with fundamentals. I like the discipline, Coach.",
+  },
+  {
+    test: (t) => t.has('ND') && t.has('AG'),
+    message: "This lineup is fast and athletic. Our opponent will have a difficult time keeping up with us.",
+  },
+  {
+    test: (t) => (t.has('SC') || t.has('SH')) && t.has('IQ'),
+    message: 'This is a smart offensive lineup.',
+  },
+  {
+    test: (t) => (t.has('ID') || t.has('OD')) && t.has('IQ'),
+    message: 'This is a smart defensive lineup.',
+  },
+  {
+    // "two of (ST, AG, ND)"
+    test: (t) => ['ST', 'AG', 'ND'].filter((k) => t.has(k)).length >= 2,
+    message: 'Leading with pure athleticism. I like it, Coach.',
+  },
+  {
+    test: (t) => (t.has('PS') || t.has('BH')) && t.has('IQ'),
+    message: 'A very cerebral and disciplined lineup. Good luck, Coach.',
+  },
+  {
+    test: (t) => (t.has('SC') || t.has('SH')) && (t.has('ST') || t.has('AG') || t.has('ND')),
+    message: 'This is an athletically focused offensive lineup. Good luck, Coach.',
+  },
+  {
+    test: (t) => (t.has('ID') || t.has('OD')) && (t.has('ST') || t.has('AG') || t.has('ND')),
+    message: 'This is an athletically focused defensive lineup. Good luck, Coach.',
+  },
+  {
+    test: (t) => (t.has('SC') || t.has('SH')) && (t.has('BH') || t.has('PS')),
+    message: 'This is a technically focused offensive lineup. Good luck, Coach.',
+  },
+  {
+    test: (t) => (t.has('ID') || t.has('OD')) && (t.has('BH') || t.has('PS')),
+    message: 'This is a technically focused defensive lineup. Good luck, Coach.',
+  },
+  {
+    test: (t) => (t.has('SC') || t.has('SH')) && t.has('RB'),
+    message: 'This is a rebounding focused offensive lineup. Good luck, Coach.',
+  },
+  {
+    test: (t) => (t.has('ID') || t.has('OD')) && t.has('RB'),
+    message: 'This is a rebounding focused defensive lineup. Good luck, Coach.',
+  },
+];
+
+/**
+ * Compute the "top 2" set of attribute IDs (by total across the 5 starters).
+ * Includes all ties at the #1 OR #2 rank, per the spec — so if 3 attributes
+ * share the top spot, all 3 are included; if SC is #1 alone and SH/IQ/ST
+ * are tied at #2, all 4 are included.
+ *
+ * @param {Array<{attributes:object}>} starters — 5 player objects with
+ *   anchor_<attr> or <attr> fields on player.attributes
+ * @returns {Set<string>}
+ */
+function computeTopTwoAttributes(starters) {
+  const totals = {};
+  for (const attr of ATTRS_IN_PLAY) {
+    let sum = 0;
+    for (const p of starters) {
+      const a = p.attributes || {};
+      const raw = a[`anchor_${attr}`] ?? a[attr] ?? 0;
+      sum += Number(raw) || 0;
+    }
+    totals[attr] = sum;
+  }
+  // Sort attribute totals descending. Identify the cutoff value at rank 2
+  // (or rank 1 if there's only one distinct value). Include all attributes
+  // with totals >= the cutoff.
+  const sortedDescUnique = Array.from(new Set(Object.values(totals))).sort((a, b) => b - a);
+  const cutoff = sortedDescUnique[1] ?? sortedDescUnique[0] ?? 0;
+  const top = new Set();
+  for (const attr of ATTRS_IN_PLAY) {
+    if (totals[attr] >= cutoff) top.add(attr);
+  }
+  return top;
+}
+
+/**
+ * Returns true iff the 5 chosen starters are the top 5 players on the roster
+ * by their highest position rating (RT). Ties at the 5th spot: include all
+ * ties — the user qualifies for Talent as long as the chosen 5 are among
+ * the top-RT-tier players.
+ *
+ * @param {Array<object>} starters — 5 player objects with position_ratings
+ * @param {Array<object>} fullRoster — the full team roster
+ */
+function isTopFiveRtLineup(starters, fullRoster) {
+  if (!Array.isArray(starters) || !Array.isArray(fullRoster)) return false;
+  if (starters.length !== 5) return false;
+  if (fullRoster.length < 5) return false;
+  const rt = (p) => {
+    const r = Object.values(p.position_ratings || {});
+    return r.length ? Math.max(...r) : -Infinity;
+  };
+  const sortedRoster = [...fullRoster].sort((a, b) => rt(b) - rt(a));
+  const fifthRt = rt(sortedRoster[4]);
+  // Top-RT tier = every player whose highest RT >= the 5th-best player's RT.
+  // (Captures ties at the cutoff so a 6th player tied with the 5th doesn't
+  // make Talent silently impossible.)
+  const eligibleIds = new Set(
+    sortedRoster.filter((p) => rt(p) >= fifthRt).map((p) => p._id)
+  );
+  return starters.every((p) => eligibleIds.has(p._id));
+}
+
+/**
+ * Pick a single lineup-feedback message per the spec:
+ *   - Talent qualifies if all 5 chosen starters are top-5-RT.
+ *   - Each of the 18 skill-based qualifiers checks against the top-2 attrs.
+ *   - Talent + all qualifying skill messages form the candidate pool.
+ *   - Pool size 1 → use it. Pool size 2+ → random pick. Pool size 0 → Unconventional.
+ *
+ * @param {Array<object>} starters — the user's chosen 5 starters
+ * @param {Array<object>} fullRoster — the user team's full roster (for Talent check)
+ * @returns {string}
+ */
+export function pickLineupFeedbackMessage(starters, fullRoster) {
+  const pool = [];
+  if (isTopFiveRtLineup(starters, fullRoster)) pool.push(TALENT_MESSAGE);
+
+  const topTwo = computeTopTwoAttributes(starters);
+  for (const q of QUALIFIERS) {
+    if (q.test(topTwo)) pool.push(q.message);
+  }
+
+  if (pool.length === 0) return UNCONVENTIONAL_MESSAGE;
+  if (pool.length === 1) return pool[0];
+  return pool[Math.floor(Math.random() * pool.length)];
+}

--- a/FrontEnd/static/set-lineup.js
+++ b/FrontEnd/static/set-lineup.js
@@ -2045,54 +2045,32 @@ async function init() {
     autosetBtn.addEventListener('click', autosetLineup);
   }
 
-  // FTE v2 tutorial: init-game has already run on the situation page, so the
-  // lineup is in the URL (restoreLineupFromUrl populates it above). We do NOT
-  // call autoset here — the engine assigned the tutorial-roster starters
-  // (rank_roster + Section 5 templates) and we want to honor that exactly.
-  //
-  // Onboarding redesign: replaces the previous centered "I've set your
-  // lineup" Sammy modal with a coach-mark spotlight anchored to the roster.
-  // Coach-marks are their own guidance pattern (per styleguide), distinct
-  // from the three modal types — they leave the screen visible so the
-  // copy points at the very thing it's describing.
+  // FTE v2 tutorial: the slots load empty (tutorial-situation no longer
+  // forwards home_pg/etc.) — the user sets their own lineup as part of
+  // the lesson. On first paint, show a centered Functional-modal-style
+  // intro that nudges them into the task. The CTA is renamed "Return To
+  // Game" here, and clicking it shows a second modal with algorithm-
+  // chosen feedback before actual navigation.
   if (modeParam === 'tutorial') {
+    const playBtnEl = document.getElementById('play-now');
+    if (playBtnEl) playBtnEl.textContent = 'Return To Game';
+
     const introKey = gameId
-      ? `fteV2TutorialLineupCoachMarkShown_${gameId}`
-      : 'fteV2TutorialLineupCoachMarkShown';
+      ? `fteV2TutorialLineupModalShown_${gameId}`
+      : 'fteV2TutorialLineupModalShown';
     const alreadyShown = (() => {
       try { return sessionStorage.getItem(introKey) === '1'; } catch (_) { return false; }
     })();
-    if (!alreadyShown) {
-      try { sessionStorage.setItem(introKey, '1'); } catch (_) {}
-      // Resolve the team-linked Sammy portrait. `homeTeam` here is the
-      // user's team (per fte_inject_state §1-§2, user is always home).
-      Promise.all([
-        import('/js/shared/coachMark.js'),
-        import('/js/shared/teamCoachAsset.js'),
-        import('/js/shared/tutorialProgressThread.js'),
-      ]).then(([{ showCoachMark }, { getTeamSammyImage }, { mountTutorialProgress }]) => {
-        mountTutorialProgress('lineup');
-        // Wait one frame for the roster to render before anchoring.
-        requestAnimationFrame(() => {
-          showCoachMark({
-            anchor: document.getElementById('roster-table-container'),
-            side: 'right',
-            offset: 18,
-            eyebrow: 'QUICK TIP',
-            body: "I've set a solid lineup for you. Hover any attribute to learn what it does — then tweak the lineup if you want.",
-            dismissLabel: 'GOT IT',
-            portraitSrc: getTeamSammyImage(homeTeam),
-            count: 'Tip 1 of 1',
-          });
-        });
-      }).catch((e) => console.warn('[tutorial] could not show lineup coach-mark:', e));
-    } else {
-      // Re-entry (return from game-plan, timeout-resume, etc.) — keep the
-      // progress thread present but don't re-show the tip.
-      import('/js/shared/tutorialProgressThread.js')
-        .then(({ mountTutorialProgress }) => mountTutorialProgress('lineup'))
-        .catch(() => {});
-    }
+    Promise.all([
+      import('/js/shared/tutorialProgressThread.js'),
+      alreadyShown ? Promise.resolve(null) : import('/js/shared/tutorialLineupModals.js'),
+    ]).then(([{ mountTutorialProgress }, lineupModals]) => {
+      mountTutorialProgress('lineup');
+      if (!alreadyShown && lineupModals) {
+        try { sessionStorage.setItem(introKey, '1'); } catch (_) {}
+        lineupModals.showLineupIntroModal({ teamName: homeTeam });
+      }
+    }).catch((e) => console.warn('[tutorial] could not init lineup tutorial chrome:', e));
   }
 
   const btn = document.getElementById('play-now');
@@ -2234,8 +2212,37 @@ async function init() {
       const finalUrl = `/court.html?${params.toString()}`;
       console.log('🔍 [DEBUG QTR BREAK] set-lineup.js - Navigating to court.html:', finalUrl);
       playSound('confirm-1-lowervol.wav');
-      // Delay navigation so the sound can start before the page unloads
-      setTimeout(() => { window.location.href = finalUrl; }, 200);
+      const navigate = () => setTimeout(() => { window.location.href = finalUrl; }, 200);
+
+      // FTE v2 tutorial: insert a feedback modal between Return To Game and
+      // the actual navigation. Algorithm picks a Talent / skill-based /
+      // Unconventional message based on the user's chosen starters. The
+      // modal's CTA is the real navigation trigger.
+      if (modeParam === 'tutorial') {
+        try {
+          const { showLineupFeedbackModal, pickLineupFeedbackMessage } = await import('/js/shared/tutorialLineupModals.js');
+          const starters = ['PG', 'SG', 'SF', 'PF', 'C']
+            .map((pos) => lineup[pos])
+            .filter(Boolean)
+            .map((id) => roster.find((p) => p._id === id))
+            .filter(Boolean);
+          const message = pickLineupFeedbackMessage(starters, roster);
+          showLineupFeedbackModal({
+            teamName: homeTeam,
+            message,
+            onConfirm: navigate,
+          });
+        } catch (e) {
+          // If the feedback modal fails to load, don't block the user from
+          // proceeding — fall through to direct navigation.
+          console.warn('[tutorial] lineup feedback modal failed; proceeding:', e);
+          navigate();
+        }
+        return;
+      }
+
+      // Non-tutorial: navigate directly.
+      navigate();
     });
   }
   // Game Plan, Playbooks, Box Score wired in wireLineupNavButtons()

--- a/FrontEnd/static/tutorial-situation.js
+++ b/FrontEnd/static/tutorial-situation.js
@@ -93,7 +93,11 @@ async function initTutorialGame(userTeam, opponent) {
   }
 }
 
-function gotoSetLineup(userTeam, opponent, gameId, lineup) {
+function gotoSetLineup(userTeam, opponent, gameId, _lineup) {
+  // Tutorial set-lineup deliberately leaves the 5 slots blank — the user
+  // sets their own lineup as part of the lesson. We no longer forward
+  // home_pg / home_sg / etc. URL params even when the backend provides a
+  // tutorial_lineup hint, so the slots render empty.
   const params = new URLSearchParams({
     mode: 'tutorial',
     home: userTeam,
@@ -103,9 +107,6 @@ function gotoSetLineup(userTeam, opponent, gameId, lineup) {
     team_id: userTeam,
   });
   if (gameId) params.set('game_id', gameId);
-  ['PG', 'SG', 'SF', 'PF', 'C'].forEach(pos => {
-    if (lineup[pos]) params.set(`home_${pos.toLowerCase()}`, lineup[pos]);
-  });
   window.location.href = `/set-lineup.html?${params.toString()}`;
 }
 

--- a/_documentation_master/00_General_Systems/fte_system.md
+++ b/_documentation_master/00_General_Systems/fte_system.md
@@ -29,7 +29,7 @@ Grandfathered users (those who already had a franchise when FTE v2 shipped, or n
 | 1 | **Pick Your Program** | `franchise-select-team.html?mode=tutorial` | `team_select` | Existing team cards + orange-ring selected state | (card tap opens modal) |
 | 2 | **Username** | Functional modal over screen 1 | `username` | `.gob-modal-*` chrome (Functional) | `CONTINUE` orange |
 | 3 | **Pre-Game Tip-off** | `tutorial-situation.html` | `situation` | Moment modal (560px, banner bg, score hero) | **`SET LINEUP` green** ← only green in the flow |
-| 4 | **Set Lineup** | `set-lineup.html?mode=tutorial&...` | `set_lineup` → `in_game` | Coach-mark (not a modal) anchored to roster | `GOT IT` ghost (acks tip); `PLAY GAME` green (gating, outside FTE scope) |
+| 4 | **Set Lineup** | `set-lineup.html?mode=tutorial&...` | `set_lineup` → `in_game` | Centered Functional modal w/ team Sammy (intro on load + feedback on CTA click) | `GOT IT` orange (intro); `RETURN TO GAME` green (gating; also relabeled on the page CTA) |
 
 The actual game runs on `court.html?mode=tutorial`; the End-of-Game modal renders the tutorial variant of `gameCompletionPopup.js`.
 
@@ -55,7 +55,7 @@ Helper: `FrontEnd/static/js/shared/teamCoachAsset.js`. Team-name → abbreviatio
 
 ### Action color (Styleguide §)
 
-Green = gating (advances game state). Orange = non-gating primary. In the FTE flow, **exactly one green button**: the Tip-off `SET LINEUP`. Username `CONTINUE`, Persona `LET'S GO`, and any other onboarding CTA are orange. Coach-mark `GOT IT` is ghost — it's an acknowledgement, not an action.
+Green = gating (advances game state). Orange = non-gating primary. In the FTE flow, **two green buttons by design**: the Tip-off `SET LINEUP` and the set-lineup-page `RETURN TO GAME` (both advance game state). Username `CONTINUE`, Persona `LET'S GO`, lineup intro `GOT IT`, and any other onboarding CTA are orange. The lineup-feedback modal's `RETURN TO GAME` is the green CTA (it's the actual navigation trigger; the page-level Return To Game button just opens the feedback modal).
 
 Universal button class system: `FrontEnd/static/css/gob-buttons.css` (`.gob-btn--action` / `--gate` / `--ghost`, plus `--lg`).
 
@@ -91,7 +91,7 @@ TutorialStep = Literal[
 | `team_select` | persona-intro CTA | `/franchise-select-team.html?mode=tutorial` | card `Select` → advance to `username` (+ `team_pick`) |
 | `username` | card select | (modal stays on team-select) | `CONTINUE` → set-username + advance to `situation` |
 | `situation` | username success | `/tutorial-situation.html` | `SET LINEUP` → init-game + advance to `set_lineup` |
-| `set_lineup` | tip-off CTA | `/set-lineup.html?mode=tutorial&quarter=4&...` | `PLAY GAME` → advance to `in_game` |
+| `set_lineup` | tip-off CTA | `/set-lineup.html?mode=tutorial&quarter=4&...` (slots load empty) | `RETURN TO GAME` → opens lineup-feedback modal → modal CTA advances to `in_game` and navigates |
 | `in_game` | play CTA | `/court.html?mode=tutorial&...` | game completes → `complete` |
 | `complete` | EOG locker-room click | `/mode-select.html` | (terminal; `fte_v2_complete=true`) |
 
@@ -181,7 +181,7 @@ Mutates both `GameManager` and the `summary` dict. Injected state:
 | `player.metadata["fouls"]` | per template `F` column (cumulative; doesn't reset per Q) |
 | `NG` (energy) all players | `0.95` |
 | `MO` (momentum) all players | `0` |
-| `team.lineup` | engine-derived starting five (from `rank_roster`) |
+| `team.lineup` | engine-derived starting five (from `rank_roster`) — **harmless default**; the frontend no longer surfaces these as URL hints on set-lineup, and the user's chosen lineup overrides this on Return To Game |
 | `playbook_settings` | the 8 user offense plays above |
 | `timeout_next_play_type` | `SIDE_INBOUND` |
 | `game_stats_initialized` | `True` (critical — engine zeroes stats otherwise) |
@@ -215,8 +215,9 @@ Tutorial follows the `single` path through `finalizeGame.js` (no franchise/tourn
 | File | Purpose |
 |---|---|
 | `js/shared/teamCoachAsset.js` | Team → Sammy image path |
-| `js/shared/tutorialProgressThread.js` + `css/tutorial-progress.css` | 5-dot progress indicator |
-| `js/shared/coachMark.js` + `css/coach-mark.css` | Spotlight tooltip primitive (Screen 4) |
+| `js/shared/tutorialProgressThread.js` + `css/tutorial-progress.css` | 6-dot progress indicator |
+| `js/shared/tutorialLineupModals.js` + `css/tutorial-lineup-modal.css` | Set-lineup intro + post-lineup feedback modals; also exports `pickLineupFeedbackMessage` (the algorithm) |
+| `js/shared/coachMark.js` + `css/coach-mark.css` | Spotlight tooltip primitive — **available but not currently used in the FTE flow** (set-lineup intro switched to a centered Functional modal); kept for future tutorials |
 | `js/shared/getGameMode.js` | Single source of truth for the mode value passed to EOG popup (see §8) |
 | `js/shared/rtBucket.js` + `css/rt-buckets.css` | RT color bucket helper (exposes `window.getRtBucketClass`) |
 | `css/gob-buttons.css` | `.gob-btn` system (--action / --gate / --ghost / --lg) |
@@ -227,9 +228,50 @@ Tutorial follows the `single` path through `finalizeGame.js` (no franchise/tourn
 
 | Pattern | Classes / file | Used by |
 |---|---|---|
-| Functional modal | `.gob-modal-*` in `resource-pages.css` (canonical = Auto-Train confirmation in `training.html`) | Username modal |
+| Functional modal | `.gob-modal-*` in `resource-pages.css` (canonical = Auto-Train confirmation in `training.html`) | Username modal, set-lineup intro modal, set-lineup feedback modal |
 | Moment modal | inline in `css/tutorial-tipoff.css` (canonical = `gameCompletionPopup.js`) | Tip-off, EOG |
-| Coach-mark | `.gob-coachmark*` in `css/coach-mark.css` (new primitive — distinct from the three modal types) | Set-lineup intro |
+| Coach-mark | `.gob-coachmark*` in `css/coach-mark.css` | Available primitive; not currently used in FTE |
+
+### Set-lineup tutorial flow
+
+The tutorial set-lineup intentionally loads with empty slots — the user fills their own lineup as part of the lesson. Two modals bracket the experience, both centered Functional-modal chrome with team-linked Sammy portrait overlapping the top edge:
+
+1. **Intro modal** (fires once per `game_id`, sessionStorage guard): "Here's your moment, Coach. Set your lineup for crunch time." Single `GOT IT` orange CTA.
+2. **Feedback modal** (fires every Return To Game click): algorithm-chosen message + single green `RETURN TO GAME` CTA that performs the actual navigation to `court.html`.
+
+The page-level `play-now` button is relabeled "Return To Game" in tutorial mode (still uses the existing green disabled-until-complete styling).
+
+### Set-lineup feedback algorithm
+
+Implemented in `js/shared/tutorialLineupModals.js → pickLineupFeedbackMessage(starters, fullRoster)`. Source of truth lives in the module; this section mirrors it.
+
+**Pool composition** (all checks run together; build a candidate pool, then pick):
+
+| Check | Qualifies if | Message |
+|---|---|---|
+| **Talent** | The 5 chosen starters are the team's top-5 by highest RT (ties at the 5th-place RT all count as eligible) | "You're putting your five best players on the court. Smart." |
+| SC & SH | Both in top-2 attrs | "You're leading with your best scorers, good luck, Coach." |
+| ID & OD | Both in top-2 | "You're leading with your best defenders, good luck, Coach." |
+| (SC or SH) and (ID or OD) | One of each in top-2 | "You're balancing offense and defense, good luck, Coach." |
+| RB & ST | Both in top-2 | "You're leading with your strong rebounders. Let's see how well they clean the boards." |
+| (ID or OD) and ST | At least one defensive + ST in top-2 | "You're leading with muscle and defense. You're an intimidator, Coach." |
+| (SC or SH) and AG | Offensive + AG in top-2 | "You're leading with your athletic scorers. I like it, Coach." |
+| PS & BH | Both in top-2 | "You're leading with fundamentals. I like the discipline, Coach." |
+| ND & AG | Both in top-2 | "This lineup is fast and athletic. Our opponent will have a difficult time keeping up with us." |
+| (SC or SH) and IQ | Offensive + IQ in top-2 | "This is a smart offensive lineup." |
+| (ID or OD) and IQ | Defensive + IQ in top-2 | "This is a smart defensive lineup." |
+| 2+ of (ST, AG, ND) | At least two of those three in top-2 | "Leading with pure athleticism. I like it, Coach." |
+| (PS or BH) and IQ | Either + IQ in top-2 | "A very cerebral and disciplined lineup. Good luck, Coach." |
+| (SC or SH) and (ST/AG/ND) | Offensive + any athleticism in top-2 | "This is an athletically focused offensive lineup. Good luck, Coach." |
+| (ID or OD) and (ST/AG/ND) | Defensive + any athleticism in top-2 | "This is an athletically focused defensive lineup. Good luck, Coach." |
+| (SC or SH) and (BH or PS) | Offensive + fundamentals in top-2 | "This is a technically focused offensive lineup. Good luck, Coach." |
+| (ID or OD) and (BH or PS) | Defensive + fundamentals in top-2 | "This is a technically focused defensive lineup. Good luck, Coach." |
+| (SC or SH) and RB | Offensive + RB in top-2 | "This is a rebounding focused offensive lineup. Good luck, Coach." |
+| (ID or OD) and RB | Defensive + RB in top-2 | "This is a rebounding focused defensive lineup. Good luck, Coach." |
+
+**Top-2 attrs** = the set of attribute IDs whose total across the 5 starters is at the #1 or #2 rank (ties at either rank all included). Attrs in play: `SC, SH, ID, OD, PS, BH, RB, ST, AG, ND, IQ`.
+
+**Pick rule**: pool size 1 → use it. Pool size 2+ → random pick. Pool size 0 → Unconventional: "A very unconventional lineup, Coach. You're going to keep our opponent very off-balance."
 
 ### EOG / debut publish
 
@@ -280,7 +322,7 @@ These are real regressions we've hit. Listed so the next person doesn't pay the 
 | 2 | **Duplicated mode derivation at EOG callsites.** Four call-sites of `showGameCompletionPopup` were independently building `mode`. One missed the tutorial branch → Box Score reappeared, locker-room routed wrong, `tutorial-complete` never fired, authBar bounced back to situation. | Always go through `js/shared/getGameMode.js`. |
 | 3 | **Stale `.pre-game-container` flash on court.html.** It used to default to visible; bootGame then decided whether to hide. Caused a "Play Quarter / Sim Quarter" flash before live court paint. | `.pre-game-container.hidden` by default. bootGame removes `.hidden` only when it explicitly wants to show. Overlay dismisses on `court-ready` event dispatched from `bootGame.initGame()`. Don't revert. |
 | 4 | **Bare `.rt-low` etc. without `!important`.** Page-local `.roster-table td { color: ... }` rules (specificity 0,1,1) silently override the bucket classes (0,1,0). | `/css/rt-buckets.css` uses `!important` deliberately. These are canonical scale colors; they should always win. |
-| 5 | **Forgetting to flush `sessionStorage` lineup-intro guard on rerun.** Tutorial coach-mark uses key `fteV2TutorialLineupCoachMarkShown_${gameId}`. Renamed from the prior Sammy-modal key; if you re-tour an existing user, prior runs' keys are harmless but new runs key off the fresh game_id. | No action needed; documented so you don't think it's broken when it skips on re-entry. |
+| 5 | **Forgetting to flush `sessionStorage` lineup-intro guard on rerun.** Tutorial set-lineup intro modal uses key `fteV2TutorialLineupModalShown_${gameId}` (renamed from the prior coach-mark / Sammy-modal keys; old keys are harmless leftovers). Each fresh game_id gets its own key so re-tours work. | No action needed; documented so you don't think it's broken when it skips on re-entry. |
 
 ---
 
@@ -326,4 +368,37 @@ For commit-level history, `git log --grep "FTE v2"`. High-level milestones:
 
 
 **Set Lineup Alogrithm**
+##If User has the players with the top 5 RT values on the team, add Talent message to the list of possible choices.
 
+##Skill based logic
+- Attributes in play: SC, SH, ID, OD, PS, BH, RB, ST, AG, ND, IQ
+- Step 1: Calculate the total attributes value for attributes in play for the user's lineup. 
+- Step 2: Identify the top 2 attributes in terms of total. If 2 or more are tied for the second, include them all. Example: 1. SC: 54, 2. SH: 53, ST: 53, IQ: 53 -- all four of those would be considered "Top 2". LMK if that is not clear.
+- Step 3: Choose the outgoing modal messsage based on the top 2 attributes.
+
+##Outgoing modal messages
+**Talent** 
+- "You're putting your five best players on the court. Smart."
+**Skill Based** Track all of the below that qualify based on the top 2 attributes for the lineup
+- SC & SH: "You're leading with your best scorers, good luck Coach."
+- ID & OD: "You're leading with your best defenders, good luck Coach."
+- one of (SC or SH) and one of (ID or OD): "You're balancing offense and defense, good luck Coach."
+- RB & ST: "You're leading with your strong rebounders. Let's see how well they clean the boards."
+- one of (ID or OD) and ST: "You're leading with muscle and defense. You're an intimidator, Coach."
+- one of (SH or SC) and AG: "You're leading with your athletic scorers. I like it Coach."
+- PS & BH: "You're leading wtih fundamentals. I like the discipline, Coach."
+- ND & AG: "This lineup is fast and athletic. Our opponent will have a difficult time keeping up with us."
+- one of (SC or SH) and IQ: "This is a smart offensive lineup."
+- one of (ID or OD) and IQ: "This is a smart defensive lineup."
+- two of (ST, AG, ND): "Leading with pure athletcisim. I like it, Coach."
+- one of (PS or BH) and IQ: "A very cerebral and disciplines lineup. Good luck Coach."
+- if the list is zero after checking for qualifiers, use the unconventional message
+- one of (SC or SH) and one of (ST, AG, ND): "This is an athletically focused offensive lineup. Good luck Coach."
+- one of (ID or OD) and one of (ST, AG, ND): "This is an athletically focused defensive lineup. Good luck Coach."
+- one of (SC or SH) and one of (BH or PS): "This is an technically focused offensive lineup. Good luck Coach."
+- one of (ID or OD) and one of (BH or PS): "This is an technically focused defensive lineup. Good luck Coach."
+- one of (SC or SH) and RB: "This is an rebouning focused offensive lineup. Good luck Coach."
+- one of (ID or OD) and RB: "This is an rebounding focused defensive lineup. Good luck Coach."
+
+**Unconventional Message**
+- "A very unconventional lineup, Coach. You're going to keep our opponent very off-balance."


### PR DESCRIPTION
Reworks the tutorial set-lineup experience per spec.

## Flow change
1. **Slots load empty** — `tutorial-situation.js` stops forwarding `home_pg/sg/sf/pf/c` URL params. The user picks their own 5. (Backend still pre-computes a lineup as a harmless default; user always overrides.)
2. **Intro modal** on first paint (sessionStorage-guarded per game_id): centered Functional modal w/ team-linked Sammy overlapping the top edge.
   - Copy: *"Here's your moment, Coach. Set your lineup for crunch time."* (fixed comma + "you" → "your" from your draft)
   - CTA: \`GOT IT\` (orange — acknowledgement)
3. **Page CTA renamed** "Play Game" → "Return To Game".
4. **Feedback modal** on Return To Game click: same chrome, body holds the algorithm-chosen message, CTA is \`RETURN TO GAME\` (**green — this is the actual gating navigation trigger**).

## Algorithm (in [\`js/shared/tutorialLineupModals.js\`](FrontEnd/static/js/shared/tutorialLineupModals.js))

- **Talent** qualifies if all 5 chosen starters are top-5 RT (ties at the 5th-place RT all count).
- **Top-2 attrs** = all attrs at rank #1 OR #2 in totals across the 5 starters (ties at either rank all included). Attrs in play: \`SC SH ID OD PS BH RB ST AG ND IQ\`.
- **18 skill-based qualifiers** + Talent form a candidate pool. 1 match → use it. 2+ → random pick. 0 → Unconventional fallback.

Full qualifier table is documented in [\`fte_system.md\` §6 "Set-lineup feedback algorithm"](_documentation_master/00_General_Systems/fte_system.md) as the source of truth.

## Typos / grammar fixed
| Original | Fixed |
|---|---|
| "leading wtih fundamentals" | "leading **with** fundamentals" |
| "pure athletcisim" | "pure **athleticism**" |
| "cerebral and **disciplines**" | "cerebral and **disciplined**" |
| "I like it Coach." (×N) | "I like it**, Coach.**" |
| "Good luck Coach." (×N) | "Good luck**, Coach.**" |
| "This is **an** technically focused…" (×2) | "This is **a** technically focused…" |
| "This is **an** rebouning focused…" | "This is **a** rebounding focused…" |
| "This is **an** rebounding focused…" | "This is **a** rebounding focused…" |
| "Here's your moment Coach. Set **you** lineup…" | "Here's your moment**, Coach.** Set **your** lineup…" |

## New / changed files
| File | Purpose |
|---|---|
| `js/shared/tutorialLineupModals.js` (new) | Both modals + algorithm |
| `css/tutorial-lineup-modal.css` (new) | Portrait-overlap + body-only on top of canonical `.gob-modal-*` |
| `set-lineup.js` | Replace coach-mark intro with new modal flow; rename CTA; gate navigation behind feedback modal in tutorial mode |
| `tutorial-situation.js` | Stop forwarding lineup URL hints |
| `fte_system.md` | New §6 subsections + table-row updates |

## Test plan
- [ ] Fresh tutorial walkthrough → set-lineup slots are **empty**, intro modal appears once with proper copy + team Sammy.
- [ ] Dismiss intro → slots remain empty, user can drag/click to fill.
- [ ] Return To Game button on the page reads "Return To Game" and is disabled until all 5 slots filled.
- [ ] Click Return To Game with a complete lineup → feedback modal appears with a message; click modal CTA → navigates to court.
- [ ] Try a Talent lineup (the top 5 by RT) → either Talent message shows alone or appears in random rotation with other qualifying messages.
- [ ] Try a unconventional lineup that triggers no qualifiers → Unconventional message shows.
- [ ] Non-tutorial single/franchise/tournament set-lineup unaffected (no modals, "Play Game" label, direct navigation).