### PR TITLE
Signing: unique player_id to fix cross-franchise uniform collision

### DIFF
--- a/BackEnd/api/franchise_routes.py
+++ b/BackEnd/api/franchise_routes.py
@@ -10369,9 +10369,14 @@ def _persist_week_35_awards_if_needed(franchise_doc: dict[str, Any]) -> dict[str
 def _week_35_result_entry_from_recruit(recruit_doc: dict[str, Any], team_doc: dict[str, Any], scholarship: bool, playing_time: bool, walk_on: bool = False) -> dict[str, Any]:
     best_pos = _best_position(recruit_doc.get("position_ratings") or {})
     return {
-        # keep the recruit's stable id so its pre-generated portrait follows him onto the
-        # roster (players/master/<id>.png). Walk-ons have no recruit_id -> fresh uuid.
-        "player_id": recruit_doc.get("recruit_id") or str(uuid.uuid4()),
+        # ALWAYS a fresh uuid — never the recruit_id. Set recruits share one
+        # recruit_id across every franchise (they all draw set_0001), so keying the
+        # signed uniform master by recruit_id collides: franchise A signs recruit X
+        # to team A and franchise B signs the same X to team B, but both would
+        # resolve to players/master/<recruit_id>.png (first-writer-wins → wrong
+        # jersey for everyone else). A unique player_id gives each signed player its
+        # own master. The portrait link is image_id (below), not player_id.
+        "player_id": str(uuid.uuid4()),
         "recruit_id": recruit_doc.get("recruit_id"),
         # the portrait to paint into this team's uniform at signing (its own for
         # set recruits, a borrowed base-library id for dynamic ones). Walk-ons

--- a/_documentation_master/00_Operations/Recruit_Image_System.md
+++ b/_documentation_master/00_Operations/Recruit_Image_System.md
@@ -68,6 +68,12 @@ forever after** — no pre-generation, no batch job, no queue:
 - **Uniformed master** (`players/master/<player_id>.png`, post-signing) → `POST
   /player-image/ensure` recolors the kit into the signed team's colors.
 
+> **`player_id` is a fresh unique uuid at signing — NOT the recruit_id.** Set recruits share one
+> recruit_id across every franchise (all draw set_0001), so keying the uniformed master by
+> recruit_id would collide across franchises that sign the same recruit to different teams
+> (first-writer-wins → wrong jersey). The portrait link is `image_id`, not `player_id`, so a
+> unique player_id is free — each signed player gets its own uniformed master.
+
 Both endpoints (`BackEnd/api/player_image_routes.py`) are idempotent, auth'd, and degrade to a
 status the frontend reads as "use generic" — **never a 500**. The paint core
 (`BackEnd/services/recruit_image.py`) is a **verbatim port** of the league recolor + finish, so
@@ -463,7 +469,9 @@ exactly. Decision: **use the templated system for their recruits anyway.**
 - **Fixed sets** of 300 (not a face library); a franchise loads a whole set per season.
 - **Never reuse a set within a franchise**; random pick from unused; graceful fallback to
   dynamic generation when exhausted.
-- **`player_id = recruit_id`** through signing — one image lineage; walk-ons excepted.
+- **`player_id` is a fresh unique uuid at signing** (superseding the earlier `player_id =
+  recruit_id`). The image lineage runs through `image_id`, not `player_id`, so a unique player_id
+  avoids cross-franchise uniformed-master collisions (see the as-built section).
 - **First proof set reuses existing faces** (free); fresh NB for real sets.
 - **Portrait = projected mature build.** Attribute maturity scaling (ST/AG/RT) by per-year
   factor **JH 0.55 / FR 0.65 / SO 0.80 / JR 1.00**, plus height/weight growth projection; then

--- a/scripts/recruit_sets/SCHEMA.md
+++ b/scripts/recruit_sets/SCHEMA.md
@@ -6,8 +6,9 @@ for the full architecture; this file is the exact field-level spec the **baker**
 **loader** reads.
 
 A "set" is 300 pre-built recruits shipped as a unit. Each recruit carries a **stable
-`recruit_id`** that keys its pre-generated uniform kit in R2 (`recruits/kit/<recruit_id>.png`) and
-survives all the way to the rostered player (`player_id = recruit_id` at signing).
+`recruit_id`** that keys its pre-generated uniform kit in R2 (`recruits/kit/<recruit_id>.png`).
+At signing the player gets a fresh unique `player_id` (not the recruit_id — set recruits share
+one recruit_id across franchises, which would collide); the portrait follows via `image_id`.
 
 There are **two artifacts**:
 


### PR DESCRIPTION
## The bug (only surfaces at multi-franchise / prod scale)
Every franchise draws **set_0001**, so they all share the **same 300 `recruit_id`s**. At signing `player_id = recruit_id`, so the same set recruit has the **same `player_id` across every franchise**. The uniformed master is keyed `players/master/<player_id>.png` — a *global* R2 key — but different franchises sign the same recruit to **different teams**.

Result: whichever franchise signs+views recruit X first paints `players/master/X.png` in *their* team's colors; the paint is idempotent, so **every other franchise's recruit X shows that first team's jersey**. Invisible with one test franchise (staging); guaranteed once prod has many franchises drawing set_0001.

(White pre-sign portraits are unaffected — they're team-independent, so sharing by `image_id` is correct. Only the *signed* masters collided.)

## The fix
`player_id = recruit_id` predates `image_id`. Now that **`image_id` is the portrait link**, `player_id` no longer needs to equal `recruit_id`. Give each signed player a **fresh unique `player_id`** at signing (walk-ons already got one) — so each gets its own uniformed master, painted from `image_id`'s kit into its own team's colors.

One line in `_week_35_result_entry_from_recruit`; `recruit_id` and `image_id` still ride on the signed entry, and `FPD.meta.image_id` still lets the painter resolve the kit.

## Safety audit
Nothing depends on `player_id == recruit_id`: the frontend never builds player images from `recruit_id`, and every `recruit_id` lookup is in the pre-sign recruiting context. No test asserts the coupling. Docs + SCHEMA updated to the new keying.

## Why it matters for the prod release
This should land on `develop` **before** the `develop → main` cut, so production is correct from day one and never produces wrong signed jerseys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A35cCo9CQ3nfwc6A7tTF8y

---
_Generated by [Claude Code](https://claude.ai/code/session_01A35cCo9CQ3nfwc6A7tTF8y)_