### PR TITLE
scripts: reset_fte_v2_for_all — force every user back through the tutorial

### DIFF
--- a/_documentation_master/projects/bugs.md
+++ b/_documentation_master/projects/bugs.md
@@ -13,6 +13,7 @@
 15. Traning page hover tool tips
 16. No SFX on RR FB made shot
 17. Need airhorn at end of quarter
+18. Final Turn perfection (Run clock to 0:00 for Final Shot)
 
 35. Verify Special Stats are tracking properly
 36. Season & Career Stats for Players for special stats
@@ -25,7 +26,6 @@
 45. Improve FCC API
 
 48. Double block announce on Final Shot
-49. Run clock to 0:00 for Final Shot
 
 57. Player Momentum System
 

--- a/scripts/reset_fte_v2_for_all.py
+++ b/scripts/reset_fte_v2_for_all.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""
+Reset FTE v2 status for every user → force everyone through the tutorial.
+
+Context (Coach):
+  We're removing the "grandfathering" introduced by migrate_fte_v2.py (which
+  set fte_v2_complete=True for franchise owners so they'd skip the new
+  tutorial). Going forward we want every user to walk the FTE v2 funnel,
+  including users who already completed it. There is no DB flag
+  distinguishing originally-grandfathered users from users who actually
+  completed the tutorial, so this script targets ALL users.
+
+What it does (when --apply):
+  For every user document:
+    - fte_v2_complete                  → False
+    - tutorial_state.step              → "persona_intro"
+    - tutorial_state.team_pick         → None
+    - tutorial_state.completed_at      → None
+  Leaves tutorial_state.started_at intact (preserves the user's original
+  signup timestamp; their first-time experience already happened, this is
+  a re-tour).
+
+Side effects to know about (already flagged in the PR description):
+  - Every user gets force-routed into the tutorial on next page load
+    (authBarInit.routeToTutorial fires whenever fte_v2_complete === false).
+  - Franchises / tournaments / past data are untouched — full access
+    restored once the user completes the tutorial.
+  - Idempotent: re-running just sets the same values; no destructive
+    history-loss.
+
+Safety guarantees (same as migrate_fte_v2.py):
+  - DEFAULT IS DRY-RUN. Pass --apply to actually write.
+  - DEFAULT TARGET IS STAGING (gob-staging). Pass --db production to switch.
+  - PRODUCTION WRITES require an additional --confirm-production-write flag.
+  - NEVER UNSETS OR DELETES anything; only $set on the four fields above.
+
+Usage:
+  python scripts/reset_fte_v2_for_all.py                                                  # dry-run, staging
+  python scripts/reset_fte_v2_for_all.py --apply                                          # apply, staging
+  python scripts/reset_fte_v2_for_all.py --db production                                  # dry-run, production
+  python scripts/reset_fte_v2_for_all.py --apply --db production --confirm-production-write
+"""
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+try:
+    from dotenv import load_dotenv
+    if os.path.exists(".env.local"):
+        load_dotenv(".env.local")
+    else:
+        load_dotenv()
+except ImportError:
+    pass
+
+from pymongo import MongoClient
+
+
+DB_NAME_STAGING = "gob-staging"
+DB_NAME_PRODUCTION = "gob"
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually write to the database. Without this flag, runs in dry-run mode (default).",
+    )
+    p.add_argument(
+        "--db",
+        choices=["staging", "production"],
+        default="staging",
+        help="Which database to target. Defaults to staging.",
+    )
+    p.add_argument(
+        "--confirm-production-write",
+        action="store_true",
+        help="Required confirmation when --apply is used with --db production.",
+    )
+    return p.parse_args()
+
+
+def get_mongo_client():
+    mongo_uri = os.environ.get("MONGO_URI")
+    if not mongo_uri:
+        print("ERROR: MONGO_URI not set in environment or .env file.", file=sys.stderr)
+        sys.exit(1)
+    return MongoClient(mongo_uri)
+
+
+def get_db_name(target: str) -> str:
+    return DB_NAME_PRODUCTION if target == "production" else DB_NAME_STAGING
+
+
+# The set of fields we'll overwrite on every user. Intentionally narrow —
+# we don't touch usernames, account settings, franchises, etc.
+RESET_FIELDS = {
+    "fte_v2_complete": False,
+    "tutorial_state.step": "persona_intro",
+    "tutorial_state.team_pick": None,
+    "tutorial_state.completed_at": None,
+}
+
+
+def print_pre_summary(users):
+    total = users.count_documents({})
+    completed = users.count_documents({"fte_v2_complete": True})
+    incomplete = users.count_documents({"fte_v2_complete": False})
+    missing = users.count_documents({"fte_v2_complete": {"$exists": False}})
+    step_persona = users.count_documents({"tutorial_state.step": "persona_intro"})
+    step_team_select = users.count_documents({"tutorial_state.step": "team_select"})
+    print("Before:")
+    print(f"  Total users:                          {total}")
+    print(f"  fte_v2_complete = True:               {completed}")
+    print(f"  fte_v2_complete = False:              {incomplete}")
+    print(f"  fte_v2_complete missing (anomaly):    {missing}")
+    print(f"  tutorial_state.step = persona_intro:  {step_persona}")
+    print(f"  tutorial_state.step = team_select:    {step_team_select}")
+
+
+def apply_reset(users, dry_run: bool):
+    if dry_run:
+        print("[DRY-RUN] Would set on EVERY user:")
+        for k, v in RESET_FIELDS.items():
+            print(f"            {k} = {v!r}")
+        return 0
+    result = users.update_many({}, {"$set": RESET_FIELDS})
+    print(f"Matched:  {result.matched_count}")
+    print(f"Modified: {result.modified_count}")
+    return result.modified_count
+
+
+def print_post_summary(users):
+    total = users.count_documents({})
+    completed = users.count_documents({"fte_v2_complete": True})
+    step_persona = users.count_documents({"tutorial_state.step": "persona_intro"})
+    print("After:")
+    print(f"  Total users:                          {total}")
+    print(f"  fte_v2_complete = True:               {completed}  (should be 0)")
+    print(f"  tutorial_state.step = persona_intro:  {step_persona}  (should equal total)")
+
+
+def main():
+    args = parse_args()
+    dry_run = not args.apply
+    db_name = get_db_name(args.db)
+
+    if args.apply and args.db == "production" and not args.confirm_production_write:
+        print(
+            "ERROR: Refusing to write to production without --confirm-production-write.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    mode = "DRY-RUN" if dry_run else "APPLY"
+    print("=" * 64)
+    print(f"  Reset FTE v2 status for all users — Mode: {mode} — Database: {db_name}")
+    print("=" * 64)
+    print()
+
+    client = get_mongo_client()
+    db = client[db_name]
+    users = db["users"]
+
+    print_pre_summary(users)
+    print()
+    apply_reset(users, dry_run)
+    print()
+
+    if not dry_run:
+        print_post_summary(users)
+        print()
+        print("Done.")
+    else:
+        print("Done (dry-run). Re-run with --apply to actually write.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Removes the grandfathering set up by [\`migrate_fte_v2.py\`](scripts/migrate_fte_v2.py). Every user gets sent back through the FTE v2 tutorial on next login.

## What it does (per user)
| Field | New value |
|---|---|
| \`fte_v2_complete\` | \`false\` |
| \`tutorial_state.step\` | \`"persona_intro"\` |
| \`tutorial_state.team_pick\` | \`null\` |
| \`tutorial_state.completed_at\` | \`null\` |

\`tutorial_state.started_at\` is intentionally preserved (it's signup history).

There's no DB flag distinguishing originally-grandfathered users from users who already completed the FTE v2 tutorial, so this script targets **all users** — both groups get sent back through. That matches the direction ("I'd like every user to go through the tutorial").

## Side effects (per the alignment above)
- Every user gets force-routed into the tutorial on next page load (\`authBarInit.routeToTutorial\` fires whenever \`fte_v2_complete === false\`).
- Franchises / tournaments / past data are untouched — full access restored once the user completes the tutorial.
- Idempotent re-runs.
- Only \`$set\` on the four fields above; no other state touched.

## Safety (matches \`migrate_fte_v2.py\` precedent)
- Default dry-run.
- Default staging.
- Production requires \`--apply --db production --confirm-production-write\`.

## Run order
\`\`\`bash
# Verify staging first
python scripts/reset_fte_v2_for_all.py                       # dry-run
python scripts/reset_fte_v2_for_all.py --apply               # apply

# Then production
python scripts/reset_fte_v2_for_all.py --db production       # dry-run
python scripts/reset_fte_v2_for_all.py --apply --db production --confirm-production-write
\`\`\`

Each run prints before/after counts (total / completed / incomplete / by-step) so you can verify the operation matched expectations.