### PR TITLE
Recruit-set append tooling (inspector + add-on generator + merge)

### DIFF
--- a/scripts/recruit_sets/build_recruit_set.py
+++ b/scripts/recruit_sets/build_recruit_set.py
@@ -284,7 +284,17 @@ def main():
                     help="max drift (percentage points) of each race from the 60/30/10 base")
     ap.add_argument("--selftest", action="store_true",
                     help="build from synthetic recruits (validates proj/classify, writes nothing)")
+    ap.add_argument("--append-to", default=None, metavar="EXISTING_SET.json",
+                    help="ADD-ON mode: generate --count NEW recruits as a standalone add-on file "
+                         "(<set_id>_add<count>.json + .manifest.json) to be merged into the existing "
+                         "set later. Collision-checks recruit_ids against the existing set and NEVER "
+                         "regenerates it. Feed the add-on to build_recruit_images.py, then merge with "
+                         "merge_recruits_into_set.py.")
     args = ap.parse_args()
+
+    if args.append_to:
+        _append_mode(args)
+        return
 
     if args.selftest:
         recruits = synthetic_recruits(max(args.count, 60) if args.count != 300 else 60)
@@ -317,6 +327,51 @@ def main():
         print(f"[ok] wrote {man_path}")
 
     print_summary(records, manifests, args.selftest, eth_target)
+
+
+def _append_mode(args):
+    """Generate --count NEW recruits as an add-on for an existing set. Writes only
+    the new recruits (never touches the existing set). Output is a normal set+manifest
+    pair so build_recruit_images.py can build kits for JUST these, and
+    merge_recruits_into_set.py can fold them into the base set + DB afterward."""
+    existing = json.load(open(args.append_to))
+    set_id = existing.get("set_id", args.set_id)
+    existing_ids = {r["recruit_id"] for r in existing.get("recruits", []) if r.get("recruit_id")}
+    print(f"[append] base set {set_id}: {len(existing_ids)} existing recruits; generating {args.count} new")
+
+    recruits = generate_recruits(args.count, args.seed)
+    # Balance the add-on's own race mix; seed off (set_id + count) so a given add-on
+    # is reproducible but distinct from the base set's balance draw.
+    eth_seed = args.seed if args.seed is not None else f"{set_id}+add{args.count}"
+    random_weights, eth_target = bounded_race_weights(recruits, eth_seed, args.eth_cap_pp)
+
+    records, manifests = [], []
+    for rc in recruits:
+        rec, man = build_one(rc, random_weights=random_weights)
+        # recruit_id is a fresh uuid4; a clash with the existing 300 (or within the
+        # add-on) is astronomically unlikely, but assert rather than silently ship a dup.
+        if rec["recruit_id"] in existing_ids:
+            raise SystemExit(f"recruit_id collision with existing set: {rec['recruit_id']}")
+        existing_ids.add(rec["recruit_id"])
+        records.append(rec)
+        manifests.append(man)
+
+    add_doc = {"set_id": set_id, "version": 1, "recruit_count": len(records),
+               "add_on_for": set_id, "recruits": records}
+    add_manifest = {"set_id": set_id, "entries": manifests}
+    validate(add_doc)
+    print_summary(records, manifests, is_selftest=False, eth_target=eth_target)
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    base = f"{set_id}_add{args.count}"
+    set_path = os.path.join(args.out_dir, f"{base}.json")
+    man_path = os.path.join(args.out_dir, f"{base}.manifest.json")
+    json.dump(add_doc, open(set_path, "w"), indent=2)
+    json.dump(add_manifest, open(man_path, "w"), indent=2)
+    print(f"[ok] wrote add-on {set_path}")
+    print(f"[ok] wrote add-on {man_path}")
+    print(f"[next] build kits:  python scripts/recruit_sets/build_recruit_images.py --set {set_path} --limit 15")
+    print(f"[next] then merge:  python scripts/recruit_sets/merge_recruits_into_set.py --addon {set_path}")
 
 
 if __name__ == "__main__":

