### PR TITLE
Recruit-set 450 regen support: revert guard, SCHEMA sync, retired-mover kit backup

### DIFF
--- a/scripts/recruit_sets/SCHEMA.md
+++ b/scripts/recruit_sets/SCHEMA.md
@@ -64,7 +64,11 @@ downloadable build it ships as a pack file. Self-contained (~1 MB), well under M
       "weight": 190,              // integer lbs,   AS GENERATED (not projected)
       "attributes": { /* exactly the dict generate_recruits_list() emits — see below */ },
       "position_ratings": { "PG": 41, "SG": 44, "SF": 47, "PF": 39, "C": 30 },
-      "Home Region": "C"          // stable identity — region A–H, baked once, same in every franchise
+      "Home Region": "C",         // stable identity — region A–H, baked once, same in every franchise
+      "entry_tier": "Average",    // talent tier Poor…Elite (RT anchor)         — carried since the 450 regen
+      "position_intent": "SG",    // generated position PG…C (height + RT target) — carried since the 450 regen
+      "potential_factor": 1.0,    // frozen growth factor used by progression     — carried since the 450 regen
+      "has_portrait": true        // kit exists in R2 (borrow-pool / fallback)    — carried since the 450 regen
     }
     // ... 449 more
   ]
@@ -94,6 +98,15 @@ downloadable build it ships as a pack file. Self-contained (~1 MB), well under M
   per-franchise from this region with its own randomness (75% "open", etc.), and jersey is still
   rolled at signing. A recruit with no `Home Region` (dynamic, or a legacy un-baked set) falls
   back to the loader's per-franchise random draw.
+- **`entry_tier`, `position_intent`, `potential_factor`, `has_portrait`** — carried top-level as
+  of the **450 regen**. They come straight from the current `generate_recruits_list()` / recalibrated
+  generation and are stored **deliberately** so a set reload can't drop them and re-introduce a
+  re-derive / potential-factor mismatch. `entry_tier` (Poor…Elite) and `position_intent`
+  (`PG…C`) are the tier + position the recruit was generated at (drive the RT anchor and the
+  position-based height draw); `potential_factor` is the frozen growth factor used by progression;
+  `has_portrait` (bool) tracks whether a kit exists in R2 (borrow-pool inclusion / generic
+  fallback). The loader tolerates extra fields — it validates presence of the core set, not a
+  closed schema — so these load into FRD verbatim.
 
 ### Deliberately excluded (layered on per-franchise at load time — never in the set)
 

--- a/scripts/recruit_sets/SCHEMA.md
+++ b/scripts/recruit_sets/SCHEMA.md
@@ -10,7 +10,7 @@ for the full architecture; this file is the exact field-level spec the **baker**
 
 | Sequence | Purpose | Who draws from it | Current |
 |---|---|---|---|
-| **`recruit_set_NNNN`** | Pre-built recruit classes (stats + kits) | Recruit assignment **only** | `recruit_set_0001` (300) |
+| **`recruit_set_NNNN`** | Pre-built recruit classes (stats + kits) | Recruit assignment **only** | `recruit_set_0001` (450) |
 | **`builder_set_NNNN`** | Portrait kits for Team Builder body/skin coverage | Team Builder picker + fitted assignment | `builder_set_0001` (150) |
 
 **Team Builder pool** = `recruit_set_0001` ∪ `builder_set_0001`.  
@@ -26,7 +26,8 @@ for the full architecture; this file is the exact field-level spec the **baker**
 Future recruit classes continue `recruit_set_0002`, `0003`, … (new prefix optional at cutover).  
 Future builder extensions continue `builder_set_0002`, `0003`, ….
 
-A recruit set is 300 pre-built recruits shipped as a unit. Each recruit carries a **stable
+A recruit set is a batch of pre-built recruits shipped as a unit (`recruit_set_0001` is **450**
+after the regen; was 300). Each recruit carries a **stable
 `recruit_id`** that keys its pre-generated uniform kit. At signing the player gets a fresh
 unique `player_id` (not the recruit_id — set recruits share one recruit_id across franchises,
 which would collide); the portrait follows via `image_id`.
