### PR TITLE
Fix numpy libstdc++.so.6 load failure on Railway (recruit paint service)

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -3,6 +3,11 @@
 
 [phases.setup]
 nixPkgs = ["python311", "nodejs_18"]
+# numpy/scipy's compiled C-extensions dlopen libstdc++.so.6 at runtime; the base
+# image doesn't provide it, so `import numpy` fails with
+# "libstdc++.so.6: cannot open shared object file". nixLibs puts the gcc C++
+# runtime on LD_LIBRARY_PATH so the recruit paint service (Pillow/numpy/scipy) loads.
+nixLibs = ["stdenv.cc.cc.lib"]
 
 [phases.install]
 cmds = [


### PR DESCRIPTION
## The bug
Recruit portraits show the generic silhouette because the paint endpoints return `{status: "error"}`. Root cause, confirmed on the staging container:

```
Original error was: libstdc++.so.6: cannot open shared object file: No such file or directory
```

`numpy 2.4.6` / `scipy` / `Pillow` install into `/opt/venv` correctly, but numpy's compiled C-extensions `dlopen` **`libstdc++.so.6`** at runtime, and the nixpacks base image doesn't provide the gcc C++ runtime — so `import numpy` fails, and the recruit paint service (which needs numpy/scipy/Pillow) throws.

**Not** an R2 or code problem: `is_configured()` passed and the kit was successfully read from R2 *before* this threw, so the R2 env vars and the paint code are already correct.

## The fix
One line in `nixpacks.toml` — add `nixLibs = ["stdenv.cc.cc.lib"]` to the setup phase, which puts the gcc C++ runtime (including `libstdc++.so.6`) on `LD_LIBRARY_PATH` in the built image.

## After merge
Railway redeploys from `develop`. Verify on the running container:
```
/opt/venv/bin/python -c "import numpy, scipy, PIL; print('ok', numpy.__version__)"
```
should print `ok 2.4.6` instead of the libstdc++ error. Then the browser `ensureRecruitImage(...)` call flips from `error` to `painted`, and recruit portraits appear.

If `stdenv.cc.cc.lib` somehow doesn't resolve in this nixpkgs pin, the fallback is `aptPkgs = ["libstdc++6"]` in the same phase — but `nixLibs` is the correct mechanism for a nix-provided Python.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A35cCo9CQ3nfwc6A7tTF8y

---
_Generated by [Claude Code](https://claude.ai/code/session_01A35cCo9CQ3nfwc6A7tTF8y)_