### PR TITLE
FTE v2: lineup-feedback algorithm — consider top-3 attrs (not top-2)

### DIFF
--- a/FrontEnd/static/js/shared/tutorialLineupModals.js
+++ b/FrontEnd/static/js/shared/tutorialLineupModals.js
@@ -128,7 +128,7 @@ const ATTRS_IN_PLAY = ['SC', 'SH', 'ID', 'OD', 'PS', 'BH', 'RB', 'ST', 'AG', 'ND
 const TALENT_MESSAGE = "You're putting your five best players on the court. Smart.";
 const UNCONVENTIONAL_MESSAGE = "A very unconventional lineup, Coach. You're going to keep our opponent very off-balance.";
 
-// Qualifier matchers: each takes the set of "top-2 attribute IDs" (a Set<string>)
+// Qualifier matchers: each takes the set of "top-3 attribute IDs" (a Set<string>)
 // and returns true if it qualifies. If qualified, the paired message is
 // added to the candidate pool.
 const QUALIFIERS = [
@@ -208,16 +208,25 @@ const QUALIFIERS = [
 ];
 
 /**
- * Compute the "top 2" set of attribute IDs (by total across the 5 starters).
- * Includes all ties at the #1 OR #2 rank, per the spec — so if 3 attributes
- * share the top spot, all 3 are included; if SC is #1 alone and SH/IQ/ST
- * are tied at #2, all 4 are included.
+ * Compute the "top 3" set of attribute IDs (by total across the 5 starters).
+ *
+ * Per the spec: identify the top 3 attributes by total; if 2+ are tied
+ * for the 3rd rank, include them all. Example — SC: 54, SH: 53, ST: 53,
+ * IQ: 53 yields {SC, SH, ST, IQ} (rank #1 alone, three tied filling
+ * ranks #2 and #3).
+ *
+ * Algorithm: sort attrs descending by total. The value at the 3rd
+ * position (index 2) is the cutoff. Include every attr whose total
+ * >= that cutoff. This naturally captures ties at #3 — anyone sharing
+ * the cutoff value comes in — and ALSO captures ties at #1/#2 that
+ * extend past index 2 (e.g. four attrs tied at the top all qualify
+ * since they all share the cutoff value).
  *
  * @param {Array<{attributes:object}>} starters — 5 player objects with
  *   anchor_<attr> or <attr> fields on player.attributes
  * @returns {Set<string>}
  */
-function computeTopTwoAttributes(starters) {
+function computeTopThreeAttributes(starters) {
   const totals = {};
   for (const attr of ATTRS_IN_PLAY) {
     let sum = 0;
@@ -228,11 +237,10 @@ function computeTopTwoAttributes(starters) {
     }
     totals[attr] = sum;
   }
-  // Sort attribute totals descending. Identify the cutoff value at rank 2
-  // (or rank 1 if there's only one distinct value). Include all attributes
-  // with totals >= the cutoff.
-  const sortedDescUnique = Array.from(new Set(Object.values(totals))).sort((a, b) => b - a);
-  const cutoff = sortedDescUnique[1] ?? sortedDescUnique[0] ?? 0;
+  // Sort attrs descending by total; the value at position index 2 is the
+  // cutoff. ATTRS_IN_PLAY has 11 entries so [2] always exists.
+  const sortedAttrs = [...ATTRS_IN_PLAY].sort((a, b) => totals[b] - totals[a]);
+  const cutoff = totals[sortedAttrs[2]];
   const top = new Set();
   for (const attr of ATTRS_IN_PLAY) {
     if (totals[attr] >= cutoff) top.add(attr);
@@ -271,7 +279,7 @@ function isTopFiveRtLineup(starters, fullRoster) {
 /**
  * Pick a single lineup-feedback message per the spec:
  *   - Talent qualifies if all 5 chosen starters are top-5-RT.
- *   - Each of the 18 skill-based qualifiers checks against the top-2 attrs.
+ *   - Each of the 18 skill-based qualifiers checks against the top-3 attrs.
  *   - Talent + all qualifying skill messages form the candidate pool.
  *   - Pool size 1 → use it. Pool size 2+ → random pick. Pool size 0 → Unconventional.
  *
@@ -283,9 +291,9 @@ export function pickLineupFeedbackMessage(starters, fullRoster) {
   const pool = [];
   if (isTopFiveRtLineup(starters, fullRoster)) pool.push(TALENT_MESSAGE);
 
-  const topTwo = computeTopTwoAttributes(starters);
+  const topThree = computeTopThreeAttributes(starters);
   for (const q of QUALIFIERS) {
-    if (q.test(topTwo)) pool.push(q.message);
+    if (q.test(topThree)) pool.push(q.message);
   }
 
   // Debug log so we can verify which qualifiers matched and what the pool
@@ -298,7 +306,7 @@ export function pickLineupFeedbackMessage(starters, fullRoster) {
       : pool[Math.floor(Math.random() * pool.length)];
   try {
     console.log('[tutorial][lineup-feedback]', {
-      topTwoAttrs: Array.from(topTwo),
+      topThreeAttrs: Array.from(topThree),
       poolSize: pool.length,
       pool,
       picked,

--- a/_documentation_master/00_General_Systems/fte_system.md
+++ b/_documentation_master/00_General_Systems/fte_system.md
@@ -271,26 +271,26 @@ Implemented in `js/shared/tutorialLineupModals.js → pickLineupFeedbackMessage(
 | Check | Qualifies if | Message |
 |---|---|---|
 | **Talent** | The 5 chosen starters are the team's top-5 by highest RT (ties at the 5th-place RT all count as eligible) | "You're putting your five best players on the court. Smart." |
-| SC & SH | Both in top-2 attrs | "You're leading with your best scorers, good luck, Coach." |
-| ID & OD | Both in top-2 | "You're leading with your best defenders, good luck, Coach." |
-| (SC or SH) and (ID or OD) | One of each in top-2 | "You're balancing offense and defense, good luck, Coach." |
-| RB & ST | Both in top-2 | "You're leading with your strong rebounders. Let's see how well they clean the boards." |
-| (ID or OD) and ST | At least one defensive + ST in top-2 | "You're leading with muscle and defense. You're an intimidator, Coach." |
-| (SC or SH) and AG | Offensive + AG in top-2 | "You're leading with your athletic scorers. I like it, Coach." |
-| PS & BH | Both in top-2 | "You're leading with fundamentals. I like the discipline, Coach." |
-| ND & AG | Both in top-2 | "This lineup is fast and athletic. Our opponent will have a difficult time keeping up with us." |
-| (SC or SH) and IQ | Offensive + IQ in top-2 | "This is a smart offensive lineup." |
-| (ID or OD) and IQ | Defensive + IQ in top-2 | "This is a smart defensive lineup." |
-| 2+ of (ST, AG, ND) | At least two of those three in top-2 | "Leading with pure athleticism. I like it, Coach." |
-| (PS or BH) and IQ | Either + IQ in top-2 | "A very cerebral and disciplined lineup. Good luck, Coach." |
-| (SC or SH) and (ST/AG/ND) | Offensive + any athleticism in top-2 | "This is an athletically focused offensive lineup. Good luck, Coach." |
-| (ID or OD) and (ST/AG/ND) | Defensive + any athleticism in top-2 | "This is an athletically focused defensive lineup. Good luck, Coach." |
-| (SC or SH) and (BH or PS) | Offensive + fundamentals in top-2 | "This is a technically focused offensive lineup. Good luck, Coach." |
-| (ID or OD) and (BH or PS) | Defensive + fundamentals in top-2 | "This is a technically focused defensive lineup. Good luck, Coach." |
-| (SC or SH) and RB | Offensive + RB in top-2 | "This is a rebounding focused offensive lineup. Good luck, Coach." |
-| (ID or OD) and RB | Defensive + RB in top-2 | "This is a rebounding focused defensive lineup. Good luck, Coach." |
+| SC & SH | Both in top-3 attrs | "You're leading with your best scorers, good luck, Coach." |
+| ID & OD | Both in top-3 | "You're leading with your best defenders, good luck, Coach." |
+| (SC or SH) and (ID or OD) | One of each in top-3 | "You're balancing offense and defense, good luck, Coach." |
+| RB & ST | Both in top-3 | "You're leading with your strong rebounders. Let's see how well they clean the boards." |
+| (ID or OD) and ST | At least one defensive + ST in top-3 | "You're leading with muscle and defense. You're an intimidator, Coach." |
+| (SC or SH) and AG | Offensive + AG in top-3 | "You're leading with your athletic scorers. I like it, Coach." |
+| PS & BH | Both in top-3 | "You're leading with fundamentals. I like the discipline, Coach." |
+| ND & AG | Both in top-3 | "This lineup is fast and athletic. Our opponent will have a difficult time keeping up with us." |
+| (SC or SH) and IQ | Offensive + IQ in top-3 | "This is a smart offensive lineup." |
+| (ID or OD) and IQ | Defensive + IQ in top-3 | "This is a smart defensive lineup." |
+| 2+ of (ST, AG, ND) | At least two of those three in top-3 | "Leading with pure athleticism. I like it, Coach." |
+| (PS or BH) and IQ | Either + IQ in top-3 | "A very cerebral and disciplined lineup. Good luck, Coach." |
+| (SC or SH) and (ST/AG/ND) | Offensive + any athleticism in top-3 | "This is an athletically focused offensive lineup. Good luck, Coach." |
+| (ID or OD) and (ST/AG/ND) | Defensive + any athleticism in top-3 | "This is an athletically focused defensive lineup. Good luck, Coach." |
+| (SC or SH) and (BH or PS) | Offensive + fundamentals in top-3 | "This is a technically focused offensive lineup. Good luck, Coach." |
+| (ID or OD) and (BH or PS) | Defensive + fundamentals in top-3 | "This is a technically focused defensive lineup. Good luck, Coach." |
+| (SC or SH) and RB | Offensive + RB in top-3 | "This is a rebounding focused offensive lineup. Good luck, Coach." |
+| (ID or OD) and RB | Defensive + RB in top-3 | "This is a rebounding focused defensive lineup. Good luck, Coach." |
 
-**Top-2 attrs** = the set of attribute IDs whose total across the 5 starters is at the #1 or #2 rank (ties at either rank all included). Attrs in play: `SC, SH, ID, OD, PS, BH, RB, ST, AG, ND, IQ`.
+**Top-3 attrs** = sort all attribute totals descending across the 5 starters; the cutoff is the value at the 3rd position. Include every attr whose total ≥ that cutoff. This captures ties at the #3 rank, and also captures ties at #1 or #2 that extend past index 2 (e.g. four attrs tied at the top all qualify since they all share the cutoff value). Attrs in play: `SC, SH, ID, OD, PS, BH, RB, ST, AG, ND, IQ`. Example: totals SC=54, SH=53, ST=53, IQ=53 yields {SC, SH, ST, IQ} — rank #1 alone, three tied filling ranks #2 and #3.
 
 **Pick rule**: pool size 1 → use it. Pool size 2+ → random pick. Pool size 0 → Unconventional: "A very unconventional lineup, Coach. You're going to keep our opponent very off-balance."
 
@@ -394,13 +394,13 @@ For commit-level history, `git log --grep "FTE v2"`. High-level milestones:
 ##Skill based logic
 - Attributes in play: SC, SH, ID, OD, PS, BH, RB, ST, AG, ND, IQ
 - Step 1: Calculate the total attributes value for attributes in play for the user's lineup. 
-- Step 2: Identify the top 2 attributes in terms of total. If 2 or more are tied for the second, include them all. Example: 1. SC: 54, 2. SH: 53, ST: 53, IQ: 53 -- all four of those would be considered "Top 2". LMK if that is not clear.
-- Step 3: Choose the outgoing modal messsage based on the top 2 attributes.
+- Step 2: Identify the top 3 attributes in terms of total. If 2 or more are tied for the third, include them all. Example: 1. SC: 54, 2. SH: 53, ST: 53, IQ: 53 -- all four of those would be considered "Top 3". LMK if that is not clear.
+- Step 3: Choose the outgoing modal messsage based on the top 3 attributes.
 
 ##Outgoing modal messages
 **Talent** 
 - "You're putting your five best players on the court. Smart." (Talent-Led)
-**Skill Based** Track all of the below that qualify based on the top 2 attributes for the lineup
+**Skill Based** Track all of the below that qualify based on the top 3 attributes for the lineup
 - SC & SH: "You're leading with your best scorers, good luck Coach." (Offense-Led)
 - ID & OD: "You're leading with your best defenders, good luck Coach." (Defense-Led)
 - one of (SC or SH) and one of (ID or OD): "You're balancing offense and defense, good luck Coach." (Balanced)


### PR DESCRIPTION
Per spec update: qualifier checks now run against the **top-3** attribute IDs by lineup total instead of top-2.

## Algorithm change

\`computeTopTwoAttributes\` → \`computeTopThreeAttributes\`. The cutoff logic also tightened:

**Old:** cutoff = 2nd-highest *distinct* total. Worked for top-2 by happy coincidence because the spec example had ties at the cutoff value, but the same approach for top-3 over-includes when ties at rank #1 span past rank #3.

**New:** sort attrs descending by total; cutoff = value at position index 2 (the 3rd attr in sorted order). Include every attr whose total ≥ cutoff. Naturally captures:
- Ties at the #3 rank
- Ties at #1 or #2 that extend past index 2 (e.g. 4 attrs tied at the top all qualify since they all share the cutoff value)

## Verified against spec example
SC: 54, SH: 53, ST: 53, IQ: 53 → \`sortedAttrs[2] = ST(53)\` → cutoff = 53 → \`{SC, SH, ST, IQ}\` ✓ (matches your "all four would be considered Top 3").

## Other changes
- Local var \`topTwo\` → \`topThree\`
- Debug log key \`topTwoAttrs\` → \`topThreeAttrs\` (the \`[tutorial][lineup-feedback]\` log on Return To Game)
- 4 in-file comments updated

## Doc
- All 19 qualifier-table "in top-2" cells → "in top-3"
- "Top-2 attrs" definition paragraph rewritten as "Top-3 attrs" with the value-at-position-index-2 cutoff explanation + the spec example inlined

## Untouched
- The 18 qualifier rules + their messages
- Talent rule + Unconventional fallback
- Pool composition (Talent + qualifiers in one pool, random pick from 2+, Unconventional when 0)

## Test plan
- [ ] Tutorial set-lineup → set a lineup → Return To Game → console shows \`[tutorial][lineup-feedback]\` with \`topThreeAttrs\` (3+ entries depending on ties) and a sane \`pool\`.
- [ ] Try a lineup heavy on offense (SC/SH dominant) → SC & SH qualifier matches as expected.
- [ ] Try a balanced lineup → multiple qualifiers match; random pick from pool.