### PR TITLE
GC signed-recruit uniform masters from R2 on franchise delete

### DIFF
--- a/BackEnd/api/admin_routes.py
+++ b/BackEnd/api/admin_routes.py
@@ -4,6 +4,7 @@ Admin API (Step 12.2).
 All endpoints require role=admin (get_admin_user).
 """
 
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -58,6 +59,14 @@ def reset_user_state(
     franchises_deleted = 0
     for doc in franchise_docs:
         fid = doc["_id"]
+        # GC this franchise's painted signed-recruit masters from R2 before wiping
+        # FPD (the helper reads FPD to find the keys). Best-effort.
+        try:
+            from BackEnd.api.player_image_routes import delete_signed_masters_for_franchise
+            delete_signed_masters_for_franchise(fid)
+        except Exception:
+            logging.getLogger(__name__).exception(
+                "[IMG-GC] cleanup failed on admin franchise delete fid=%s", str(fid))
         # FTD uses ObjectId; FPD/FRD use string franchise_id
         franchise_team_data_collection.delete_many({"franchise_id": fid})
         franchise_players_data_collection.delete_many({"franchise_id": str(fid)})

--- a/BackEnd/api/franchise_routes.py
+++ b/BackEnd/api/franchise_routes.py
@@ -6876,6 +6876,13 @@ def delete_current_franchise(user: dict = Depends(get_current_user)):
     if not doc:
         return {"deleted": False, "count": 0}
     fid = doc["_id"]
+    # GC this franchise's painted signed-recruit masters from R2 before wiping FPD
+    # (the helper reads FPD to find the keys). Best-effort — never blocks the delete.
+    try:
+        from BackEnd.api.player_image_routes import delete_signed_masters_for_franchise
+        delete_signed_masters_for_franchise(fid)
+    except Exception:
+        logger.exception("[IMG-GC] cleanup failed on franchise delete fid=%s", str(fid))
     # FTD stores franchise_id as ObjectId; FPD/FRD store as string; games store franchise_id as string
     franchise_team_data_collection.delete_many({"franchise_id": fid})
     franchise_players_data_collection.delete_many({"franchise_id": str(fid)})

--- a/BackEnd/api/player_image_routes.py
+++ b/BackEnd/api/player_image_routes.py
@@ -70,6 +70,44 @@ def _resolve_signed(franchise_id: str, player_id: str):
     return None, None
 
 
+def delete_signed_masters_for_franchise(franchise_id) -> int:
+    """Best-effort GC of a deleted franchise's signed-recruit uniform masters in R2.
+
+    Only removes players/master/<player_id>.png for THIS franchise's signed
+    recruits — identified by their FPD doc carrying meta.image_id. That is safe on
+    two counts: (1) a signed player's player_id is a fresh per-franchise uuid, so a
+    key can never belong to another franchise; (2) original/universal players have
+    no image_id, so their shared masters are never touched. The shared uniform
+    cache (recruits/uniform-cache/...) is also left intact. Never raises — a portrait
+    GC failure must not block the franchise delete. Returns count removed.
+
+    Call BEFORE deleting the franchise's FPD docs (it reads them to find the keys).
+    """
+    if not r2_images.is_configured():
+        return 0
+    deleted = 0
+    try:
+        cursor = franchise_players_data_collection.find(
+            {"franchise_id": str(franchise_id), "meta.image_id": {"$exists": True, "$ne": None}},
+            {"player_id": 1},
+        )
+        for doc in cursor:
+            pid = doc.get("player_id")
+            if not pid:
+                continue
+            try:
+                if r2_images.delete(f"players/master/{pid}.png"):
+                    deleted += 1
+            except Exception:
+                logger.exception("[IMG-GC] delete failed franchise_id=%s player_id=%s",
+                                 str(franchise_id), pid)
+    except Exception:
+        logger.exception("[IMG-GC] scan failed franchise_id=%s", str(franchise_id))
+    if deleted:
+        logger.info("[IMG-GC] removed %s signed masters franchise_id=%s", deleted, str(franchise_id))
+    return deleted
+
+
 @router.post("/player-image/ensure")
 def ensure_player_image(req: EnsurePlayerImageRequest, user: dict = Depends(get_current_user)):
     """Paint a signed player's uniformed master into R2 if it's missing."""

--- a/BackEnd/services/r2_images.py
+++ b/BackEnd/services/r2_images.py
@@ -56,3 +56,18 @@ def put(key: str, data: bytes, content_type: str = "image/png") -> None:
     s3, bucket = _s3()
     s3.put_object(Bucket=bucket, Key=key, Body=data,
                   ContentType=content_type, CacheControl=CACHE_CONTROL)
+
+
+def delete(key: str) -> bool:
+    """Delete an object. Returns True if the object existed and was removed, False
+    if it was already absent. Idempotent — deleting a missing key is not an error."""
+    s3, bucket = _s3()
+    from botocore.exceptions import ClientError
+    try:
+        s3.head_object(Bucket=bucket, Key=key)
+    except ClientError as e:
+        if e.response["Error"]["Code"] in ("404", "NoSuchKey", "NotFound"):
+            return False
+        raise
+    s3.delete_object(Bucket=bucket, Key=key)
+    return True


### PR DESCRIPTION
## Problem

Deleting a franchise wiped its FPD/FTD/FRD/games but did **nothing** with R2. Every painted signed-recruit master (`players/master/<player_id>.png`) that franchise created was orphaned forever, so R2 storage grew unbounded across the whole user base. Both delete paths (`delete_current_franchise` and the admin cascade) had this gap.

## Fix — reclaim them on delete

- **`r2_images.delete(key)`** — idempotent object delete (head-check first; a missing key returns `False` rather than erroring), so cleanup is safe to run repeatedly.
- **`delete_signed_masters_for_franchise(franchise_id)`** — best-effort GC that removes `players/master/<player_id>.png` **only for that franchise's signed recruits**, identified by their FPD doc carrying `meta.image_id`.
- Wired into **both** delete paths, **before** the FPD `delete_many` (the helper reads FPD to find the keys), each guarded so a portrait GC failure can never block the franchise delete.
- `admin_routes`: added the missing `import logging` used by the new guard.

## Why it's safe (never touches shared images)

Two independent guarantees that we only ever delete franchise-private files:

1. A signed player's `player_id` is a **fresh per-franchise uuid**, so `players/master/<player_id>.png` can never belong to another franchise.
2. **Original / universal players have no `image_id`**, so the `meta.image_id` filter excludes them — their shared masters (baked once, reused by every franchise) are never touched.

Any future shared uniform cache (`recruits/uniform-cache/...`, the planned reuse/archive work) is also left intact — this only removes the per-franchise player_id copies.

## Scope note

This is the storage-hygiene half of the image-lifecycle work. The reuse/archive optimization (paint each `(image_id, team)` once globally, reuse across franchises) is intentionally **not** in this PR — it changes the paint path and is being deferred until season-progression verification settles, so it doesn't confound that testing. This GC change does not alter any paint behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A35cCo9CQ3nfwc6A7tTF8y)_