### PR TITLE
debug: log tutorial gate state on set-lineup load

### DIFF
--- a/FrontEnd/static/js/shared/tutorialLineupModals.js
+++ b/FrontEnd/static/js/shared/tutorialLineupModals.js
@@ -288,7 +288,21 @@ export function pickLineupFeedbackMessage(starters, fullRoster) {
     if (q.test(topTwo)) pool.push(q.message);
   }
 
-  if (pool.length === 0) return UNCONVENTIONAL_MESSAGE;
-  if (pool.length === 1) return pool[0];
-  return pool[Math.floor(Math.random() * pool.length)];
+  // Debug log so we can verify which qualifiers matched and what the pool
+  // looked like before the random pick. Useful for staging walks; cheap
+  // to leave in production since this fires once per Return To Game click.
+  const picked = pool.length === 0
+    ? UNCONVENTIONAL_MESSAGE
+    : pool.length === 1
+      ? pool[0]
+      : pool[Math.floor(Math.random() * pool.length)];
+  try {
+    console.log('[tutorial][lineup-feedback]', {
+      topTwoAttrs: Array.from(topTwo),
+      poolSize: pool.length,
+      pool,
+      picked,
+    });
+  } catch (_) { /* non-fatal */ }
+  return picked;
 }

--- a/FrontEnd/static/set-lineup.js
+++ b/FrontEnd/static/set-lineup.js
@@ -2045,6 +2045,20 @@ async function init() {
     autosetBtn.addEventListener('click', autosetLineup);
   }
 
+  // Debug: surface the resolved mode + tour-gate state so we can see
+  // immediately why the tutorial chrome (intro modal + attribute tour)
+  // does or doesn't fire on this page load. Cheap, fires once per load.
+  try {
+    console.log('[tutorial][gate]', {
+      modeParam,
+      isTutorial: modeParam === 'tutorial',
+      gameId,
+      homeTeam,
+      attrTourSeenFlag: (() => { try { return localStorage.getItem('fteV2AttrTourSeen'); } catch (_) { return '<denied>'; } })(),
+      url: typeof window !== 'undefined' ? window.location.href : null,
+    });
+  } catch (_) { /* non-fatal */ }
+
   // FTE v2 tutorial: the slots load empty (tutorial-situation no longer
   // forwards home_pg/etc.) — the user sets their own lineup as part of
   // the lesson. On first paint, show a centered Functional-modal-style


### PR DESCRIPTION
Diagnostic only — adds one \`console.log\` right before the tutorial intro/tour wiring on set-lineup so we can stop guessing why the tour isn't firing.

On every set-lineup load you'll see:
\`\`\`
[tutorial][gate] {
  modeParam: 'tutorial' | 'single' | null,
  isTutorial: true | false,
  gameId: '...',
  homeTeam: '...',
  attrTourSeenFlag: '1' | null | '<denied>',
  url: 'https://gob-test.netlify.app/set-lineup.html?...'
}
\`\`\`

If \`isTutorial: false\` → URL is missing \`mode=tutorial\` (root cause is upstream).
If \`isTutorial: true\` AND \`attrTourSeenFlag === '1'\` → tour is correctly gated by your prior dismissal; clear with \`localStorage.removeItem('fteV2AttrTourSeen')\`.
If \`isTutorial: true\` AND \`attrTourSeenFlag === null\` AND the tour still doesn't fire → real bug; we'll know to look at \`launchAttributeTour\` invocation next.

Removable in a follow-up once the gating is resolved.