### PR TITLE
Fix startup crash: use nix gcc libstdc++ via start.sh (not Debian)

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -17,4 +17,4 @@ cmds = [
 ]
 
 [start]
-cmd = "LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH /opt/venv/bin/uvicorn BackEnd.api.api:app --host 0.0.0.0 --port ${PORT:-8000}"
+cmd = "sh /app/start.sh"

--- a/railway.json
+++ b/railway.json
@@ -4,7 +4,7 @@
     "builder": "NIXPACKS"
   },
   "deploy": {
-    "startCommand": "LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH /opt/venv/bin/uvicorn BackEnd.api.api:app --host 0.0.0.0 --port $PORT",
+    "startCommand": "sh /app/start.sh",
     "healthcheckPath": "/health",
     "healthcheckTimeout": 100,
     "restartPolicyType": "ON_FAILURE",

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Railway/nixpacks start wrapper.
+#
+# numpy/scipy's C-extensions dlopen libstdc++.so.6 at runtime, but the nix-built
+# Python's environment doesn't expose it on LD_LIBRARY_PATH. We must NOT use
+# Debian's /usr/lib/x86_64-linux-gnu libstdc++ — loading Debian's libc into the
+# nix Python crashes the interpreter ("__vdso_gettimeofday: invalid mode for
+# dlopen()"). Instead, add the *nix* gcc lib dir (pulled in by nixLibs =
+# ["stdenv.cc.cc.lib"] in nixpacks.toml), which matches the nix Python's ABI.
+#
+# Safe by construction: if the glob matches nothing it contributes an ignored
+# path and the original LD_LIBRARY_PATH is preserved, so Python still starts.
+GCC_LIBS="$(echo /nix/store/*gcc*-lib/lib | tr ' ' ':')"
+export LD_LIBRARY_PATH="${GCC_LIBS}:${LD_LIBRARY_PATH}"
+
+exec /opt/venv/bin/uvicorn BackEnd.api.api:app --host 0.0.0.0 --port "${PORT:-8000}"


### PR DESCRIPTION
Fixes the failed deploy from #565. That change prepended **Debian's** `/usr/lib/x86_64-linux-gnu` to `LD_LIBRARY_PATH`, which made the **nix-built Python load a conflicting libc and crash at startup**:

```
/opt/venv/bin/python: error while loading shared libraries:
__vdso_gettimeofday: invalid mode for dlopen(): Invalid argument
```

Python crash-looped → healthcheck failed → Railway rejected the deploy (kept the previous build, so staging never went down).

## Fix
Replace the inline `LD_LIBRARY_PATH` prefix with a small **`start.sh`** that adds the **nix** gcc lib dir — the one matching the nix Python's ABI, pulled into the image by `nixLibs = ["stdenv.cc.cc.lib"]` (#564) at `/nix/store/…gcc…-lib/lib/` — so numpy's C-extensions find `libstdc++.so.6` **without** dragging in Debian's conflicting libc.

**Safe by construction:** the script only *appends* nix gcc libs and preserves the original `LD_LIBRARY_PATH`, so the interpreter always starts even if the glob matches nothing (worst case = deploy succeeds, numpy still needs another nudge — but no crash). `railway.json` + `nixpacks.toml` both now run `sh /app/start.sh`.

Validated locally: script parses (`sh -n`), `railway.json` is valid JSON, and the path build works in both the match and no-match cases.

## After merge → redeploy
1. Deploy should go **green** (Python starts).
2. Railway console: `/opt/venv/bin/python -c "import numpy" ` will *still* error there (interactive shell doesn't run start.sh), so test the real thing — reload a recruit page, or in the browser console: `API_CONFIG.ensureRecruitImage('42fe2984-a157-46fa-886d-1d853ad1b6ee').then(d=>console.log(d))` → should be `painted`.

If numpy *still* can't find libstdc++ even via the nix path, the deploy will at least be healthy and we diagnose from a stable base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A35cCo9CQ3nfwc6A7tTF8y

---
_Generated by [Claude Code](https://claude.ai/code/session_01A35cCo9CQ3nfwc6A7tTF8y)_