--- a/scripts/recruit_sets/inspect_recruit_sets.py
+++ b/scripts/recruit_sets/inspect_recruit_sets.py
@@ -1,0 +1,79 @@
+"""READ-ONLY inspector for the recruit_sets collection.
+
+Prints, per set: id, version, recruit_count vs actual, field coverage (image-linkage
+and the stable Home Region), year distribution, and a few sample recruit_ids — so we
+can confirm the as-built state before appending recruits. Writes NOTHING.
+
+Usage (MONGO_URI / .env.local selects the DB, like the other recruit_set scripts):
+    python scripts/recruit_sets/inspect_recruit_sets.py
+    python scripts/recruit_sets/inspect_recruit_sets.py --set-id set_0001 --samples 5
+"""
+import argparse
+import os
+import sys
+from collections import Counter
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(os.path.dirname(HERE))
+sys.path.insert(0, ROOT)
+
+CORE_ATTRS = ["SC", "SH", "ID", "OD", "PS", "BH", "RB", "AG", "ST", "ND", "IQ", "FT"]
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Read-only inspect of recruit_sets.")
+    ap.add_argument("--set-id", default=None, help="limit to one set_id (default: all)")
+    ap.add_argument("--samples", type=int, default=3, help="how many sample recruits to print")
+    args = ap.parse_args()
+
+    from BackEnd.db import db, client
+    is_mock = "mongomock" in type(client).__module__
+    banner = f"DB: {db.name} | conn: {'MOCK (no MONGO_URI)' if is_mock else 'REAL'}"
+    print("=" * len(banner)); print(banner); print("=" * len(banner))
+
+    query = {"set_id": args.set_id} if args.set_id else {}
+    sets = list(db.recruit_sets.find(query))
+    if not sets:
+        print(f"No recruit_sets found{' for ' + args.set_id if args.set_id else ''}.")
+        return
+
+    for doc in sets:
+        recs = doc.get("recruits") or []
+        n = len(recs)
+        print(f"\n── set_id={doc.get('set_id')}  version={doc.get('version')}  "
+              f"recruit_count={doc.get('recruit_count')}  actual_recruits={n}")
+        if doc.get("recruit_count") != n:
+            print(f"   ⚠️  recruit_count ({doc.get('recruit_count')}) != actual ({n})")
+
+        # field coverage
+        have_rid = sum(1 for r in recs if r.get("recruit_id"))
+        have_region = sum(1 for r in recs if r.get("Home Region"))
+        have_attrs = sum(1 for r in recs if all(c in (r.get("attributes") or {}) for c in CORE_ATTRS))
+        have_pr = sum(1 for r in recs if r.get("position_ratings"))
+        print(f"   coverage: recruit_id {have_rid}/{n} | Home Region {have_region}/{n} "
+              f"| core attrs {have_attrs}/{n} | position_ratings {have_pr}/{n}")
+
+        # uniqueness
+        ids = [r.get("recruit_id") for r in recs if r.get("recruit_id")]
+        dupes = [k for k, v in Counter(ids).items() if v > 1]
+        print(f"   unique recruit_ids: {len(set(ids))}/{len(ids)}"
+              + (f"  ⚠️ DUPLICATES: {dupes[:5]}" if dupes else "  ✓"))
+
+        # distributions
+        yr = Counter(r.get("year") for r in recs)
+        print("   year: " + " | ".join(f"{k} {yr[k]}" for k in ("JH", "Freshman", "Sophomore", "Junior") if yr.get(k)))
+        reg = Counter(r.get("Home Region") for r in recs if r.get("Home Region"))
+        if reg:
+            print("   region: " + " | ".join(f"{k} {reg[k]}" for k in sorted(reg)))
+
+        # samples
+        print(f"   sample recruits (first {args.samples}):")
+        for r in recs[:args.samples]:
+            print(f"     - {r.get('recruit_id')}  {r.get('name'):<22} "
+                  f"{str(r.get('year')):<10} region={r.get('Home Region')}")
+
+    print("\n(read-only — nothing was written)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/recruit_sets/merge_recruits_into_set.py
+++ b/scripts/recruit_sets/merge_recruits_into_set.py
@@ -1,0 +1,154 @@
+"""Merge an add-on (from build_recruit_set.py --append-to) into the base set.
+
+Run this LAST — after the add-on's kits are built (build_recruit_images.py) and
+uploaded to R2 — so the newly-merged recruits have portraits ready.
+
+Two independent merges, both idempotent by recruit_id (a recruit already present
+is skipped, so re-running never double-adds and never re-bumps version):
+
+  * DB    : appends the new recruits to the recruit_sets doc in the connected
+            database (dry-run unless --commit; prints which DB it hits).
+  * REPO  : with --update-repo-file, folds them into scripts/recruit_sets/
+            set_<id>.json AND its .manifest.json so the tracked artifact stays in
+            sync (a plain local file write — no DB, no --commit needed).
+
+Both set recruit_count to the new length and bump version by 1 (only when there
+is actually something new to add).
+
+Usage:
+    # DB dry-run (staging via .env.local) — see the plan, write nothing
+    python scripts/recruit_sets/merge_recruits_into_set.py --addon scripts/recruit_sets/set_0001_add100.json
+    # commit to the connected DB
+    MONGO_URI="<uri>" python scripts/recruit_sets/merge_recruits_into_set.py --addon .../set_0001_add100.json --commit
+    # update the tracked repo files (local, safe)
+    python scripts/recruit_sets/merge_recruits_into_set.py --addon .../set_0001_add100.json --update-repo-file
+"""
+import argparse
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(os.path.dirname(HERE))
+sys.path.insert(0, ROOT)
+
+
+def _load(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+def _new_recruits(addon_recruits, existing_ids):
+    """Add-on recruits whose recruit_id is not already present (idempotent merge)."""
+    seen = set(existing_ids)
+    out = []
+    for r in addon_recruits:
+        rid = r.get("recruit_id")
+        if rid and rid not in seen:
+            seen.add(rid)
+            out.append(r)
+    return out
+
+
+def merge_db(addon, commit):
+    from BackEnd.db import db, client
+    is_mock = "mongomock" in type(client).__module__
+    banner = f"DB: {db.name} | conn: {'MOCK (no MONGO_URI)' if is_mock else 'REAL'}"
+    print("=" * len(banner)); print(banner); print("=" * len(banner))
+
+    set_id = addon["set_id"]
+    doc = db.recruit_sets.find_one({"set_id": set_id})
+    if not doc:
+        print(f"  ⚠️  set_id={set_id} not found in {db.name}.recruit_sets — nothing to merge into.")
+        return
+    existing = doc.get("recruits") or []
+    existing_ids = {r.get("recruit_id") for r in existing}
+    new = _new_recruits(addon["recruits"], existing_ids)
+    after = len(existing) + len(new)
+    cur_v = int(doc.get("version", 1) or 1)
+
+    print(f"  {set_id}: {len(existing)} existing (v{cur_v}) | add-on {len(addon['recruits'])} "
+          f"| NEW to add {len(new)} | already-present {len(addon['recruits']) - len(new)}")
+    if not new:
+        print("  nothing new to add — already merged. No write.")
+        return
+    print(f"  -> would become recruit_count={after}, version={cur_v + 1}")
+
+    if commit:
+        db.recruit_sets.update_one(
+            {"set_id": set_id},
+            {"$push": {"recruits": {"$each": new}},
+             "$set": {"recruit_count": after, "version": cur_v + 1}},
+        )
+        print(f"  ✔ committed: appended {len(new)} recruits -> {after}, version -> {cur_v + 1}")
+    else:
+        print("  DRY-RUN — nothing written. Re-run with --commit to persist.")
+
+
+def merge_repo_file(addon, set_file):
+    """Fold the add-on into the tracked set_<id>.json and its .manifest.json."""
+    man_file = set_file.replace(".json", ".manifest.json")
+    addon_man_file = None
+    # add-on manifest sits beside the add-on set file
+    cand = None
+    for a in (addon.get("_path"),):
+        if a:
+            cand = a.replace(".json", ".manifest.json")
+    addon_man_file = cand
+
+    base = _load(set_file)
+    existing_ids = {r.get("recruit_id") for r in base.get("recruits", [])}
+    new = _new_recruits(addon["recruits"], existing_ids)
+    cur_v = int(base.get("version", 1) or 1)
+    print(f"  repo {os.path.basename(set_file)}: {len(base['recruits'])} existing (v{cur_v}) "
+          f"| NEW to add {len(new)}")
+    if not new:
+        print("  repo file already contains these recruits — no change.")
+        return
+
+    base["recruits"].extend(new)
+    base["recruit_count"] = len(base["recruits"])
+    base["version"] = cur_v + 1
+    json.dump(base, open(set_file, "w"), indent=2)
+    print(f"  ✔ wrote {set_file}: recruit_count={base['recruit_count']}, version={base['version']}")
+
+    # manifest merge (best-effort; needs the add-on manifest beside the add-on set)
+    if addon_man_file and os.path.exists(addon_man_file) and os.path.exists(man_file):
+        base_man = _load(man_file)
+        man_ids = {e.get("recruit_id") for e in base_man.get("entries", [])}
+        addon_man = _load(addon_man_file)
+        new_entries = [e for e in addon_man.get("entries", []) if e.get("recruit_id") not in man_ids]
+        base_man["entries"].extend(new_entries)
+        json.dump(base_man, open(man_file, "w"), indent=2)
+        print(f"  ✔ wrote {man_file}: +{len(new_entries)} manifest entries")
+    else:
+        print(f"  ⚠️  manifest not merged (missing {addon_man_file} or {man_file}) — merge it manually if needed.")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Merge a recruit add-on into the base set (DB + repo).")
+    ap.add_argument("--addon", required=True, help="path to the add-on set_<id>_add<N>.json")
+    ap.add_argument("--commit", action="store_true", help="perform the DB write (default: dry-run)")
+    ap.add_argument("--update-repo-file", metavar="SET.json", nargs="?",
+                    const=os.path.join(HERE, "set_0001.json"),
+                    help="also merge into the tracked set file (default scripts/recruit_sets/set_0001.json)")
+    ap.add_argument("--skip-db", action="store_true", help="only touch the repo file, skip the DB entirely")
+    args = ap.parse_args()
+
+    addon = _load(args.addon)
+    addon["_path"] = os.path.abspath(args.addon)
+    if not addon.get("recruits"):
+        sys.exit("add-on has no recruits")
+
+    if args.update_repo_file:
+        print("── repo file merge ──")
+        merge_repo_file(addon, args.update_repo_file)
+        print()
+
+    if not args.skip_db:
+        print("── database merge ──")
+        merge_db(addon, args.commit)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Tooling to **append recruits to an existing set** (e.g. +100 to `set_0001`) without ever regenerating the existing recruits — because image generation is non-deterministic AI, so re-running would change the faces already live in R2.

### 1. `inspect_recruit_sets.py` (read-only)
Confirms the as-built state before/after a merge: `version`, `recruit_count` vs actual, field coverage (`recruit_id`, `Home Region`, core attrs, `position_ratings`), `recruit_id` uniqueness, year/region distributions, samples. Writes nothing; prints a `DB: … | REAL/MOCK` banner.

### 2. `build_recruit_set.py --append-to <set.json>` (add-on generator)
Generates N **new** recruits as a standalone add-on (`<set_id>_add<N>.json` + `.manifest.json`), collision-checked against the base set's `recruit_id`s, with baked stable `Home Region` and portrait genes. Feed the add-on straight to `build_recruit_images.py` so **only the new recruits** get kits built. (Also restores `main()`'s end-of-run summary that the edit had displaced.)

### 3. `merge_recruits_into_set.py` (merge)
Folds a built add-on into the base set — **DB** (dry-run unless `--commit`, prints which DB) and/or the tracked **repo file + manifest** (`--update-repo-file`). Idempotent by `recruit_id`: re-runs never double-add or re-bump; `recruit_count`+`version` update only when there's something new. **Run LAST**, after kits are built + uploaded.

## The intended flow (append +100 to set_0001)
1. `inspect_recruit_sets.py` — confirm base (300, v2). ✅ done on staging.
2. `build_recruit_set.py --append-to set_0001.json --count 100 --seed <n>` → add-on files.
3. `build_recruit_images.py --set set_0001_add100.json` → kits for the 100 (Gemini key, your machine).
4. `upload_recruit_images_to_r2.py` → upload the 100 kits.
5. `merge_recruits_into_set.py --addon set_0001_add100.json --update-repo-file --commit` → set_0001 becomes 400, v3, in the repo + DB.

## Testing
All three tested against mongomock and repo-file copies: append generates valid collision-free add-ons; merge goes 300→305, v2→v3, and a re-run is a no-op (idempotent). No real data or repo artifacts touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)