### PR TITLE
FTE v2: log lineup-feedback pool + pick on Return To Game

### DIFF
--- a/FrontEnd/static/js/shared/tutorialLineupModals.js
+++ b/FrontEnd/static/js/shared/tutorialLineupModals.js
@@ -288,7 +288,21 @@ export function pickLineupFeedbackMessage(starters, fullRoster) {
     if (q.test(topTwo)) pool.push(q.message);
   }
 
-  if (pool.length === 0) return UNCONVENTIONAL_MESSAGE;
-  if (pool.length === 1) return pool[0];
-  return pool[Math.floor(Math.random() * pool.length)];
+  // Debug log so we can verify which qualifiers matched and what the pool
+  // looked like before the random pick. Useful for staging walks; cheap
+  // to leave in production since this fires once per Return To Game click.
+  const picked = pool.length === 0
+    ? UNCONVENTIONAL_MESSAGE
+    : pool.length === 1
+      ? pool[0]
+      : pool[Math.floor(Math.random() * pool.length)];
+  try {
+    console.log('[tutorial][lineup-feedback]', {
+      topTwoAttrs: Array.from(topTwo),
+      poolSize: pool.length,
+      pool,
+      picked,
+    });
+  } catch (_) { /* non-fatal */ }
+  return picked;
 }


### PR DESCRIPTION
Adds a debug \`console.log\` in \`pickLineupFeedbackMessage\` so you can verify on staging which qualifiers matched and which message got picked.

On every Return To Game click:
\`\`\`
[tutorial][lineup-feedback] {
  topTwoAttrs: [...attr keys at rank #1 or #2],
  poolSize: N,
  pool: [...candidate messages that qualified],
  picked: "the message that displays"
}
\`\`\`

One log per click. Safe to leave in production — cheap, only fires once per modal, no PII.