### PR TITLE
Universal player-image painting: one delegated paint-on-miss hook

### DIFF
--- a/BackEnd/api/franchise_routes.py
+++ b/BackEnd/api/franchise_routes.py
@@ -13889,6 +13889,60 @@ def sim_championship(req: SimChampionshipRequest):
 
 
 @router.post("/franchise/finish-season")
+def _warm_user_signed_player_masters(franchise_id, franchise_doc, signed_players):
+    """Eager-paint the USER team's freshly-signed players' uniform masters at
+    rollover, so their portraits are already in R2 the instant they open their
+    roster next season — matching the "already baked" experience of the original
+    start-of-franchise players. CPU opponents stay lazy (painted on first view).
+
+    Best-effort and self-contained: any failure is logged and swallowed so a
+    portrait paint can never break the season transition. Mirrors the paint in
+    player_image_routes.ensure_player_image, minus the HTTP layer."""
+    from BackEnd.services import recruit_image, r2_images
+
+    if not r2_images.is_configured():
+        return
+    user_team_id = str(franchise_doc.get("user_team_id") or "")
+    if not user_team_id:
+        return
+    to_warm = [
+        s for s in signed_players
+        if str(s.get("team_id") or "") == user_team_id and s.get("image_id") and s.get("player_id")
+    ]
+    if not to_warm:
+        return
+
+    team = db.teams.find_one({"_id": ObjectId(user_team_id)}) if ObjectId.is_valid(user_team_id) else None
+    if not team:
+        return
+    primary = team.get("primary_color", "#000000")
+    secondary = team.get("secondary_color", "#ffffff")
+    wordmark = team.get("mascot", "")
+
+    painted = 0
+    for s in to_warm:
+        player_id = str(s["player_id"])
+        image_id = s["image_id"]
+        master_key = f"players/master/{player_id}.png"
+        try:
+            if r2_images.exists(master_key):
+                continue
+            kit_key = f"recruits/kit/{image_id}.png"
+            mask_key = f"recruits/kit/{image_id}.mask.png"
+            if not (r2_images.exists(kit_key) and r2_images.exists(mask_key)):
+                continue
+            master = recruit_image.make_signed_master(
+                r2_images.get(kit_key), r2_images.get(mask_key), primary, secondary, wordmark)
+            r2_images.put(master_key, master)
+            painted += 1
+        except Exception:
+            logger.exception("[IMG-WARM] paint failed franchise_id=%s player_id=%s",
+                              str(franchise_id), player_id)
+    if painted:
+        logger.info("[IMG-WARM] pre-painted %s user signings franchise_id=%s",
+                    painted, str(franchise_id))
+
+
 def finish_season(req: FinishSeasonRequest):
     """Finish current season and start new season."""
     try:
@@ -14137,6 +14191,14 @@ def finish_season(req: FinishSeasonRequest):
     franchise_players_data_collection.delete_many({"franchise_id": str(franchise_id)})
     if next_fpd_docs:
         franchise_players_data_collection.insert_many(next_fpd_docs)
+
+    # Eager-warm the user's own signed players' uniform masters (best-effort, never
+    # blocks the transition on a portrait paint) so their new signings are already
+    # painted when they open next season's roster. Opponents paint lazily on view.
+    try:
+        _warm_user_signed_player_masters(franchise_id, franchise_doc, signed_players)
+    except Exception:
+        logger.exception("[IMG-WARM] eager paint pass failed franchise_id=%s", str(franchise_id))
 
     fm = FranchiseManager(db)
     fm.franchise_id = franchise_id