@@ -51,8 +52,8 @@ downloadable build it ships as a pack file. Self-contained (~1 MB), well under M
 ```jsonc
 {
   "set_id": "set_0001",           // human-readable, stable, globally unique
-  "version": 1,                   // schema/content version; bump if regenerated
-  "recruit_count": 300,
+  "version": 2,                   // schema/content version; bump if regenerated
+  "recruit_count": 450,
   "recruits": [
     {
       "recruit_id": "550e8400-e29b-41d4-a716-446655440000",  // stable UUID
@@ -65,7 +66,7 @@ downloadable build it ships as a pack file. Self-contained (~1 MB), well under M
       "position_ratings": { "PG": 41, "SG": 44, "SF": 47, "PF": 39, "C": 30 },
       "Home Region": "C"          // stable identity — region A–H, baked once, same in every franchise
     }
-    // ... 299 more
+    // ... 449 more
   ]
 }
 ```
@@ -85,8 +86,8 @@ downloadable build it ships as a pack file. Self-contained (~1 MB), well under M
   present; do not cherry-pick.
 - **`position_ratings`** — as produced by `compute_position_ratings(recruit, profile="recruit")`;
   keys are `PG SG SF PF C`.
-- **`year`** — one of the four recruit years. A 300-pool skews heavily **JH** (Freshman 10–30,
-  Sophomore 5–15, Junior 5–15, JH = remainder).
+- **`year`** — one of the four recruit years. The pool skews heavily **JH** (per draw: Freshman
+  10–30, Sophomore 5–15, Junior 5–15, JH = remainder — so a larger pool is proportionally more JH).
 - **`Home Region`** — one of `A`–`H`. **Stable identity**: baked once (by the baker, or by
   `bake_home_region.py` for the original set) and read verbatim by the loader, so the recruit
   lands in the same region in every franchise. Note: `Lean` is **not** stored — it still derives
@@ -174,7 +175,9 @@ Files:
 
 ## Validation rules (baker must enforce)
 
-1. Recruit sets: `recruits` length == `recruit_count` == 300.
+1. Recruit sets: `recruits` length == `recruit_count`. (`recruit_set_0001` is **450** after the
+   300→450 regen — 300 reuse + 150 new; it was 300 pre-regen. The invariant is the length/count
+   match, not a fixed number.)
 2. All ids unique **within the set** and disjoint from every other published kit UUID
    (recruit + builder). Before writing any kit to a flat or prefixed path, verify no collision.
 3. Every kit has bust + mask + geometry at its R2 keys before the set is published.

