### PR TITLE
FTE v2: attribute tour stacking fix — dim siblings instead of full-screen scrim

### DIFF
--- a/FrontEnd/static/css/attribute-tour.css
+++ b/FrontEnd/static/css/attribute-tour.css
@@ -1,56 +1,47 @@
 /*
  * FTE v2 — Attribute Tour Mechanic (tutorial set-lineup, after intro modal).
  *
- * Layers (back → front):
- *   .attribute-tour__scrim      soft dark overlay over the whole page
- *   .attribute-tour__sammy      compact Sammy coach-mark anchored under the header row
- *   header-row classes          lifted above the scrim via z-index + gold glow
+ * Stacking approach: instead of laying one full-screen scrim *above* the
+ * page (which fights table-section stacking — <thead> z-index is
+ * notoriously unreliable in some browsers and the header row was
+ * rendering under the scrim), we DIM the siblings directly. The header
+ * row stays at its natural position, full opacity, with the gold ring +
+ * glow visible.
  *
- * The mechanic is additive — it never moves the table, never replaces the
- * existing tooltip helper, never alters columns. It only orchestrates the
- * spotlight, the shimmer cue, the per-header explored state, and Sammy.
- * Existing per-attribute tooltips remain the source of truth for what the
- * abbreviations mean.
+ * Layers (no overlay required):
+ *   .attribute-tour-dim     applied to surrounding content — opacity
+ *                           drops + pointer-events keep the user from
+ *                           clicking buttons mid-tour
+ *   thead / its <th>s       untouched — they stay at full opacity and
+ *                           get the gold ring/glow + shimmer cue
+ *   .attribute-tour__sammy  fixed, high z-index, above everything
+ *
+ * Existing per-attribute tooltips (position: fixed; z-index: 99999) keep
+ * rendering on top — unchanged.
  */
 
-/* ---------- Scrim ---------- */
+/* ---------- Dimmed siblings ---------- */
 