--- a/FrontEnd/static/court.html
+++ b/FrontEnd/static/court.html
@@ -5343,7 +5343,7 @@
           if (shooterId) {
             const headshotImg = playOption.querySelector('.play-headshot');
             if (headshotImg) {
-              const imgPath = API_CONFIG.buildStaticPath(`/images/players/${shooterId}.png`);
+              const imgPath = API_CONFIG.getPlayerImageUrl(shooterId, { size: 'card' });
               headshotImg.setAttribute('data-player-id', shooterId);
               // Team-aware initials fallback when the per-player photo fails;
               // matches the announcement system + v2 on-court sprite rule.
@@ -7171,7 +7171,7 @@
       
       // Set player image — team-aware initials fallback when the per-player
       // photo fails (matches announcement system + v2 on-court sprite rule).
-      const tooltipImgSrc = API_CONFIG.buildStaticPath(`/images/players/${playerId}.png`);
+      const tooltipImgSrc = API_CONFIG.getPlayerImageUrl(playerId, { size: 'card' });
       window.applyHeadshotFallback(image, tooltipImgSrc, window.buildPlaycallInitialsInfo(playerId));
       
       // Energy (NG)
@@ -7262,7 +7262,7 @@
       
       // Set intended shooter headshot
       if (data.intendedShooterId) {
-        const photoUrl = API_CONFIG.buildStaticPath(`/images/players/${data.intendedShooterId}.png`);
+        const photoUrl = API_CONFIG.getPlayerImageUrl(data.intendedShooterId, { size: 'card' });
         headshotEl.style.display = 'block';
         // Team-aware initials fallback when the per-player photo fails;
         // matches the announcement system + v2 on-court sprite rule.

--- a/FrontEnd/static/js/config/api-config.js
+++ b/FrontEnd/static/js/config/api-config.js
@@ -320,10 +320,69 @@ const API_CONFIG = {
       body: JSON.stringify({ franchise_id: franchiseId, player_id: playerId }),
     }).then((r) => r.json()).catch(() => ({ status: 'error' }));
   },
+
+  // Franchise id for the current page. Every franchise screen carries it as the
+  // `franchise_id` query param (that's how the whole app sources it); fall back
+  // to localStorage for the rare context that doesn't.
+  currentFranchiseId() {
+    try {
+      const q = new URLSearchParams(window.location.search).get('franchise_id');
+      if (q) return q;
+    } catch (e) { /* no window/search */ }
+    try { return localStorage.getItem('franchise_id') || null; } catch (e) { return null; }
+  },
 };
 
 // Make it globally available
 window.API_CONFIG = API_CONFIG;
