### PR TITLE
UESS: build_foul_announcement helper — wire whistle SFX on OTB + consolidate

### DIFF
--- a/BackEnd/engine/dreb_step_emitter.py
+++ b/BackEnd/engine/dreb_step_emitter.py
@@ -32,6 +32,7 @@ from typing import Any, Dict, List, Optional
 
 from BackEnd.constants import HCO_STEP_T_FLOOR_GAME_SECONDS
 from BackEnd.utils.animation_step_helpers import (
+    build_foul_announcement,
     rebound_attemptor_ids,
     stamp_rebound_capture_player_motion,
     stamp_tween_durations,
@@ -204,16 +205,18 @@ def build_dreb_animation_steps(
         next_step = {"kind": "next_step", "index": 999}
 
     if otb_foul:
-        announcement = {
-            "text": "Over The Back!",
-            "team": otb_foul.get("announcement_team")
-            or ("home" if away_offense else "away"),
-            "hold_ms": 1000,
-            "style": "primary",
-            "player_data": {
-                "playerId": str(otb_foul.get("fouler_id") or rebounder_id)
-            },
-        }
+        # Canonical UESS foul-announcement builder. Stamps meta.sfx="foul"
+        # so the whistle fires at overlay mount. Going through the helper
+        # is what guarantees the SFX — building this dict by hand is what
+        # caused OTB to ship silent originally.
+        announcement = build_foul_announcement(
+            text="Over The Back!",
+            team=(
+                otb_foul.get("announcement_team")
+                or ("home" if away_offense else "away")
+            ),
+            fouler_id=otb_foul.get("fouler_id") or rebounder_id,
+        )
     else:
         announcement = {
             "text": "Rebound!",

--- a/BackEnd/engine/skeleton_step_emitter.py
+++ b/BackEnd/engine/skeleton_step_emitter.py
@@ -41,6 +41,7 @@ from BackEnd.utils.animation_step_helpers import (
     _ag_grid_per_game_sec,
     _euclid,
     _player_lookup_by_id,
+    build_foul_announcement,
     pass_arrival_sfx,
     pass_release_sfx,
     rattle_hop_sfx,
@@ -1915,15 +1916,14 @@ def _shooting_foul_on_miss_announcement(
     )
     if not fouler_id:
         return None
-    return {
-        "text": "Shooting Foul!",
-        "team": "neutral",
-        "hold_ms": 1000.0,
-        "style": "shooting_foul",
-        "player_data": {"playerId": str(fouler_id)},
-        # Whistle SFX carried on payload; FE plays at overlay mount.
-        "meta": {"sfx": "foul"},
-    }
+    # Canonical UESS foul-announcement builder (single source for foul
+    # announcement payloads + meta.sfx). See animation_step_helpers.py.
+    return build_foul_announcement(
+        text="Shooting Foul!",
+        team="neutral",
+        fouler_id=fouler_id,
+        style="shooting_foul",
+    )
 
 
 def _stamp_shooting_foul_on_miss_end(

--- a/BackEnd/utils/animation_step_helpers.py
+++ b/BackEnd/utils/animation_step_helpers.py
@@ -765,3 +765,77 @@ def log_fb_animation_steps(
                         gap,
                     )
         prev_end_coords = dict(end_coords)
+
+
+# ----------------------------------------------------------------------------
+# Step-announcement helpers
+# ----------------------------------------------------------------------------
+#
+# UESS step emitters emit announcement dicts via `step["end"]["announcement"]`
+# (or directly on the step) that the frontend's runStepAnnouncement picks up.
+# The frontend reads SFX from `announcement.meta.sfx` (architecture comment
+# at animationPlayback.js:631 — "SFX comes from announcement.meta.sfx
+# (backend-stamped); no FE hardcode."). Building these dicts inline is
+# error-prone — the OTB foul on rebound shipped without `meta.sfx` and was
+# silent for weeks. Use this helper instead so the whistle SFX is impossible
+# to forget.
+#
+# SFX key resolution lives in gameSfx.js — `"foul"` → `whistle-1-lowervol.wav`
+# today. Other foul-type SFX keys can be added there without touching emitters.
+
+
+def build_foul_announcement(
+    text: str,
+    team: str,
+    fouler_id: Any,
+    *,
+    hold_ms: int = 1000,
+    style: str = "primary",
+    sfx_key: str = "foul",
+    extra_meta: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Canonical UESS step-announcement dict for any foul event.
+
+    Stamps ``meta.sfx = sfx_key`` (default ``"foul"`` → whistle) so the
+    whistle SFX always fires at announcement mount. This is the single
+    place foul announcements should be constructed inside UESS step
+    emitters; bypassing it risks silent whistles (see dreb_step_emitter
+    OTB regression that motivated this helper).
+
+    Args:
+        text: Announcement headline (e.g. "Over The Back!",
+            "Shooting Foul!", "BLOCKING FOUL!"). Frontend renders verbatim.
+        team: Announcement-team key, one of ``"home"`` / ``"away"`` /
+            ``"neutral"``. Drives accent color on the overlay card.
+        fouler_id: Player ID of the foul committer; coerced to str.
+        hold_ms: How long the overlay stays on screen. Default 1000ms,
+            matches existing foul announcements.
+        style: ``"primary"`` (default) or ``"shooting_foul"`` — the
+            latter triggers the dual-row chrome on the frontend.
+        sfx_key: Key resolved by gameSfx.js. Default ``"foul"`` →
+            ``whistle-1-lowervol.wav``. Override only if a specific foul
+            type wants a different sound (e.g. shot-clock violation uses
+            ``"shot_clock_violation"`` → ``whistle-3.mp3``).
+        extra_meta: Optional dict merged into ``meta`` alongside the SFX
+            key. Use for foul-type-specific metadata (decision pills,
+            etc.) without overriding ``meta.sfx``.
+
+    Returns:
+        Announcement dict ready to assign to ``step["end"]["announcement"]``
+        or used directly as ``announcement`` on a step.
+    """
+    meta: Dict[str, Any] = {"sfx": sfx_key}
+    if extra_meta:
+        # Caller-supplied meta is merged last so explicit overrides win, but
+        # we re-apply sfx_key at the end so a caller can't accidentally
+        # drop the whistle by passing extra_meta={"sfx": None}.
+        meta.update(extra_meta)
+        meta["sfx"] = sfx_key
+    return {
+        "text": text,
+        "team": team,
+        "hold_ms": hold_ms,
+        "style": style,
+        "player_data": {"playerId": str(fouler_id) if fouler_id is not None else ""},
+        "meta": meta,
+    }

--- a/_documentation_master/00_General_Systems/UESS_System.md
+++ b/_documentation_master/00_General_Systems/UESS_System.md
@@ -130,8 +130,11 @@ Reusable across turn types. Live in [`BackEnd/utils/transition_bridge.py`](../..
 - `build_final_coords(game)` — snapshots `player.coords` at end of every turn.
 - `build_final_ball_handler_id(turn_result)` — resolves the end-of-turn BH.
 - `stamp_tween_durations(start, end_coords, T, off_lineup, def_lineup)` — writes per-player tween durations.
+- `build_foul_announcement(text, team, fouler_id, *, hold_ms=1000, style="primary", sfx_key="foul", extra_meta=None)` — canonical step-announcement dict for any foul event. Stamps `meta.sfx` so the whistle always fires at overlay mount. Use this in every UESS step emitter that emits a foul announcement; constructing the dict by hand is what caused the DREB OTB foul to ship silent (no `meta.sfx`, no whistle). Current consumers: `dreb_step_emitter` (OTB), `skeleton_step_emitter` (shooting-foul-on-miss).
 
 Both `final_coords` and `final_ball_handler_id` are stamped unconditionally on every turn by `_append_turn` in [`game_manager.py`](../../BackEnd/models/game_manager.py). Next-turn emitters read from `prior_turn.final_coords` / `prior_turn.final_ball_handler_id`.
+
+**SFX architecture invariant.** UESS step announcements carry their SFX via `announcement.meta.sfx` (a key resolved by [`gameSfx.js`](../../FrontEnd/static/js/phaser/utils/gameSfx.js); `"foul"` → `whistle-1-lowervol.wav` today). The frontend's `runStepAnnouncement` is deliberately not allowed to hardcode SFX by announcement text — see comment at [`animationPlayback.js:631`](../../FrontEnd/static/js/phaser/animation/animationPlayback.js#L631). All SFX wiring lives in backend emitters; `build_foul_announcement` exists to enforce that for foul-type events.
 
 ---
 


### PR DESCRIPTION
Per your direction — universal foul-SFX coverage rolled into the existing UESS architecture, not a new system.

## What was broken
UESS step emitters carry per-step SFX via \`announcement.meta.sfx\`. The frontend reads it; if absent, no SFX fires. The contract is explicit at [\`animationPlayback.js:631\`](FrontEnd/static/js/phaser/animation/animationPlayback.js#L631):
> *"SFX comes from \`announcement.meta.sfx\` (backend-stamped); no FE hardcode."*

DREB's OTB announcement was built inline as a dict literal without \`meta.sfx\` → silent whistle. Easy mistake, hard to spot. (Audit found exactly two UESS foul announcements; the other — \`_shooting_foul_on_miss_announcement\` in skeleton — was correctly stamped.)

## What this PR does

### 1. Adds \`build_foul_announcement\` helper
[\`BackEnd/utils/animation_step_helpers.py\`](BackEnd/utils/animation_step_helpers.py): canonical foul-announcement builder. Stamps \`meta.sfx="foul"\` (→ \`whistle-1-lowervol.wav\` via gameSfx.js) by default. Per-foul-type extras can be passed via \`extra_meta\` without clobbering the SFX.

\`\`\`python
build_foul_announcement(
    text="Over The Back!",
    team="home",
    fouler_id=player_id,
    # hold_ms=1000, style="primary", sfx_key="foul" are defaults
)
\`\`\`

### 2. Migrates both existing foul-announcement sites
- [\`dreb_step_emitter.py\`](BackEnd/engine/dreb_step_emitter.py) — OTB. **Fixes the silent whistle.**
- [\`skeleton_step_emitter.py\`](BackEnd/engine/skeleton_step_emitter.py) — shooting-foul-on-miss. No behavior change (was already correctly stamped); migration consolidates onto the canonical path.

### 3. Documents the contract
[\`UESS_System.md §4\`](_documentation_master/00_General_Systems/UESS_System.md) gets the helper in the Universal Helpers list + a new "SFX architecture invariant" paragraph explaining why SFX wiring lives backend-side and why this helper exists.

## Why this scopes well
No new system code, no new schema, no new dispatch logic. Just a helper that uses the existing UESS \`announcement.meta.sfx\` contract — and one paragraph in the doc making the contract explicit so the next foul emitter doesn't have to re-discover it.

## Test plan
- [ ] OTB foul during a defensive rebound → whistle plays at announcement mount.
- [ ] Shooting foul on a miss → whistle plays at announcement mount (no regression).
- [ ] Any non-foul announcement (Rebound, It's Good, No Fast Break, etc.) → unchanged.