-.attribute-tour__scrim {
-  position: fixed;
-  inset: 0;
-  background: rgba(7, 9, 14, 0.66);
-  z-index: 1400;
-  opacity: 0;
-  pointer-events: auto;
+.attribute-tour-dim {
+  opacity: 0.30;
+  pointer-events: none;
   transition: opacity 220ms ease;
-}
-
-.attribute-tour__scrim.is-visible {
-  opacity: 1;
 }
 
 /* ---------- Lifted header row ---------- */
 
-/* Lift the table's thead above the scrim so it stays fully lit. */
-.attribute-tour-active thead.attribute-tour__lifted {
-  position: relative;
-  z-index: 1500;
-}
-
-/* Apply the gold ring + soft glow to a wrapper around the thead. We can't
- * box-shadow a <thead> reliably in all browsers, so the tour wraps each
- * header cell instead. */
+/* Gold ring + soft glow on each header cell. No z-index lift — the
+ * header is fully visible because nothing is over it. */
 .attribute-tour-active th.attribute-tour__lifted {
   position: relative;
-  z-index: 1500;
   background-color: rgba(11, 13, 20, 0.96);
   box-shadow:
     0 0 0 1px rgba(247, 148, 32, 0.5),
     0 0 38px rgba(247, 148, 32, 0.18);
 }
 
-/* Soften the gold ring on the leftmost/rightmost cells so they merge into
- * a single horizontal lit row visually (no broken borders between cells). */
+/* Build a clean horizontal band — internal vertical edges between
+ * adjacent lifted cells merge, only first/last carry the outer ring. */
 .attribute-tour-active th.attribute-tour__lifted + th.attribute-tour__lifted {
   box-shadow:
     inset 1px 0 0 rgba(247, 148, 32, 0.18),
@@ -59,7 +50,6 @@
     0 0 38px rgba(247, 148, 32, 0.18);
 }
 
-/* The very first lifted cell gets the left ring, the last gets the right. */
 .attribute-tour-active th.attribute-tour__lifted.is-first {
   box-shadow:
     inset 1px 0 0 rgba(247, 148, 32, 0.5),
@@ -78,7 +68,6 @@
 
 /* ---------- Per-header cue: shimmer underline ---------- */
 
-/* Only tooltipped headers get the shimmer cue — driven by .is-cued. */
 .attribute-tour-active th.is-cued {
   cursor: help;
 }
@@ -233,9 +222,9 @@
 }
 
 .attribute-tour__sammy-dismiss {
-  /* Build on the .gob-btn--ghost recipe inline so this file doesn't depend
-   * on /css/gob-buttons.css being loaded everywhere. Smaller-than-default
-   * to stay compact within the coach-mark. */
+  /* Ghost button recipe inlined so this file doesn't depend on
+   * /css/gob-buttons.css being loaded everywhere. Compact size to fit
+   * inside the coach-mark. */
   appearance: none;
   cursor: pointer;
   display: inline-flex;

--- a/FrontEnd/static/js/shared/attributeTour.js
+++ b/FrontEnd/static/js/shared/attributeTour.js
@@ -5,9 +5,17 @@
  * Runs in tutorial mode only, after the "Here's your moment, Coach"
  * intro modal dismisses.
  *
+ * Stacking approach: we DIM the surrounding siblings directly instead of
+ * laying a full-screen scrim over everything. <thead> z-index is
+ * notoriously unreliable against a full-screen overlay (early build of
+ * this mechanic had the gold ring + headers rendering UNDER the scrim).
+ * Dimming siblings keeps the header row at its natural position — fully
+ * lit, ring visible, no stacking-order fragility.
+ *
  * What it does:
- *   1. Lays a soft scrim over the page; lifts the table header row above it
- *      with a quiet gold ring so the rest of the page recedes.
+ *   1. Adds .attribute-tour-dim to caller-specified surrounding elements
+ *      (banner, score bar, toggle, tbody, footnote, right panel). Each
+ *      drops to opacity 0.30 + pointer-events: none.
  *   2. Adds a shimmer underline cue to each tooltipped header.
  *   3. Mounts a compact Sammy coach-mark just below the header row,
  *      pointing up at it, with a live "X of N explored" counter and a
@@ -26,10 +34,11 @@
  *   import { showAttributeTour } from '/js/shared/attributeTour.js';
  *
  *   showAttributeTour({
- *     headerRow:   <tr|thead element>,         // required — the row to lift
- *     teamName:    'Bentley-Truman',           // for the team-linked Sammy
- *     persistKey:  'fteV2AttrTourSeen',        // optional, defaults shown
- *     onDismiss:   () => { ... },              // optional callback after dismiss
+ *     headerRow:    <tr|thead element>,                 // required — the row to spotlight
+ *     teamName:     'Bentley-Truman',                   // for the team-linked Sammy
+ *     dimSelectors: ['.lineup-banner-strip', ...],      // caller-owned list of siblings to dim
+ *     persistKey:   'fteV2AttrTourSeen',                // optional, defaults shown
+ *     onDismiss:    () => { ... },                      // optional callback after dismiss
  *   });
  */
 
@@ -115,11 +124,21 @@ export function showAttributeTour(opts = {}) {
 
   document.body.classList.add('attribute-tour-active');
 
-  // Scrim.
-  const scrim = document.createElement('div');
-  scrim.className = 'attribute-tour__scrim';
-  scrim.setAttribute('aria-hidden', 'true');
-  document.body.appendChild(scrim);
+  // Dim siblings. Caller passes a list of CSS selectors for the elements
+  // that should fade back during the tour (banner, score bar, table body,
+  // right-hand panel, etc.). Each matched element gets .attribute-tour-dim
+  // applied — opacity drops + pointer-events disable so the user can't
+  // accidentally click into game-plan/etc. mid-tour. The header row is
+  // intentionally NOT in this list; it stays at its natural position with
+  // full opacity and the gold ring/glow.
+  const dimSelectors = Array.isArray(opts.dimSelectors) ? opts.dimSelectors : [];
+  const dimmedEls = [];
+  dimSelectors.forEach((sel) => {
+    document.querySelectorAll(sel).forEach((el) => {
+      el.classList.add('attribute-tour-dim');
+      dimmedEls.push(el);
+    });
+  });
 
   // Sammy coach-mark.
   const sammyImg = getTeamSammyImage(opts.teamName);
@@ -165,9 +184,8 @@ export function showAttributeTour(opts = {}) {
     sammy.style.setProperty('--sammy-arrow-x', `${Math.max(20, Math.min(arrowX, sammyRect.width - 20))}px`);
   }
 
-  // Reveal scrim + sammy on next frame so the entrance transitions run.
+  // Reveal sammy on next frame so the entrance transition runs.
   requestAnimationFrame(() => {
-    scrim.classList.add('is-visible');
     sammy.classList.add('is-visible');
     // Position after the first paint so getBoundingClientRect is accurate.
     requestAnimationFrame(positionSammy);
@@ -227,13 +245,15 @@ export function showAttributeTour(opts = {}) {
 
   function close() {
     markSeen(persistKey);
-    scrim.classList.remove('is-visible');
     sammy.classList.remove('is-visible');
+    // Lift the dim immediately so the page comes back into focus while
+    // the Sammy bubble fades — feels more responsive than waiting for
+    // both to fade together.
+    dimmedEls.forEach((el) => el.classList.remove('attribute-tour-dim'));
     window.removeEventListener('resize', reposition);
     window.removeEventListener('scroll', reposition, true);
     cleanupFns.forEach((fn) => fn());
     setTimeout(() => {
-      if (scrim.parentNode) scrim.parentNode.removeChild(scrim);
       if (sammy.parentNode) sammy.parentNode.removeChild(sammy);
       // Restore the table — strip every class we added.
       thCells.forEach((th) => {

--- a/FrontEnd/static/set-lineup.js
+++ b/FrontEnd/static/set-lineup.js
@@ -2077,7 +2077,24 @@ async function init() {
         // Defer a frame so any post-intro-modal layout settles before we
         // measure the header row for Sammy positioning.
         requestAnimationFrame(() => {
-          showAttributeTour({ headerRow, teamName: homeTeam });
+          showAttributeTour({
+            headerRow,
+            teamName: homeTeam,
+            // Dim everything around the header row instead of laying a
+            // scrim on top — <thead> z-index is unreliable against a
+            // full-screen overlay (early build had the header rendering
+            // UNDER the dim). These are the siblings that should fade
+            // back during the tour; the header row itself is absent.
+            dimSelectors: [
+              '.lineup-banner-strip',
+              '.lineup-context-bar',
+              '.lineup-roster-header-row',
+              '#roster-body',
+              '#roster-pos-note',
+              '.roster-panel-actions',
+              '.lineup-right-panel',
+            ],
+          });
         });
       };
       if (!alreadyShown && lineupModals) {

--- a/_documentation_master/00_General_Systems/fte_system.md
+++ b/_documentation_master/00_General_Systems/fte_system.md
@@ -247,10 +247,12 @@ The page-level `play-now` button is relabeled "Return To Game" in tutorial mode 
 
 Module: [`js/shared/attributeTour.js`](FrontEnd/static/js/shared/attributeTour.js) + [`css/attribute-tour.css`](FrontEnd/static/css/attribute-tour.css). Tutorial mode only. Fires once per browser (localStorage flag `fteV2AttrTourSeen`).
 
+**Stacking approach.** We DIM the surrounding siblings directly instead of laying a full-screen scrim on top. Reason: `<thead>` z-index is unreliable against a full-screen overlay — an earlier build had the lifted header row + its gold ring rendering UNDER the scrim. Dimming siblings keeps the header at its natural position, fully lit, with the ring always visible.
+
 | Layer | What |
 |---|---|
-| Scrim | Fixed `rgba(7,9,14,0.66)` overlay over the whole viewport; pointer-events capture clicks so the user can't accidentally interact with the page during the tour. |
-| Lifted header row | `z-index: 1500` on the `<thead>` + each `<th>` so the row sits above the scrim. Gold ring + soft glow (`box-shadow: 0 0 0 1px rgba(247,148,32,0.5), 0 0 38px rgba(247,148,32,0.18)`). |
+| Dimmed siblings | Caller passes a `dimSelectors` array (banner, score bar, ATTRIBUTES/STATS toggle, tbody, footnote, right-hand Starting Five panel, action buttons). Each matched element gets `.attribute-tour-dim` → `opacity: 0.30; pointer-events: none`. |
+| Lifted header row | No z-index lift — nothing covers it. Gold ring + soft glow (`box-shadow: 0 0 0 1px rgba(247,148,32,0.5), 0 0 38px rgba(247,148,32,0.18)`) applied per `<th>`, with internal edges merging into a single horizontal band. |
 | Shimmer cue | Each header that maps to a known attribute (per `attributeTooltips.js`) gets a slow ~2.4s gold underline pulse — invitation to hover, not a demand. |
 | Hover/explored states | Hover → orange tint. Once hovered → green tint + shimmer suppressed; counter increments. |
 | Sammy coach-mark | Compact fixed-position bubble below the header row with team-linked Sammy, eyebrow `QUICK TOUR`, body copy, live `X of N explored` counter, ghost `GOT IT` dismiss. Button stays at 55% opacity until all headers are explored, then full opacity. Always clickable. |
@@ -258,7 +260,7 @@ Module: [`js/shared/attributeTour.js`](FrontEnd/static/js/shared/attributeTour.j
 
 **N** = headers whose text content strictly matches a known attribute key (SC SH ID OD PS BH RB ST AG ND IQ FT + HT WT NG). The Player Name th's inline `RT` label is intentionally excluded since RT lives inside the name column, not as its own header.
 
-**Dismissal**: `GOT IT` (or all headers explored, optionally) fades the scrim + shimmer + Sammy, restores every class the tour added, sets the localStorage flag. After dismissal the tooltips behave exactly as before — the tour is one-shot UI; the underlying tooltip helper is permanent.
+**Dismissal**: `GOT IT` lifts the dim, fades Sammy, restores every class the tour added, sets the localStorage flag. After dismissal the tooltips behave exactly as before — the tour is one-shot UI; the underlying tooltip helper is permanent.
 
 ### Set-lineup feedback algorithm
 
@@ -397,27 +399,26 @@ For commit-level history, `git log --grep "FTE v2"`. High-level milestones:
 
 ##Outgoing modal messages
 **Talent** 
-- "You're putting your five best players on the court. Smart."
+- "You're putting your five best players on the court. Smart." (Talent-Led)
 **Skill Based** Track all of the below that qualify based on the top 2 attributes for the lineup
-- SC & SH: "You're leading with your best scorers, good luck Coach."
-- ID & OD: "You're leading with your best defenders, good luck Coach."
-- one of (SC or SH) and one of (ID or OD): "You're balancing offense and defense, good luck Coach."
-- RB & ST: "You're leading with your strong rebounders. Let's see how well they clean the boards."
-- one of (ID or OD) and ST: "You're leading with muscle and defense. You're an intimidator, Coach."
-- one of (SH or SC) and AG: "You're leading with your athletic scorers. I like it Coach."
-- PS & BH: "You're leading wtih fundamentals. I like the discipline, Coach."
-- ND & AG: "This lineup is fast and athletic. Our opponent will have a difficult time keeping up with us."
-- one of (SC or SH) and IQ: "This is a smart offensive lineup."
-- one of (ID or OD) and IQ: "This is a smart defensive lineup."
-- two of (ST, AG, ND): "Leading with pure athletcisim. I like it, Coach."
-- one of (PS or BH) and IQ: "A very cerebral and disciplines lineup. Good luck Coach."
-- if the list is zero after checking for qualifiers, use the unconventional message
-- one of (SC or SH) and one of (ST, AG, ND): "This is an athletically focused offensive lineup. Good luck Coach."
-- one of (ID or OD) and one of (ST, AG, ND): "This is an athletically focused defensive lineup. Good luck Coach."
-- one of (SC or SH) and one of (BH or PS): "This is an technically focused offensive lineup. Good luck Coach."
-- one of (ID or OD) and one of (BH or PS): "This is an technically focused defensive lineup. Good luck Coach."
-- one of (SC or SH) and RB: "This is an rebouning focused offensive lineup. Good luck Coach."
-- one of (ID or OD) and RB: "This is an rebounding focused defensive lineup. Good luck Coach."
+- SC & SH: "You're leading with your best scorers, good luck Coach." (Offense-Led)
+- ID & OD: "You're leading with your best defenders, good luck Coach." (Defense-Led)
+- one of (SC or SH) and one of (ID or OD): "You're balancing offense and defense, good luck Coach." (Balanced)
+- RB & ST: "You're leading with your strong rebounders. Let's see how well they clean the boards." (Straight Intimidation)
+- one of (ID or OD) and ST: "You're leading with muscle and defense. You're an intimidator, Coach."(Defensive Intimidation)
+- one of (SH or SC) and AG: "You're leading with your athletic scorers. I like it Coach." (Offensive Quickness)
+- PS & BH: "You're leading wtih fundamentals. I like the discipline, Coach." (Fundamentals)
+- ND & AG: "This lineup is fast and athletic. Our opponent will have a difficult time keeping up with us." (Speed)
+- one of (SC or SH) and IQ: "This is a smart offensive lineup." (Intelligent Offense)
+- one of (ID or OD) and IQ: "This is a smart defensive lineup." (Intelligent Defense)
+- two of (ST, AG, ND): "Leading with pure athletcisim. I like it, Coach." (Pure Athleticism)
+- one of (PS or BH) and IQ: "A very cerebral and disciplines lineup. Good luck Coach." (Cerebral Discipline)
+- one of (SC or SH) and one of (ST, AG, ND): "This is an athletically focused offensive lineup. Good luck Coach." (Offensive Athleticism)
+- one of (ID or OD) and one of (ST, AG, ND): "This is an athletically focused defensive lineup. Good luck Coach." (Defensive Athleticism)
+- one of (SC or SH) and one of (BH or PS): "This is an technically focused offensive lineup. Good luck Coach." (Technical Offense)
+- one of (ID or OD) and one of (BH or PS): "This is an technically focused defensive lineup. Good luck Coach." (Technical Defense)
+- one of (SC or SH) and RB: "This is an rebouning focused offensive lineup. Good luck Coach." (Offense & Rebounding)
+- one of (ID or OD) and RB: "This is an rebounding focused defensive lineup. Good luck Coach." (Defense & Rebounding)
 
 **Unconventional Message**
-- "A very unconventional lineup, Coach. You're going to keep our opponent very off-balance."
+- "A very unconventional lineup, Coach. You're going to keep our opponent very off-balance." (Unconventional)


### PR DESCRIPTION
Fixes the spotlight-bug you flagged: the lifted header row + its gold ring were rendering **under** the scrim because \`<thead>\` z-index doesn't reliably win against a full-screen overlay across browsers.

## What changed

Switched stacking strategy per your prompt: dim the **siblings** instead of overlaying everything. The header row stays at its natural position, fully lit, with the gold ring always visible — no z-index fight.

| Before | After |
|---|---|
| Fixed scrim (\`z-index: 1400\`) over the whole viewport; \`<thead>\` lifted to \`z-index: 1500\` to sit above it. Header rendered UNDER the scrim. | No scrim element. Caller-specified siblings get \`.attribute-tour-dim\` → \`opacity: 0.30; pointer-events: none\`. Header at natural position, gold ring always visible. |

## API change
\`showAttributeTour\` now accepts \`dimSelectors: string[]\` — caller-owned CSS-selector list for the surrounding elements that should fade. Keeps the tour module page-agnostic.

In [\`set-lineup.js\`](FrontEnd/static/set-lineup.js) the call passes 7 selectors:
\`\`\`
.lineup-banner-strip
.lineup-context-bar
.lineup-roster-header-row     // ATTRIBUTES/STATS toggle + label
#roster-body                  // tbody only — thead stays lit
#roster-pos-note              // footnote
.roster-panel-actions         // Game Plan / Playbooks buttons
.lineup-right-panel           // Starting Five panel
\`\`\`

## Unchanged
- Gold ring + glow on the header row
- Shimmer cue
- Hover orange / explored green logic
- Sammy coach-mark + counter + ghost GOT IT
- Existing per-attribute tooltips (still \`position: fixed; z-index: 99999\` so they render above everything)
- localStorage guard
- Touch tap fallback

## Test plan
- [ ] Walk a fresh tutorial → intro modal → dismiss → tour fires. Header row is the brightest element on screen with the gold ring visible.
- [ ] Hover headers → orange → green check progression works.
- [ ] Counter reaches N → GOT IT button hits full opacity.
- [ ] GOT IT dismisses cleanly — page returns to normal opacity, tooltips still work.