--- a/scripts/recruit_sets/backup_retired_mover_kits.py
+++ b/scripts/recruit_sets/backup_retired_mover_kits.py
@@ -1,0 +1,118 @@
+"""Back up the retired 71 mover kits to a neutral archive prefix BEFORE regen.
+
+The 71 reused-but-rebuilt recruits ("movers") get NEW art at their existing keys
+(recruits/kit/<recruit_id>.{png,mask.png,json}) — the same keys the new art will
+OVERWRITE. This copies the full recolorable kit trio to a neutral, collision-free
+archive prefix first, so the old art is never lost and can later be adopted into a
+builder_set_0002 / headshot library once that design is decided.
+
+  source  recruits/kit/<recruit_id>.{png,mask.png,json}
+  dest    portrait-kits/set_0001_retired_movers/<recruit_id>.{png,mask.png,json}
+
+Neutral prefix on purpose: it makes NO builder-namespace claim. Do NOT target
+portrait-kits/builder_set_0001/ — that pool already exists (150 kits, its own
+uuids); writing here would collide with and pollute it.
+
+HARD ORDERING RULE: run this (and verify 71/71) BEFORE any mover kit is
+regenerated/uploaded. Run it where R2 is reachable (Railway / prod creds) — local
+dev R2 is a different/absent bucket.
+
+Usage:
+    python scripts/recruit_sets/backup_retired_mover_kits.py --keys-file mover_kit_backup_keys.txt --dry-run
+    python scripts/recruit_sets/backup_retired_mover_kits.py --keys-file mover_kit_backup_keys.txt --commit
+    # or derive the ids from the movers CSV instead of a keys file:
+    python scripts/recruit_sets/backup_retired_mover_kits.py --movers-csv set0001_reused_movers.csv --commit
+"""
+import argparse
+import csv
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(os.path.dirname(HERE))
+sys.path.insert(0, ROOT)
+
+SRC_PREFIX = "recruits/kit/"
+DEST_PREFIX = "portrait-kits/set_0001_retired_movers/"
+KIT_EXTS = (".png", ".mask.png", ".json")   # full recolorable kit trio
+
+
+def _rid_from_key(key):
+    """recruits/kit/<id>.png -> <id> (strips any kit extension)."""
+    base = key.strip().split("/")[-1]
+    for ext in (".mask.png", ".png", ".json"):
+        if base.endswith(ext):
+            return base[: -len(ext)]
+    return base
+
+
+def load_ids(args):
+    if args.keys_file:
+        with open(args.keys_file) as f:
+            ids = [_rid_from_key(line) for line in f if line.strip()]
+    else:
+        with open(args.movers_csv, newline="") as f:
+            rows = list(csv.DictReader(f))
+        ids = [r["recruit_id"] for r in rows
+               if str(r.get("crossed", "")).strip() in ("1", "true", "True", "yes")]
+    # de-dupe, preserve order
+    seen, out = set(), []
+    for i in ids:
+        if i and i not in seen:
+            seen.add(i); out.append(i)
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Archive retired mover kits before regen.")
+    src = ap.add_mutually_exclusive_group(required=True)
+    src.add_argument("--keys-file", help="text file of source keys (recruits/kit/<id>.png per line)")
+    src.add_argument("--movers-csv", help="reused-movers CSV; rows with crossed==1 are the retired 71")
+    ap.add_argument("--dest-prefix", default=DEST_PREFIX, help=f"archive prefix (default {DEST_PREFIX})")
+    ap.add_argument("--commit", action="store_true", help="actually copy (default: dry-run)")
+    args = ap.parse_args()
+
+    if "builder_set_" in args.dest_prefix:
+        sys.exit("refusing: dest-prefix must not write into an existing builder_set pool namespace.")
+
+    ids = load_ids(args)
+    print(f"retired movers to archive: {len(ids)}  (expected 71)")
+
+    from BackEnd.services import r2_images
+    if not r2_images.is_configured():
+        sys.exit("R2 not configured (need R2_* env). Run where prod/Railway R2 creds are set.")
+    s3, bucket = r2_images._s3()
+    from botocore.exceptions import ClientError
+
+    def exists(key):
+        try:
+            s3.head_object(Bucket=bucket, Key=key); return True
+        except ClientError:
+            return False
+
+    copied = missing = already = 0
+    for rid in ids:
+        for ext in KIT_EXTS:
+            src_key = f"{SRC_PREFIX}{rid}{ext}"
+            dst_key = f"{args.dest_prefix}{rid}{ext}"
+            if not exists(src_key):
+                print(f"  MISS source {src_key}")
+                missing += 1
+                continue
+            if exists(dst_key):
+                already += 1
+                continue
+            if args.commit:
+                s3.copy_object(Bucket=bucket, CopySource={"Bucket": bucket, "Key": src_key}, Key=dst_key)
+            copied += 1
+    verb = "copied" if args.commit else "would copy"
+    print(f"\n{verb} {copied} | already-archived {already} | missing-source {missing}")
+    print(f"expected files: {len(ids) * len(KIT_EXTS)} ({len(ids)} movers x {len(KIT_EXTS)} kit files)")
+    if not args.commit:
+        print("DRY-RUN — nothing written. Re-run with --commit.")
+    if missing:
+        print("⚠️  missing sources above — investigate before regenerating those movers (do not overwrite un-archived art).")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/recruit_sets/load_recruit_sets.py
+++ b/scripts/recruit_sets/load_recruit_sets.py
@@ -59,6 +59,10 @@ def main():
     ap.add_argument("--dry-run", action="store_true", help="validate + preview, no write")
     ap.add_argument("--allow-mock", action="store_true",
                     help="proceed even without MONGO_URI (writes to ephemeral mongomock — for testing only)")
