### PR TITLE
Serve signed recruits from FPD on /player (fix broken player page after rollover)

### DIFF
--- a/BackEnd/api/api.py
+++ b/BackEnd/api/api.py
@@ -7191,6 +7191,38 @@ try:
             print(f"🔍 Looking up player with ID: {player_id}")
             player = players_collection.find_one({"_id": player_id})
             if not player:
+                # Signed recruits (and walk-ons) never enter the universal
+                # `players` collection — they live only in FPD, keyed by a fresh
+                # per-franchise player_id. Serve those from FPD so their player
+                # page loads after a season rollover. The universal collection
+                # stays read-only; we build a response here without touching it.
+                if mode == "franchise" and franchise_id:
+                    fpd_doc = franchise_players_data_collection.find_one(
+                        {"franchise_id": str(franchise_id), "player_id": str(player_id)}
+                    )
+                    if fpd_doc:
+                        meta = fpd_doc.get("meta") or {}
+                        first_name = meta.get("first_name", "")
+                        last_name = meta.get("last_name", "")
+                        fpd_player = {
+                            "_id": str(player_id),
+                            "first_name": first_name,
+                            "last_name": last_name,
+                            "name": f"{first_name} {last_name}".strip(),
+                            "team": meta.get("team", meta.get("team_id", "")),
+                            "team_id": meta.get("team_id"),
+                            "year": meta.get("year"),
+                            "height": meta.get("height"),
+                            "weight": meta.get("weight"),
+                            "jersey": meta.get("jersey"),
+                            "archetype": meta.get("archetype"),
+                            "image_id": meta.get("image_id"),
+                            "attributes": fpd_doc.get("attributes") or {},
+                            "position_ratings": fpd_doc.get("position_ratings") or {},
+                            "season": fpd_doc.get("season") or {},
+                            "career": fpd_doc.get("career") or {},
+                        }
+                        return fpd_player
                 print(f"❌ Player not found with _id: {player_id}")
                 # Try a broader search to help debug
                 sample = players_collection.find_one({})


### PR DESCRIPTION
## Problem

After a season rollover, opening a newly-signed recruit's player page showed **"Failed to load player data."**

Signed recruits (and walk-ons) never enter the universal `players` collection — they exist only in `franchise_players_data` (FPD), keyed by a fresh per-franchise `player_id` (the uuid minted at signing, PR #567). Once rostered, the detail page requests the **player** path `/player/{id}` instead of `/recruit/{id}`. That endpoint looked the id up only in the universal `players` collection, missed, and returned 404.

## Fix

`get_player` now falls back to FPD when the universal lookup misses **and** the request is in franchise mode (`mode=franchise` + `franchise_id`). It builds the response from the FPD `meta` (name, team, year, height, weight, jersey, archetype, `image_id`) plus `attributes`, `position_ratings`, `season`, and `career` — the exact fields `player-detail.js` renders.

The portrait still resolves through the existing lazy paint flow: the page requests `players/master/<player_id>.png`, and on 404 the ensure endpoint paints it from `kit/<image_id>` into the team uniform.

## Constraint honored

The universal `players` collection is **never written to** — it remains the read-only starting point for all new franchises. The fallback only *reads* FPD and constructs an in-memory response. League players (present in the universal collection) are unaffected; their existing FPD-overlay path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A35cCo9CQ3nfwc6A7tTF8y)_