+
+// --- Universal paint-on-miss -------------------------------------------------
+// Player/recruit masters are painted lazily (generate-on-miss). Rather than wire
+// the ensure->retry dance into every screen that renders a headshot, install ONE
+// delegated handler: any <img> that 404s on a canonical master URL is painted and
+// retried here, so every current and future render site is covered by default.
+//
+//   players/master/<player_id>.png   -> ensurePlayerImage(franchise_id, player_id)
+//   recruits/white/<image_id>.png    -> ensureRecruitImage(image_id)
+//
+// Error events don't bubble, so we listen in the CAPTURE phase (3rd arg true).
+// On the first miss we take over (stopImmediatePropagation) so the site's own
+// onerror->generic fallback doesn't clobber the retry; if the paint fails and the
+// retry 404s again, we've restored the site's handler and no longer intercept, so
+// its normal fallback (generic / initials / hide) runs exactly as before.
+(function installPaintOnMiss() {
+  if (typeof document === 'undefined') return;
+  const MASTER_RE = /players\/master\/([^/.?]+)\.png/;
+  const WHITE_RE = /recruits\/white\/([^/.?]+)\.png/;
+
+  document.addEventListener('error', function (e) {
+    const img = e.target;
+    if (!img || img.tagName !== 'IMG') return;
+    if (img.dataset.gobPaintTried) return;                 // already attempted once
+    const src = img.currentSrc || img.getAttribute('src') || '';
+
+    const pm = src.match(MASTER_RE);
+    const rw = pm ? null : src.match(WHITE_RE);
+    if (!pm && !rw) return;                                 // not a canonical master — leave it alone
+
+    img.dataset.gobPaintTried = '1';
+    e.stopImmediatePropagation();                          // suppress the site's onerror until we've retried
+    const originalOnerror = img.onerror;                   // preserve the site's fallback for a failed retry
+
+    const retry = function () {
+      // Restore the site's own fallback so a still-missing master degrades as it
+      // always did, then re-request the (now hopefully painted) master. A cache-
+      // buster forces a fresh origin fetch past any cached 404.
+      img.onerror = originalOnerror;
+      img.src = src + (src.indexOf('?') === -1 ? '?' : '&') + 'gobr=1';
+    };
+
+    const ensure = pm
+      ? API_CONFIG.ensurePlayerImage(API_CONFIG.currentFranchiseId(), pm[1])
+      : API_CONFIG.ensureRecruitImage(rw[1]);
+    ensure.then(retry, retry);
+  }, true);
+})();
 
 (function loadCaptureBootstrap() {
   if (typeof document === 'undefined' || !API_CONFIG.isCaptureEnv()) return;


### PR DESCRIPTION
## Problem

Player/recruit masters are painted lazily (generate-on-miss), but only the **player-detail page** ever triggered the paint. Every other surface — FCC scouting tab, team roster projected starters, training report, set-lineup, box-score POTG, and all the in-game Phaser headshots — just fell back to the generic silhouette when a master wasn't painted yet. That's why the detail page worked but the FCC scouting/roster/court did not.

The root cause was **siloing**: the ensure→retry paint dance was copy-wired into 2 of ~15 render sites and forgotten everywhere else.

## Fix — one system, not per-site patches

**`api-config.js` — a single delegated paint-on-miss hook.** Install one capture-phase `error` listener on `document`. Any `<img>` that 404s on a canonical master URL gets painted and retried, so **every current and future render site is covered by default**:

- `players/master/<player_id>.png` → `ensurePlayerImage(franchise_id, player_id)`
- `recruits/white/<image_id>.png` → `ensureRecruitImage(image_id)`

Error events don't bubble, so it listens in the capture phase. On the first miss it takes over (`stopImmediatePropagation`) so the site's own `onerror → generic` doesn't clobber the retry; if painting fails and the retry 404s again, the site's original handler is restored and its normal fallback (generic / team-aware initials / hide) runs exactly as before. Adds a `currentFranchiseId()` helper (URL param, then localStorage) to source the franchise for the ensure call.

**`court.html` — CDN URL fix.** Three live playcall/HUD headshots built a static `/images/players/<id>.png` path that never reached the R2 CDN where masters live, so painting could never happen there. Switched them to `getPlayerImageUrl(...)` so masters resolve and the hook can paint misses. (The remaining static paths are in a disabled/`return`-guarded function — left untouched.)

**`finish_season` — eager warm.** Best-effort pre-paint of the **user team's** freshly-signed players' uniform masters at rollover, so their new signings are already painted the instant they open next season's roster — matching the "already baked" experience of the original start-of-franchise players. Wrapped so a portrait paint can never break the season transition. CPU opponents stay lazy (painted on first view).

## Why this is systematic, not a silo

After this, the **display path is unified** across both player populations — original start-of-franchise players (masters pre-baked & uploaded) and signed recruits (masters painted on demand) — all resolve via `getPlayerImageUrl(player_id)` → `players/master/<player_id>.png`, and any miss is handled by the one hook. A new screen just writes ``'&lt;img src=getPlayerImageUrl(player_id)&gt;'`` and it works for both. The two hand-wired functions on the detail page are now redundant (the hook intercepts them transparently) and can be retired in a follow-up.

## Verifying

- **No game needed:** FCC scouting tab, team roster projected starters, training report, set-lineup, box-score POTG.
- **Needs a game:** court/Phaser in-game headshots (the `court.html` change).
- **Needs a rollover:** eager warm — after finishing a season, your new signings' portraits should be painted immediately (no first-view lag) on your roster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A35cCo9CQ3nfwc6A7tTF8y)_