+    ap.add_argument("--force", action="store_true",
+                    help="override the revert guard — allow loading a set whose recruit_count is LOWER "
+                         "than what's already in the collection (normally refused, since a stale file "
+                         "would wipe a larger live set, e.g. reverting the 450 regen back to 300).")
     args = ap.parse_args()
 
     # Import db FIRST — that is what loads .env/.env.local and sets MONGO_URI.
@@ -91,11 +95,25 @@ def main():
         try:
             doc = json.load(open(p))
             validate(doc)
+            # Revert guard: never let a smaller set-file silently overwrite a larger
+            # live set (e.g. a stale set_0001.json at 300 clobbering the 450 regen).
+            existing = coll.find_one({"set_id": doc["set_id"]}, {"recruit_count": 1})
+            existing_count = (existing or {}).get("recruit_count")
+            shrinking = existing_count is not None and doc["recruit_count"] < existing_count
+            if shrinking and not args.force:
+                print(f"[BLOCKED] {os.path.basename(p)}: {doc['set_id']} would shrink "
+                      f"{existing_count} -> {doc['recruit_count']} recruits. Refusing (revert guard). "
+                      f"Pass --force only if this shrink is intentional.")
+                fail += 1
+                continue
             if args.dry_run:
-                print(f"[ok] {os.path.basename(p)}: valid, {doc['recruit_count']} recruits (would upsert {doc['set_id']})")
+                warn = "  ⚠️ SHRINK (allowed via --force)" if shrinking else ""
+                print(f"[ok] {os.path.basename(p)}: valid, {doc['recruit_count']} recruits "
+                      f"(would upsert {doc['set_id']}){warn}")
             else:
                 coll.replace_one({"set_id": doc["set_id"]}, doc, upsert=True)
-                print(f"[ok] upserted {doc['set_id']} ({doc['recruit_count']} recruits)")
+                note = f" (was {existing_count})" if existing_count is not None else ""
+                print(f"[ok] upserted {doc['set_id']} ({doc['recruit_count']} recruits){note}")
             ok += 1
         except Exception as e:
             print(f"[fail] {os.path.basename(p)}: {type(e).__name__}: {str(e)[:160]}")


### PR DESCRIPTION
Supports the DB-only 300→450 recruit regen (150 new + 71 rebuilt "movers") without losing art or reverting the DB. Three confirmed-safe pieces; the actual export/CSV commit, the `set_0001.json` sync, and running the backup are handled by whoever holds the regen data + R2 creds.

## 1. Loader revert guard (`load_recruit_sets.py`)
The landmine: the repo `set_0001.json` is a stale **300**, and the loader did a blind `replace_one` — re-loading it would clobber Mongo's live **450**. Now it **refuses to load a set-file whose `recruit_count` is lower than what's already in the collection**; `--force` overrides for an intentional shrink. Tested on mongomock: stale-300 load **blocked** (DB stays 450), `--force` allows it.

## 2. SCHEMA sync to 450 (`SCHEMA.md`)
`recruit_set_0001` is now **450** (was 300). Validation rule 1 becomes the length==count invariant (not a hardcoded 300); the doc example → 450/v2; pool-size language generalized. `builder_set_0001` (150, `portrait-kits/builder_set_0001/`) is unchanged and separate.

## 3. Retired-mover kit backup (`backup_retired_mover_kits.py`)
Archives the **71 rebuilt movers' kits before regen overwrites their keys**. Copies the **full recolorable trio** (`.png` + `.mask.png` + `.json`) from `recruits/kit/<id>` to a **neutral prefix `portrait-kits/set_0001_retired_movers/`** — deliberately **not** `portrait-kits/builder_set_0001/`, which is an already-populated 150-pool (writing there would collide). The script refuses any `builder_set_*` dest, dry-runs by default, and reports missing sources so no mover is regenerated over un-archived art. Runs where prod/Railway R2 is reachable.

**Hard ordering rule:** run #3 (verify 71/71) before any mover kit is regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A35cCo9CQ3nfwc6A7tTF8y)_