### PR TITLE
FTE v2: unify tutorial UI-nudge gates — attribute tour matches intro modal pattern

### DIFF
--- a/FrontEnd/static/js/shared/attributeTour.js
+++ b/FrontEnd/static/js/shared/attributeTour.js
@@ -27,25 +27,28 @@
  *   5. Touch fallback: tap on a header opens its tooltip too. Scoped to
  *      the tour run — no global helper changes.
  *
- * Persistence: localStorage flag (per-browser). Acceptable for a one-shot
- * tutorial-mode nudge — the tutorial itself is server-gated to once per
- * account, so re-firing across devices isn't a meaningful concern.
+ * Persistence: sessionStorage flag keyed by tutorial game_id (per-tab,
+ * per-tutorial-game). Matches the intro modal's pattern — one mental
+ * model for "tutorial UI nudge guards". Within-tutorial nav (set-lineup
+ * → game-plan → back) doesn't re-fire (same game_id); a fresh tutorial
+ * game wipes the slate. Real users only play one tutorial (server-gated)
+ * so they still see the tour exactly once.
  *
  *   import { showAttributeTour } from '/js/shared/attributeTour.js';
  *
  *   showAttributeTour({
- *     headerRow:    <tr|thead element>,                 // required — the row to spotlight
- *     teamName:     'Bentley-Truman',                   // for the team-linked Sammy
- *     dimSelectors: ['.lineup-banner-strip', ...],      // caller-owned list of siblings to dim
- *     persistKey:   'fteV2AttrTourSeen',                // optional, defaults shown
- *     onDismiss:    () => { ... },                      // optional callback after dismiss
+ *     headerRow:    <tr|thead element>,                                 // required — the row to spotlight
+ *     teamName:     'Bentley-Truman',                                   // for the team-linked Sammy
+ *     dimSelectors: ['.lineup-banner-strip', ...],                      // caller-owned list of siblings to dim
+ *     persistKey:   `fteV2TutorialAttrTourShown_${gameId}`,             // pass per game_id; default shown below
+ *     onDismiss:    () => { ... },                                      // optional callback after dismiss
  *   });
  */
 
 import { getTeamSammyImage } from '/js/shared/teamCoachAsset.js';
 
 const STYLESHEET_HREF = '/css/attribute-tour.css';
-const DEFAULT_PERSIST_KEY = 'fteV2AttrTourSeen';
+const DEFAULT_PERSIST_KEY = 'fteV2TutorialAttrTourShown';
 
 // Same set the canonical attributeTooltips.js helper recognizes — used to
 // decide which header cells get the shimmer cue and count toward the
@@ -66,12 +69,12 @@ function ensureStylesheet() {
 }
 
 function alreadySeen(persistKey) {
-  try { return localStorage.getItem(persistKey) === '1'; }
+  try { return sessionStorage.getItem(persistKey) === '1'; }
   catch (_) { return false; }
 }
 
 function markSeen(persistKey) {
-  try { localStorage.setItem(persistKey, '1'); }
+  try { sessionStorage.setItem(persistKey, '1'); }
   catch (_) { /* private mode etc. — non-fatal */ }
 }
 

