### PR TITLE
FTE v2: pre-fill username modal with existing username for re-toured users

### DIFF
--- a/FrontEnd/static/franchise-select-team.js
+++ b/FrontEnd/static/franchise-select-team.js
@@ -178,12 +178,22 @@ async function selectTutorialTeam(team) {
   // Step 2: open the username Functional modal with team-aware chrome.
   // Mascot drives the title ("YOU'RE COACHING THE STERLING KNIGHTS").
   // Team name drives the Sammy portrait variant (team-linked kit).
+  // Pre-fill the input with the user's existing username (if any) so
+  // returning users who are being re-tour'd through the funnel (post-
+  // reset_fte_v2_for_all) can confirm-without-retyping. New signups
+  // get an empty input as before.
   const mascotMap = await fetchMascotMap();
   const mascot = mascotMap[team] || team;
+  let existingUsername = '';
+  try {
+    const raw = localStorage.getItem('auth_user');
+    if (raw) existingUsername = (JSON.parse(raw) || {}).username || '';
+  } catch (_) { /* private mode / corrupt JSON — fall back to empty */ }
   const { openUsernameModal } = await import('/js/shared/usernameModal.js');
   openUsernameModal({
     teamName: team,
     mascot,
+    initialUsername: existingUsername,
     onSuccess: async () => {
       // Mask the team-select page during the in-flight nav to tutorial-situation
       // so the user doesn't see the (now-stale) team grid flash between modal

--- a/FrontEnd/static/js/shared/usernameModal.js
+++ b/FrontEnd/static/js/shared/usernameModal.js
@@ -75,9 +75,14 @@ function ensureStylesheets() {
 
 /**
  * @param {Object} opts
- * @param {string}   [opts.teamName]   — drives Sammy portrait variant
- * @param {string}   [opts.mascot]     — drives title ("YOU'RE COACHING THE …")
- * @param {Function} [opts.onSuccess]  — called after username is persisted server-side
+ * @param {string}   [opts.teamName]         — drives Sammy portrait variant
+ * @param {string}   [opts.mascot]           — drives title ("YOU'RE COACHING THE …")
+ * @param {string}   [opts.initialUsername]  — pre-fill the input (e.g. existing users
+ *                                             who are being re-tour'd through the funnel
+ *                                             see their current handle; CONTINUE without
+ *                                             editing keeps it via the backend's
+ *                                             same-value-OK update path).
+ * @param {Function} [opts.onSuccess]        — called after username is persisted server-side
  * @returns {{ close: Function }}
  */
 export function openUsernameModal(opts = {}) {
@@ -87,6 +92,9 @@ export function openUsernameModal(opts = {}) {
     ? `YOU'RE COACHING THE ${mascotText.toUpperCase()}`
     : 'CHOOSE A USERNAME';
   const sammySrc = getTeamSammyImage(opts.teamName);
+  // String() guard so a stray null/undefined doesn't end up rendered as
+  // the literal text "null" in the input.
+  const initialUsername = typeof opts.initialUsername === 'string' ? opts.initialUsername : '';
 
   ensureStylesheets();
   // Username step of the funnel — quiet progress thread updates.
@@ -137,6 +145,12 @@ export function openUsernameModal(opts = {}) {
   const inputEl = overlay.querySelector('#username-modal-input');
   const errorEl = overlay.querySelector('#username-modal-error');
   const ctaBtn = overlay.querySelector('#username-modal-cta');
+
+  // Pre-fill with the user's current username if one was passed in. .value
+  // is set via property (not attribute) so submit reads it directly.
+  if (inputEl && initialUsername) {
+    inputEl.value = initialUsername;
+  }
 
   function setError(msg) {
     if (errorEl) errorEl.textContent = msg || '';
@@ -209,7 +223,13 @@ export function openUsernameModal(opts = {}) {
         submit();
       }
     });
-    setTimeout(() => inputEl.focus(), 0);
+    // Autofocus on next tick. When pre-filled, select the whole value so
+    // a single keystroke clears + replaces it (matches OS-level "edit a
+    // pre-filled field" behavior).
+    setTimeout(() => {
+      inputEl.focus();
+      if (initialUsername) inputEl.select();
+    }, 0);
   }
 
   return { close };


### PR DESCRIPTION
After [\`reset_fte_v2_for_all\`](scripts/reset_fte_v2_for_all.py), every existing user gets sent back through the tutorial — including users who already chose a username. The username modal currently fires unconditionally with an empty input, forcing them to retype a handle they already picked.

## Behavior change
| User has a username? | Before | After |
|---|---|---|
| **Yes** (most existing prod users) | Empty input + placeholder; must retype | Input **pre-filled with their current handle**; whole value pre-selected so a single keystroke clears it if they want to change it. CONTINUE without editing keeps the handle (backend's set-username allows same-value updates via the user_id match path). |
| **No** (new signups) | Empty input + placeholder | Unchanged — empty input + placeholder. |

## Files
- \`js/shared/usernameModal.js\` — accepts optional \`initialUsername\` string. Sets \`inputEl.value\` after mount. Autofocus now also \`.select()\`s the pre-filled text.
- \`franchise-select-team.js\` — reads \`localStorage.auth_user.username\` (defensive try/catch for private mode / corrupt JSON) and passes it as \`initialUsername\`.

Roughly 30 lines. Doesn't change anything else about the modal — same chrome, same title (\`YOU'RE COACHING THE [MASCOT]\`), same Sammy portrait, same CTA.

## Test plan
- [ ] User with existing username walks tutorial → username modal opens with their handle pre-filled and selected → CONTINUE keeps it → tip-off appears.
- [ ] Same user opens modal → types a new handle → CONTINUE updates to new handle.
- [ ] New signup (no \`auth_user.username\`) → modal opens with empty input (unchanged behavior).
- [ ] User tries to set a handle taken by another user → error message displays (unchanged).