### PR TITLE
FTE v2: progress thread — first dot label "Persona" → "Welcome"

### DIFF
--- a/FrontEnd/static/js/shared/tutorialProgressThread.js
+++ b/FrontEnd/static/js/shared/tutorialProgressThread.js
@@ -17,7 +17,7 @@
  */
 
 const STEPS = [
-  { id: 'persona', label: 'Persona' },
+  { id: 'persona', label: 'Welcome' },
   { id: 'program', label: 'Program' },
   { id: 'username', label: 'Username' },
   { id: 'tipoff', label: 'Tip-off' },


### PR DESCRIPTION
One-line copy tweak per Coach. Display label only — the step \`id\` stays \`persona\` so the URL (\`/tutorial-persona-intro.html\`), the backend \`tutorial_state.step\` enum, and routing logic are unaffected.

\`tutorialProgressThread.js\`:
\`\`\`diff
-  { id: 'persona', label: 'Persona' },
+  { id: 'persona', label: 'Welcome' },
\`\`\`