### PR TITLE
Put multiarch lib dir on LD_LIBRARY_PATH so numpy finds libstdc++.so.6

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -17,4 +17,4 @@ cmds = [
 ]
 
 [start]
-cmd = "/opt/venv/bin/uvicorn BackEnd.api.api:app --host 0.0.0.0 --port ${PORT:-8000}"
+cmd = "LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH /opt/venv/bin/uvicorn BackEnd.api.api:app --host 0.0.0.0 --port ${PORT:-8000}"

--- a/railway.json
+++ b/railway.json
@@ -4,7 +4,7 @@
     "builder": "NIXPACKS"
   },
   "deploy": {
-    "startCommand": "/opt/venv/bin/uvicorn BackEnd.api.api:app --host 0.0.0.0 --port $PORT",
+    "startCommand": "LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH /opt/venv/bin/uvicorn BackEnd.api.api:app --host 0.0.0.0 --port $PORT",
     "healthcheckPath": "/health",
     "healthcheckTimeout": 100,
     "restartPolicyType": "ON_FAILURE",


### PR DESCRIPTION
Follow-up to #564. That change (`nixLibs`) pulled gcc libs into the image but they landed in `/nix/store/…` paths, while the container's runtime `LD_LIBRARY_PATH` is only `/usr/lib`. Diagnosed live on the staging box:

```
LD_LIBRARY_PATH=/usr/lib
find / -name libstdc++.so.6:
  /usr/lib/x86_64-linux-gnu/libstdc++.so.6      ← exists here (standard path)
  /nix/store/…gcc-13…/lib/libstdc++.so.6
  /nix/store/…gcc-14…/lib/libstdc++.so.6
```

So `libstdc++.so.6` is literally present at `/usr/lib/x86_64-linux-gnu/`, but that multiarch dir isn't on `LD_LIBRARY_PATH`, and the nix-built Python doesn't consult the standard ldconfig cache — so numpy's C-extension still can't `dlopen` it.

## Fix
Prepend `/usr/lib/x86_64-linux-gnu` to `LD_LIBRARY_PATH` in the start command. `railway.json`'s `startCommand` is authoritative (it overrides the nixpacks `[start]`), so both are updated to stay consistent.

## After merge → redeploy, verify
```
/opt/venv/bin/python -c "import numpy, scipy, PIL; print('ok', numpy.__version__)"
```
should print `ok 2.4.6`. Then browser `ensureRecruitImage(...)` → `painted`, and portraits appear.

(If numpy instead complains about a `GLIBCXX_3.4.x not found` version after this — meaning the Debian libstdc++ is older than numpy 2.4.6 wants — the next step would be pinning to a nix gcc lib or an older numpy; but the standard path should satisfy it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A35cCo9CQ3nfwc6A7tTF8y

---
_Generated by [Claude Code](https://claude.ai/code/session_01A35cCo9CQ3nfwc6A7tTF8y)_