--- a/FrontEnd/static/set-lineup.js
+++ b/FrontEnd/static/set-lineup.js
@@ -2049,12 +2049,19 @@ async function init() {
   // immediately why the tutorial chrome (intro modal + attribute tour)
   // does or doesn't fire on this page load. Cheap, fires once per load.
   try {
+    const introKeyPreview = gameId
+      ? `fteV2TutorialLineupModalShown_${gameId}`
+      : 'fteV2TutorialLineupModalShown';
+    const tourKeyPreview = gameId
+      ? `fteV2TutorialAttrTourShown_${gameId}`
+      : 'fteV2TutorialAttrTourShown';
     console.log('[tutorial][gate]', {
       modeParam,
       isTutorial: modeParam === 'tutorial',
       gameId,
       homeTeam,
-      attrTourSeenFlag: (() => { try { return localStorage.getItem('fteV2AttrTourSeen'); } catch (_) { return '<denied>'; } })(),
+      introModalShown: (() => { try { return sessionStorage.getItem(introKeyPreview); } catch (_) { return '<denied>'; } })(),
+      attrTourShown: (() => { try { return sessionStorage.getItem(tourKeyPreview); } catch (_) { return '<denied>'; } })(),
       url: typeof window !== 'undefined' ? window.location.href : null,
     });
   } catch (_) { /* non-fatal */ }
@@ -2082,9 +2089,13 @@ async function init() {
     ]).then(([{ mountTutorialProgress }, lineupModals, { showAttributeTour }]) => {
       mountTutorialProgress('lineup');
       // After the intro modal dismisses, fire the attribute tour. The tour
-      // has its own localStorage gate so it only auto-shows once per
-      // browser (intra-tutorial navigations to/from game-plan don't re-fire
-      // it). headerRow is the roster attributes table's <thead>.
+      // has its own sessionStorage gate keyed by game_id — matches the
+      // intro modal's pattern, so a fresh tutorial game = fresh tour while
+      // within-tutorial navigation (set-lineup → game-plan → back) stays
+      // quiet. headerRow is the roster attributes table's <thead>.
+      const tourKey = gameId
+        ? `fteV2TutorialAttrTourShown_${gameId}`
+        : 'fteV2TutorialAttrTourShown';
       const launchAttributeTour = () => {
         const headerRow = document.querySelector('#roster-attributes-pane .roster-table thead');
         if (!headerRow) return;
@@ -2094,6 +2105,7 @@ async function init() {
           showAttributeTour({
             headerRow,
             teamName: homeTeam,
+            persistKey: tourKey,
             // Dim everything around the header row instead of laying a
             // scrim on top — <thead> z-index is unreliable against a
             // full-screen overlay (early build had the header rendering

--- a/_documentation_master/00_General_Systems/fte_system.md
+++ b/_documentation_master/00_General_Systems/fte_system.md
@@ -238,14 +238,14 @@ Tutorial follows the `single` path through `finalizeGame.js` (no franchise/tourn
 The tutorial set-lineup intentionally loads with empty slots — the user fills their own lineup as part of the lesson. Three guided beats bracket the experience:
 
 1. **Intro modal** (centered Functional-modal chrome with team-linked Sammy portrait overlapping the top, sessionStorage-guarded per `game_id`): "Here's your moment, Coach. Set your lineup for crunch time." Single `GOT IT` orange CTA.
-2. **Attribute tour** (fires immediately after the intro dismisses, `localStorage`-guarded by `fteV2AttrTourSeen`): the user's first-run nudge that reveals the per-attribute hover tooltips that already live on the column headers. See "Attribute tour mechanic" below.
+2. **Attribute tour** (fires immediately after the intro dismisses, `sessionStorage`-guarded by `fteV2TutorialAttrTourShown_${gameId}` — same per-game_id pattern as the intro modal): the user's first-run nudge that reveals the per-attribute hover tooltips that already live on the column headers. See "Attribute tour mechanic" below.
 3. **Feedback modal** (fires every Return To Game click; same chrome as intro): algorithm-chosen message + single green `RETURN TO GAME` CTA that performs the actual navigation to `court.html`.
 
 The page-level `play-now` button is relabeled "Return To Game" in tutorial mode (still uses the existing green disabled-until-complete styling).
 
 ### Attribute tour mechanic
 
-Module: [`js/shared/attributeTour.js`](FrontEnd/static/js/shared/attributeTour.js) + [`css/attribute-tour.css`](FrontEnd/static/css/attribute-tour.css). Tutorial mode only. Fires once per browser (localStorage flag `fteV2AttrTourSeen`).
+Module: [`js/shared/attributeTour.js`](FrontEnd/static/js/shared/attributeTour.js) + [`css/attribute-tour.css`](FrontEnd/static/css/attribute-tour.css). Tutorial mode only. Fires once per tutorial game (sessionStorage flag `fteV2TutorialAttrTourShown_${gameId}`, same pattern as the intro modal — a fresh tutorial game = fresh tour; intra-tutorial nav doesn't re-fire).
 
 **Stacking approach.** We DIM the surrounding siblings directly instead of laying a full-screen scrim on top. Reason: `<thead>` z-index is unreliable against a full-screen overlay — an earlier build had the lifted header row + its gold ring rendering UNDER the scrim. Dimming siblings keeps the header at its natural position, fully lit, with the ring always visible.
 
@@ -260,7 +260,7 @@ Module: [`js/shared/attributeTour.js`](FrontEnd/static/js/shared/attributeTour.j
 
 **N** = headers whose text content strictly matches a known attribute key (SC SH ID OD PS BH RB ST AG ND IQ FT + HT WT NG). The Player Name th's inline `RT` label is intentionally excluded since RT lives inside the name column, not as its own header.
 
-**Dismissal**: `GOT IT` lifts the dim, fades Sammy, restores every class the tour added, sets the localStorage flag. After dismissal the tooltips behave exactly as before — the tour is one-shot UI; the underlying tooltip helper is permanent.
+**Dismissal**: `GOT IT` lifts the dim, fades Sammy, restores every class the tour added, sets the sessionStorage flag. After dismissal the tooltips behave exactly as before — the tour is one-shot UI; the underlying tooltip helper is permanent.
 
 ### Set-lineup feedback algorithm
 
@@ -343,7 +343,7 @@ These are real regressions we've hit. Listed so the next person doesn't pay the 
 | 2 | **Duplicated mode derivation at EOG callsites.** Four call-sites of `showGameCompletionPopup` were independently building `mode`. One missed the tutorial branch → Box Score reappeared, locker-room routed wrong, `tutorial-complete` never fired, authBar bounced back to situation. | Always go through `js/shared/getGameMode.js`. |
 | 3 | **Stale `.pre-game-container` flash on court.html.** It used to default to visible; bootGame then decided whether to hide. Caused a "Play Quarter / Sim Quarter" flash before live court paint. | `.pre-game-container.hidden` by default. bootGame removes `.hidden` only when it explicitly wants to show. Overlay dismisses on `court-ready` event dispatched from `bootGame.initGame()`. Don't revert. |
 | 4 | **Bare `.rt-low` etc. without `!important`.** Page-local `.roster-table td { color: ... }` rules (specificity 0,1,1) silently override the bucket classes (0,1,0). | `/css/rt-buckets.css` uses `!important` deliberately. These are canonical scale colors; they should always win. |
-| 5 | **Forgetting to flush `sessionStorage` lineup-intro guard on rerun.** Tutorial set-lineup intro modal uses key `fteV2TutorialLineupModalShown_${gameId}` (renamed from the prior coach-mark / Sammy-modal keys; old keys are harmless leftovers). Each fresh game_id gets its own key so re-tours work. | No action needed; documented so you don't think it's broken when it skips on re-entry. |
+| 5 | **Tutorial UI nudge guards: all sessionStorage, all per-`game_id`.** Two keys today: `fteV2TutorialLineupModalShown_${gameId}` (intro modal) + `fteV2TutorialAttrTourShown_${gameId}` (attribute tour). One mental model. Each fresh tutorial game gets a fresh set of nudges. A prior attempt used `localStorage[fteV2AttrTourSeen]` (permanent, per-browser) which made staging testing painful since every retest required `localStorage.removeItem(...)`; consolidated to the per-game_id sessionStorage pattern. **Don't add a new client-side gate for a tutorial UI nudge without matching this pattern.** | No action needed; documented so the next nudge follows the same recipe. |
 
 ---
 


### PR DESCRIPTION
Per your call — consolidates the two tutorial UI-nudge gates to one pattern.

## Before
| Gate | Where | Scope |
|---|---|---|
| Intro modal | \`sessionStorage[fteV2TutorialLineupModalShown_\${gameId}]\` | Per-tab, per-game |
| Attribute tour | \`localStorage[fteV2AttrTourSeen]\` | Per-browser, **permanent** |

Same problem class (one-shot UI nudge gated by "have you seen this yet"), two different recipes. Staging testing was painful because every retest of the tour required \`localStorage.removeItem(...)\` by hand.

## After
| Gate | Where | Scope |
|---|---|---|
| Intro modal | \`sessionStorage[fteV2TutorialLineupModalShown_\${gameId}]\` | Per-tab, per-game (unchanged) |
| Attribute tour | \`sessionStorage[fteV2TutorialAttrTourShown_\${gameId}]\` | Per-tab, per-game (NEW) |

## What this gives us
- Within-tutorial nav (set-lineup → game-plan → back): tour stays quiet (same game_id matches).
- A fresh tutorial game in staging: fresh tour, no manual clearing.
- Real users only play one tutorial (server-gated by \`fte_v2_complete\`), so they still see the tour exactly once.
- One mental model for "tutorial UI nudge guards".

## Side effect
The old \`localStorage[fteV2AttrTourSeen]\` flag set on your (and others') browsers is no longer read by the new code. Stale \`'1'\` values are harmless leftovers; no action needed.

## Debug log updated
The \`[tutorial][gate]\` log now reads sessionStorage and shows both keys' state:
\`\`\`
[tutorial][gate] {
  modeParam: 'tutorial',
  isTutorial: true,
  gameId: '...',
  homeTeam: 'Lancaster',
  introModalShown: '1' | null,
  attrTourShown: '1' | null,
  url: '...'
}
\`\`\`

## Doc
\`fte_system.md\` updated. "Don't reintroduce" row #5 rewritten as the canonical recipe: any future tutorial UI nudge should use \`sessionStorage[<key>_\${gameId}]\` — not localStorage, not a bare key.